### PR TITLE
[WIP] Test if relayers are keeping clients alive

### DIFF
--- a/conformance/relayersetup.go
+++ b/conformance/relayersetup.go
@@ -81,7 +81,7 @@ func TestRelayerSetup(t *testing.T, cf ibctest.ChainFactory, rf ibctest.RelayerF
 		rep.TrackTest(t)
 		req := require.New(rep.TestifyT(t))
 
-		req.NoError(r.CreateClients(ctx, rep.RelayerExecReporter(t), pathName))
+		req.NoError(r.CreateClients(ctx, rep.RelayerExecReporter(t), pathName, ibc.DefaultClientOpts()))
 	})
 	if t.Failed() {
 		return

--- a/examples/autoClientUpdate_test.go
+++ b/examples/autoClientUpdate_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/strangelove-ventures/ibctest"
 	"github.com/strangelove-ventures/ibctest/ibc"
@@ -66,20 +65,22 @@ func TestAutoUpdateClient(t *testing.T) {
 
 	// log queriered client trusing period to verify tp (chain1)
 	command := []string{
-		"query", "ibc", "client", "state", gaia1ClientID,
-		"--node", fmt.Sprintf("tcp://%s:26657", gaia1.GetHostRPCAddress()),
+		"gaiad", "query", "ibc", "client", "state", gaia1ClientID,
+		"--node", gaia1.GetHostRPCAddress(),
 	}
 	out, serr, err := gaia1.Exec(ctx, command, []string{})
 	if err != nil {
 		//NEED TO FIGURE OUT HOW LOGGING WORKS
-		fmt.Println(out)
-		fmt.Println(serr)
+		t.Log(out)
+		t.Log(serr)
 	}
+	t.Log("OUT GAIA1: ", out)
+	t.Log("SERR GAIA2: ", serr)
 
 	// log queriered client trusing period to verify tp (chain2)
 	command = []string{
-		"query", "ibc", "client", "state", gaia2ClientID,
-		"--node", fmt.Sprintf("tcp://%s:26657", gaia2.GetHostRPCAddress()),
+		"gaiad", "query", "ibc", "client", "state", gaia2ClientID,
+		"--node", gaia2.GetHostRPCAddress(),
 	}
 	out, serr, err = gaia2.Exec(ctx, command, []string{})
 	if err != nil {
@@ -89,10 +90,11 @@ func TestAutoUpdateClient(t *testing.T) {
 	}
 
 	// require client state active
+
 	err = r.StartRelayer(ctx, eRep, ibcPath)
 	require.NoError(t, err)
 
-	time.Sleep(5 * time.Minute)
+	// time.Sleep(5 * time.Minute)
 
 	// require client state active
 	// Try sending an IBC tx w/ relelvant client

--- a/examples/autoClientUpdate_test.go
+++ b/examples/autoClientUpdate_test.go
@@ -1,0 +1,100 @@
+package ibctest_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/strangelove-ventures/ibctest"
+	"github.com/strangelove-ventures/ibctest/ibc"
+	"github.com/strangelove-ventures/ibctest/testreporter"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+)
+
+func TestAutoUpdateClient(t *testing.T) {
+	ctx := context.Background()
+
+	cf := ibctest.NewBuiltinChainFactory(zaptest.NewLogger(t), []*ibctest.ChainSpec{
+		{Name: "gaia", ChainName: "gaia-1", Version: "v7.0.2", ChainConfig: ibc.ChainConfig{ChainID: "gaia-1"}},
+		{Name: "gaia", ChainName: "gaia-2", Version: "v7.0.2", ChainConfig: ibc.ChainConfig{ChainID: "gaia-2"}},
+	})
+
+	client, network := ibctest.DockerSetup(t)
+	r := ibctest.NewBuiltinRelayerFactory(ibc.CosmosRly, zaptest.NewLogger(t)).Build(
+		t, client, network)
+
+	chains, err := cf.Chains(t.Name())
+	require.NoError(t, err)
+	gaia1, gaia2 := chains[0], chains[1]
+
+	const ibcPath = "gaia1-gaia2"
+
+	ic := ibctest.NewInterchain().
+		AddChain(gaia1).
+		AddChain(gaia2).
+		AddRelayer(r, "relayer").
+		AddLink(ibctest.InterchainLink{
+			Chain1:  gaia1,
+			Chain2:  gaia2,
+			Relayer: r,
+			Path:    ibcPath,
+		})
+
+	rep := testreporter.NewNopReporter()
+	eRep := rep.RelayerExecReporter(t)
+	require.NoError(t, ic.Build(ctx, eRep, ibctest.InterchainBuildOptions{
+		TestName:  t.Name(),
+		HomeDir:   ibctest.TempDir(t),
+		Client:    client,
+		NetworkID: network,
+
+		SkipPathCreation: false,
+
+		CreateClientOpts: ibc.CreateClientOptions{
+			TrustingPeriod: "4m",
+		}}))
+
+	conns, err := r.GetConnections(ctx, eRep, "gaia-1")
+	require.NoError(t, err)
+	gaia1ClientID := conns[0].ClientID
+
+	conns, err = r.GetConnections(ctx, eRep, "gaia-2")
+	require.NoError(t, err)
+	gaia2ClientID := conns[0].ClientID
+
+	// log queriered client trusing period to verify tp (chain1)
+	command := []string{
+		"query", "ibc", "client", "state", gaia1ClientID,
+		"--node", fmt.Sprintf("tcp://%s:26657", gaia1.GetHostRPCAddress()),
+	}
+	out, serr, err := gaia1.Exec(ctx, command, []string{})
+	if err != nil {
+		//NEED TO FIGURE OUT HOW LOGGING WORKS
+		fmt.Println(out)
+		fmt.Println(serr)
+	}
+
+	// log queriered client trusing period to verify tp (chain2)
+	command = []string{
+		"query", "ibc", "client", "state", gaia2ClientID,
+		"--node", fmt.Sprintf("tcp://%s:26657", gaia2.GetHostRPCAddress()),
+	}
+	out, serr, err = gaia2.Exec(ctx, command, []string{})
+	if err != nil {
+		//NEED TO FIGURE OUT HOW LOGGING WORKS
+		fmt.Println(out)
+		fmt.Println(serr)
+	}
+
+	// require client state active
+	err = r.StartRelayer(ctx, eRep, ibcPath)
+	require.NoError(t, err)
+
+	time.Sleep(5 * time.Minute)
+
+	// require client state active
+	// Try sending an IBC tx w/ relelvant client
+
+}

--- a/ibc/relayer.go
+++ b/ibc/relayer.go
@@ -67,7 +67,7 @@ type Relayer interface {
 
 	// CreateClients performs the client handshake steps necessary for creating a light client
 	// on src that tracks the state of dst, and a light client on dst that tracks the state of src.
-	CreateClients(ctx context.Context, rep RelayerExecReporter, pathName string) error
+	CreateClients(ctx context.Context, rep RelayerExecReporter, pathName string, opts CreateClientOptions) error
 
 	// CreateConnections performs the connection handshake steps necessary for creating a connection
 	// between the src and dst chains.
@@ -158,6 +158,26 @@ func (o Order) Validate() error {
 		return nil
 	}
 	return chantypes.ErrInvalidChannelOrdering
+}
+
+// CreateClientOptions contains the configuration for creating a client.
+type CreateClientOptions struct {
+	TrustingPeriod string
+}
+
+// DefaultChannelOpts returns the default settings for creating an ics20 fungible token transfer channel.
+func DefaultClientOpts() CreateClientOptions {
+	return CreateClientOptions{
+		TrustingPeriod: "0",
+	}
+}
+
+func (opts CreateClientOptions) Validate() error {
+	_, err := time.ParseDuration(opts.TrustingPeriod)
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 // ExecReporter is the interface of a narrow type returned by testreporter.RelayerExecReporter.

--- a/ibc/relayer.go
+++ b/ibc/relayer.go
@@ -40,7 +40,7 @@ type Relayer interface {
 	GeneratePath(ctx context.Context, rep RelayerExecReporter, srcChainID, dstChainID, pathName string) error
 
 	// setup channels, connections, and clients
-	LinkPath(ctx context.Context, rep RelayerExecReporter, pathName string, opts CreateChannelOptions) error
+	LinkPath(ctx context.Context, rep RelayerExecReporter, pathName string, channelOpts CreateChannelOptions, clientOptions CreateClientOptions) error
 
 	// update clients, such as after new genesis
 	UpdateClients(ctx context.Context, rep RelayerExecReporter, pathName string) error

--- a/interchain.go
+++ b/interchain.go
@@ -263,7 +263,7 @@ func (ic *Interchain) Build(ctx context.Context, rep *testreporter.RelayerExecRe
 			)
 		}
 
-		if err := rp.Relayer.LinkPath(ctx, rep, rp.Path, opts.CreateChannelOpts); err != nil {
+		if err := rp.Relayer.LinkPath(ctx, rep, rp.Path, opts.CreateChannelOpts, opts.CreateClientOpts); err != nil {
 			return fmt.Errorf(
 				"failed to link path %s on relayer %s between chains %s and %s: %w",
 				rp.Path, rp.Relayer, ic.chains[c0], ic.chains[c1], err,

--- a/interchain.go
+++ b/interchain.go
@@ -165,6 +165,11 @@ type InterchainBuildOptions struct {
 	// This is useful for tests that need lower-level access to configuring relayers.
 	SkipPathCreation bool
 
+	// If set, these options will be used when creating the client in the path link step.
+	// If a zero value initialization is used, e.g. CreateClientOptions{},
+	// then the default values will be used via ibc.DefaultClientOpts.
+	CreateClientOpts ibc.CreateClientOptions
+
 	// If set, these options will be used when creating the channel in the path link step.
 	// If a zero value initialization is used, e.g. CreateChannelOptions{},
 	// then the default values will be used via ibc.DefaultChannelOpts.
@@ -223,6 +228,17 @@ func (ic *Interchain) Build(ctx context.Context, rep *testreporter.RelayerExecRe
 	// but still have wallets configured.
 	if opts.SkipPathCreation {
 		return nil
+	}
+
+	// If the user specifies a zero value CreateClientOptions struct then we fall back to the default
+	// client options.
+	if opts.CreateClientOpts == (ibc.CreateClientOptions{}) {
+		opts.CreateClientOpts = ibc.DefaultClientOpts()
+	}
+
+	// Check that the client creation options are valid and fully specified.
+	if err := opts.CreateClientOpts.Validate(); err != nil {
+		return err
 	}
 
 	// If the user specifies a zero value CreateChannelOptions struct then we fall back to the default

--- a/internal/blockdb/messages_view_test.go
+++ b/internal/blockdb/messages_view_test.go
@@ -95,7 +95,7 @@ func TestMessagesView(t *testing.T) {
 
 	t.Run("create clients", func(t *testing.T) {
 		// Creating the clients will cause transactions.
-		require.NoError(t, r.CreateClients(ctx, eRep, pathName))
+		require.NoError(t, r.CreateClients(ctx, eRep, pathName, ibc.DefaultClientOpts()))
 
 		// MsgCreateClient should match the opposite chain IDs.
 		const qCreateClient = `SELECT

--- a/relayer/docker.go
+++ b/relayer/docker.go
@@ -220,8 +220,8 @@ func (r *DockerRelayer) CreateChannel(ctx context.Context, rep ibc.RelayerExecRe
 	return res.Err
 }
 
-func (r *DockerRelayer) CreateClients(ctx context.Context, rep ibc.RelayerExecReporter, pathName string, ops ibc.CreateClientOptions) error {
-	cmd := r.c.CreateClients(pathName, r.HomeDir())
+func (r *DockerRelayer) CreateClients(ctx context.Context, rep ibc.RelayerExecReporter, pathName string, opts ibc.CreateClientOptions) error {
+	cmd := r.c.CreateClients(pathName, opts, r.HomeDir())
 	res := r.Exec(ctx, rep, cmd, nil)
 	return res.Err
 }
@@ -275,8 +275,8 @@ func (r *DockerRelayer) GetConnections(ctx context.Context, rep ibc.RelayerExecR
 	return r.c.ParseGetConnectionsOutput(string(res.Stdout), string(res.Stderr))
 }
 
-func (r *DockerRelayer) LinkPath(ctx context.Context, rep ibc.RelayerExecReporter, pathName string, opts ibc.CreateChannelOptions) error {
-	cmd := r.c.LinkPath(pathName, r.HomeDir(), opts)
+func (r *DockerRelayer) LinkPath(ctx context.Context, rep ibc.RelayerExecReporter, pathName string, channelOpts ibc.CreateChannelOptions, clientOpts ibc.CreateClientOptions) error {
+	cmd := r.c.LinkPath(pathName, r.HomeDir(), channelOpts, clientOpts)
 	res := r.Exec(ctx, rep, cmd, nil)
 	return res.Err
 }
@@ -633,14 +633,14 @@ type RelayerCommander interface {
 	AddChainConfiguration(containerFilePath, homeDir string) []string
 	AddKey(chainID, keyName, homeDir string) []string
 	CreateChannel(pathName string, opts ibc.CreateChannelOptions, homeDir string) []string
-	CreateClients(pathName, homeDir string) []string
+	CreateClients(pathName string, opts ibc.CreateClientOptions, homeDir string) []string
 	CreateConnections(pathName, homeDir string) []string
 	FlushAcknowledgements(pathName, channelID, homeDir string) []string
 	FlushPackets(pathName, channelID, homeDir string) []string
 	GeneratePath(srcChainID, dstChainID, pathName, homeDir string) []string
 	GetChannels(chainID, homeDir string) []string
 	GetConnections(chainID, homeDir string) []string
-	LinkPath(pathName, homeDir string, opts ibc.CreateChannelOptions) []string
+	LinkPath(pathName, homeDir string, channelOpts ibc.CreateChannelOptions, clientOpts ibc.CreateClientOptions) []string
 	RestoreKey(chainID, keyName, mnemonic, homeDir string) []string
 	StartRelayer(pathName, homeDir string) []string
 	UpdateClients(pathName, homeDir string) []string

--- a/relayer/docker.go
+++ b/relayer/docker.go
@@ -220,7 +220,7 @@ func (r *DockerRelayer) CreateChannel(ctx context.Context, rep ibc.RelayerExecRe
 	return res.Err
 }
 
-func (r *DockerRelayer) CreateClients(ctx context.Context, rep ibc.RelayerExecReporter, pathName string) error {
+func (r *DockerRelayer) CreateClients(ctx context.Context, rep ibc.RelayerExecReporter, pathName string, ops ibc.CreateClientOptions) error {
 	cmd := r.c.CreateClients(pathName, r.HomeDir())
 	res := r.Exec(ctx, rep, cmd, nil)
 	return res.Err

--- a/relayer/rly/cosmos_relayer.go
+++ b/relayer/rly/cosmos_relayer.go
@@ -140,6 +140,14 @@ func (commander) CreateClients(pathName, homeDir string) []string {
 	}
 }
 
+// passing a value of 0 for customeClientTrustingPeriod will use default
+func (commander) CreateClient(pathName, homeDir, customeClientTrustingPeriod string) []string {
+	return []string{
+		"rly", "tx", "client", pathName, "--client-tp", customeClientTrustingPeriod,
+		"--home", homeDir,
+	}
+}
+
 func (commander) CreateConnections(pathName, homeDir string) []string {
 	return []string{
 		"rly", "tx", "connection", pathName,

--- a/relayer/rly/cosmos_relayer.go
+++ b/relayer/rly/cosmos_relayer.go
@@ -61,7 +61,7 @@ type CosmosRelayerChainConfig struct {
 
 const (
 	DefaultContainerImage   = "ghcr.io/cosmos/relayer"
-	DefaultContainerVersion = "v2.0.0-rc3"
+	DefaultContainerVersion = "v2.0.0"
 )
 
 // Capabilities returns the set of capabilities of the Cosmos relayer.
@@ -133,9 +133,9 @@ func (commander) CreateChannel(pathName string, opts ibc.CreateChannelOptions, h
 	}
 }
 
-func (commander) CreateClients(pathName, homeDir string) []string {
+func (commander) CreateClients(pathName string, opts ibc.CreateClientOptions, homeDir string) []string {
 	return []string{
-		"rly", "tx", "clients", pathName,
+		"rly", "tx", "clients", pathName, "--client-tp", opts.TrustingPeriod,
 		"--home", homeDir,
 	}
 }
@@ -190,13 +190,14 @@ func (commander) GetConnections(chainID, homeDir string) []string {
 	}
 }
 
-func (commander) LinkPath(pathName, homeDir string, opts ibc.CreateChannelOptions) []string {
+func (commander) LinkPath(pathName, homeDir string, channelOpts ibc.CreateChannelOptions, clientOpt ibc.CreateClientOptions) []string {
 	return []string{
 		"rly", "tx", "link", pathName,
-		"--src-port", opts.SourcePortName,
-		"--dst-port", opts.DestPortName,
-		"--order", opts.Order.String(),
-		"--version", opts.Version,
+		"--src-port", channelOpts.SourcePortName,
+		"--dst-port", channelOpts.DestPortName,
+		"--order", channelOpts.Order.String(),
+		"--version", channelOpts.Version,
+		"--client-tp", clientOpt.TrustingPeriod,
 
 		"--home", homeDir,
 	}


### PR DESCRIPTION
This PR adds a test to see if relayers are autoupdating light clients.
This is needed on low traffic paths.

In order to accomplish this, the option to pass in a `--client-tp` (client trusting period) flag when creating clients with the Go Relayer was needed.


