### PR TITLE
Avoid ioutil package

### DIFF
--- a/chain/cosmos/chain_node.go
+++ b/chain/cosmos/chain_node.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"hash/fnv"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -758,7 +757,7 @@ func (tn ChainNodes) PeerString() string {
 // LogGenesisHashes logs the genesis hashes for the various nodes
 func (tn ChainNodes) LogGenesisHashes() error {
 	for _, n := range tn {
-		gen, err := ioutil.ReadFile(path.Join(n.Dir(), "config", "genesis.json"))
+		gen, err := os.ReadFile(path.Join(n.Dir(), "config", "genesis.json"))
 		if err != nil {
 			return err
 		}

--- a/chain/cosmos/cosmos_chain.go
+++ b/chain/cosmos/cosmos_chain.go
@@ -6,7 +6,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"math"
 	"os"
 	"path"
@@ -258,7 +257,7 @@ func (c *CosmosChain) StartWithGenesisFile(testName string, ctx context.Context,
 
 	chainCfg := c.Config()
 
-	genesisJsonBytes, err := ioutil.ReadFile(genesisTmpFilePath)
+	genesisJsonBytes, err := os.ReadFile(genesisTmpFilePath)
 	if err != nil {
 		return err
 	}
@@ -307,7 +306,7 @@ func (c *CosmosChain) StartWithGenesisFile(testName string, ctx context.Context,
 			return err
 		}
 
-		testNodePubKeyJsonBytes, err := ioutil.ReadFile(tn.PrivValKeyFilePath())
+		testNodePubKeyJsonBytes, err := os.ReadFile(tn.PrivValKeyFilePath())
 		if err != nil {
 			return err
 		}
@@ -355,7 +354,7 @@ func (c *CosmosChain) StartWithGenesisFile(testName string, ctx context.Context,
 	}
 
 	for i := 0; i < len(c.ChainNodes); i++ {
-		if err := ioutil.WriteFile(c.ChainNodes[i].GenesisFilePath(), genesisJsonBytes, 0644); err != nil { //nolint
+		if err := os.WriteFile(c.ChainNodes[i].GenesisFilePath(), genesisJsonBytes, 0644); err != nil { //nolint
 			return err
 		}
 	}
@@ -479,7 +478,7 @@ func (c *CosmosChain) Start(testName string, ctx context.Context, additionalGene
 		return err
 	}
 
-	genbz, err := ioutil.ReadFile(validator0.GenesisFilePath())
+	genbz, err := os.ReadFile(validator0.GenesisFilePath())
 	if err != nil {
 		return err
 	}
@@ -488,7 +487,7 @@ func (c *CosmosChain) Start(testName string, ctx context.Context, additionalGene
 	nodes = append(nodes, fullnodes...)
 
 	for i := 1; i < len(nodes); i++ {
-		if err := ioutil.WriteFile(nodes[i].GenesisFilePath(), genbz, 0644); err != nil { //nolint
+		if err := os.WriteFile(nodes[i].GenesisFilePath(), genbz, 0644); err != nil { //nolint
 			return err
 		}
 	}

--- a/ibctest/test_setup.go
+++ b/ibctest/test_setup.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"strings"
@@ -54,7 +53,7 @@ func GetTestCase(testCase string) (func(testName string, cf ChainFactory, relaye
 }
 
 func SetupTestRun(testName string) (context.Context, string, *dockertest.Pool, string, func(), error) {
-	home, err := ioutil.TempDir("", "")
+	home, err := os.MkdirTemp("", "")
 	ctx := context.Background()
 	if err != nil {
 		return ctx, "", nil, "", nil, err

--- a/relayer/rly/cosmos_relayer.go
+++ b/relayer/rly/cosmos_relayer.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"runtime"
 	"strings"
@@ -170,8 +169,7 @@ func (relayer *CosmosRelayer) AddChainConfiguration(ctx context.Context, chainCo
 		return err
 	}
 
-	err = ioutil.WriteFile(chainConfigLocalFilePath, json, 0644) //nolint
-	if err != nil {
+	if err := os.WriteFile(chainConfigLocalFilePath, json, 0644); err != nil { //nolint
 		return err
 	}
 

--- a/trophies/test_juno.go
+++ b/trophies/test_juno.go
@@ -1,9 +1,10 @@
 //go:build exclude
 
+package trophies
+
 import (
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -320,7 +321,7 @@ func (ibc IBCTestCase) JunoHaltNewGenesis(testName string, _ Chain, _ Chain, rel
 		if err := junoChainAsCosmosChain.ChainNodes[i].UnsafeResetAll(ctx); err != nil {
 			return err
 		}
-		if err := ioutil.WriteFile(junoChainAsCosmosChain.ChainNodes[i].GenesisFilePath(), []byte(newGenesisJson), 0644); err != nil {
+		if err := os.WriteFile(junoChainAsCosmosChain.ChainNodes[i].GenesisFilePath(), []byte(newGenesisJson), 0644); err != nil {
 			return err
 		}
 		junoChainAsCosmosChain.ChainNodes[i].Chain = juno3Chain


### PR DESCRIPTION
The io/ioutil package has been deprecated in favor of the existing os
and io packages. There should be no functional change by switching these
usages to the os package.