### PR TITLE
CosmosExternalChain

### DIFF
--- a/chain/cosmos/broadcaster.go
+++ b/chain/cosmos/broadcaster.go
@@ -147,7 +147,7 @@ func (b *Broadcaster) defaultClientContext(fromUser User, sdkAdd sdk.AccAddress)
 	b.buf.Reset()
 	kr := b.keyrings[fromUser]
 	cn := b.chain.getFullNode()
-	return cn.CliContext().
+	return cn.CosmosClient.
 		WithOutput(b.buf).
 		WithFrom(fromUser.Bech32Address(b.chain.Config().Bech32Prefix)).
 		WithFromAddress(sdkAdd).

--- a/chain/cosmos/chain_node.go
+++ b/chain/cosmos/chain_node.go
@@ -19,7 +19,9 @@ import (
 	"github.com/avast/retry-go/v4"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
+	simappparams "github.com/cosmos/cosmos-sdk/simapp/params"
 	"github.com/cosmos/cosmos-sdk/types"
+	authTx "github.com/cosmos/cosmos-sdk/x/auth/tx"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	dockertypes "github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
@@ -44,15 +46,16 @@ import (
 
 // ChainNode represents a node in the test network that is being created
 type ChainNode struct {
-	VolumeName   string
-	Index        int
-	Chain        ibc.Chain
-	Validator    bool
-	NetworkID    string
-	DockerClient *dockerclient.Client
-	Client       rpcclient.Client
-	TestName     string
-	Image        ibc.DockerImage
+	VolumeName       string
+	Index            int
+	Chain            ibc.Chain
+	Validator        bool
+	NetworkID        string
+	DockerClient     *dockerclient.Client
+	TendermintClient rpcclient.Client
+	CosmosClient     client.Context
+	TestName         string
+	Image            ibc.DockerImage
 
 	lock sync.Mutex
 	log  *zap.Logger
@@ -88,34 +91,36 @@ var (
 )
 
 // NewClient creates and assigns a new Tendermint RPC client to the ChainNode
-func (tn *ChainNode) NewClient(addr string) error {
+func NewTendermintClient(addr string) (rpcclient.Client, error) {
 	httpClient, err := libclient.DefaultHTTPClient(addr)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	httpClient.Timeout = 10 * time.Second
 	rpcClient, err := rpchttp.NewWithClient(addr, "/websocket", httpClient)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	tn.Client = rpcClient
-	return nil
+	return rpcClient, nil
 }
 
 // CliContext creates a new Cosmos SDK client context
-func (tn *ChainNode) CliContext() client.Context {
-	cfg := tn.Chain.Config()
+func NewCosmosClient(
+	chainID string,
+	tendermintClient rpcclient.Client,
+	encodingConfig simappparams.EncodingConfig,
+) client.Context {
 	return client.Context{
-		Client:            tn.Client,
-		ChainID:           tn.Chain.Config().ChainID,
-		InterfaceRegistry: cfg.EncodingConfig.InterfaceRegistry,
+		Client:            tendermintClient,
+		ChainID:           chainID,
+		InterfaceRegistry: encodingConfig.InterfaceRegistry,
 		Input:             os.Stdin,
 		Output:            os.Stdout,
 		OutputFormat:      "json",
-		LegacyAmino:       cfg.EncodingConfig.Amino,
-		TxConfig:          cfg.EncodingConfig.TxConfig,
+		LegacyAmino:       encodingConfig.Amino,
+		TxConfig:          encodingConfig.TxConfig,
 	}
 }
 
@@ -258,7 +263,7 @@ func (tn *ChainNode) SetPeers(ctx context.Context, peers string) error {
 }
 
 func (tn *ChainNode) Height(ctx context.Context) (uint64, error) {
-	res, err := tn.Client.Status(ctx)
+	res, err := tn.TendermintClient.Status(ctx)
 	if err != nil {
 		return 0, fmt.Errorf("tendermint rpc client status: %w", err)
 	}
@@ -273,11 +278,11 @@ func (tn *ChainNode) FindTxs(ctx context.Context, height uint64) ([]blockdb.Tx, 
 	var blockRes *coretypes.ResultBlockResults
 	var block *coretypes.ResultBlock
 	eg.Go(func() (err error) {
-		blockRes, err = tn.Client.BlockResults(ctx, &h)
+		blockRes, err = tn.TendermintClient.BlockResults(ctx, &h)
 		return err
 	})
 	eg.Go(func() (err error) {
-		block, err = tn.Client.Block(ctx, &h)
+		block, err = tn.TendermintClient.Block(ctx, &h)
 		return err
 	})
 	if err := eg.Wait(); err != nil {
@@ -361,6 +366,23 @@ func (tn *ChainNode) FindTxs(ctx context.Context, height uint64) ([]blockdb.Tx, 
 	}
 
 	return txs, nil
+}
+
+func (tn *ChainNode) Transaction(txHash string) (*types.TxResponse, error) {
+	// Retry because sometimes the tx is not committed to state yet.
+	var txResp *types.TxResponse
+	err := retry.Do(func() error {
+		var err error
+		txResp, err = authTx.QueryTx(tn.CosmosClient, txHash)
+		return err
+	},
+		// retry for total of 3 seconds
+		retry.Attempts(15),
+		retry.Delay(200*time.Millisecond),
+		retry.DelayType(retry.FixedDelay),
+		retry.LastErrorOnly(true),
+	)
+	return txResp, err
 }
 
 // TxCommand is a helper to retrieve a full command for broadcasting a tx
@@ -820,14 +842,17 @@ func (tn *ChainNode) StartContainer(ctx context.Context) error {
 
 	tn.logger().Info("Cosmos chain node started", zap.String("container", tn.Name()), zap.String("rpc_port", tn.hostRPCPort))
 
-	err = tn.NewClient("tcp://" + tn.hostRPCPort)
+	tmClient, err := NewTendermintClient("tcp://" + tn.hostRPCPort)
 	if err != nil {
 		return err
 	}
+	tn.TendermintClient = tmClient
+	chainCfg := tn.Chain.Config()
+	tn.CosmosClient = NewCosmosClient(chainCfg.ChainID, tmClient, *chainCfg.EncodingConfig)
 
 	time.Sleep(5 * time.Second)
 	return retry.Do(func() error {
-		stat, err := tn.Client.Status(ctx)
+		stat, err := tn.TendermintClient.Status(ctx)
 		if err != nil {
 			return err
 		}

--- a/chain/cosmos/cosmos_external_chain.go
+++ b/chain/cosmos/cosmos_external_chain.go
@@ -1,0 +1,370 @@
+package cosmos
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+
+	cosmosclient "github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/types"
+	bankTypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	chanTypes "github.com/cosmos/ibc-go/v5/modules/core/04-channel/types"
+	dockertypes "github.com/docker/docker/api/types"
+	"github.com/docker/docker/client"
+	"github.com/strangelove-ventures/ibctest/v5/chain/internal/tendermint"
+	"github.com/strangelove-ventures/ibctest/v5/ibc"
+	"github.com/strangelove-ventures/ibctest/v5/internal/blockdb"
+	rpcclient "github.com/tendermint/tendermint/rpc/client"
+	"go.uber.org/zap"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+type CosmosExternalChain struct {
+	TendermintClient rpcclient.Client
+	CosmosClient     cosmosclient.Context
+	cfg              ibc.ChainConfig
+	log              *zap.Logger
+	fullNode         *ChainNode
+}
+
+func NewCosmosExternalChain(log *zap.Logger, cfg ibc.ChainConfig) (*CosmosExternalChain, error) {
+	tmClient, err := NewTendermintClient(cfg.Address)
+	if err != nil {
+		return nil, err
+	}
+	if cfg.EncodingConfig == nil {
+		ec := DefaultEncoding()
+		cfg.EncodingConfig = &ec
+	}
+	cosmosClient := NewCosmosClient(cfg.ChainID, tmClient, *cfg.EncodingConfig)
+	if err != nil {
+		return nil, err
+	}
+	return &CosmosExternalChain{
+		TendermintClient: tmClient,
+		CosmosClient:     cosmosClient,
+		log:              log,
+		cfg:              cfg,
+	}, nil
+}
+
+// Implements Chain interface
+// Config fetches the chain configuration.
+func (c *CosmosExternalChain) Config() ibc.ChainConfig {
+	return c.cfg
+}
+
+// Implements Chain interface
+func (c *CosmosExternalChain) Initialize(ctx context.Context, testName string, cli *client.Client, networkID string) error {
+	for _, image := range c.cfg.Images {
+		rc, err := cli.ImagePull(
+			ctx,
+			image.Repository+":"+image.Version,
+			dockertypes.ImagePullOptions{},
+		)
+		if err != nil {
+			c.log.Error("Failed to pull image",
+				zap.Error(err),
+				zap.String("repository", image.Repository),
+				zap.String("tag", image.Version),
+			)
+		} else {
+			_, _ = io.Copy(io.Discard, rc)
+			_ = rc.Close()
+		}
+	}
+	fn, err := NewCosmosChainNode(c.log, c, ctx, testName, cli, networkID, c.cfg.Images[0], false)
+	if err != nil {
+		return err
+	}
+	fn.TendermintClient = c.TendermintClient
+	c.fullNode = fn
+	return nil
+}
+
+// Implements Chain interface
+func (c *CosmosExternalChain) Start(testName string, ctx context.Context, additionalGenesisWallets ...ibc.WalletAmount) error {
+	// Since this is an external chain, we don't want to do anything here. Assumes chain is already producing blocks.
+	return nil
+}
+
+// FindTxs implements blockdb.BlockSaver.
+func (c *CosmosExternalChain) FindTxs(ctx context.Context, height uint64) ([]blockdb.Tx, error) {
+	return c.fullNode.FindTxs(ctx, height)
+}
+
+// Implements Chain interface
+// Exec runs an arbitrary command using Chain's docker environment.
+// Whether the invoked command is run in a one-off container or execing into an already running container
+// is up to the chain implementation.
+//
+// "env" are environment variables in the format "MY_ENV_VAR=value"
+func (c *CosmosExternalChain) Exec(ctx context.Context, cmd []string, env []string) (stdout, stderr []byte, err error) {
+	return c.fullNode.Exec(ctx, cmd, env)
+}
+
+// Implements Chain interface
+// ExportState exports the chain state at specific height.
+func (c *CosmosExternalChain) ExportState(ctx context.Context, height int64) (string, error) {
+	return c.fullNode.ExportState(ctx, height)
+}
+
+// Implements Chain interface
+func (c *CosmosExternalChain) GetRPCAddress() string {
+	return fmt.Sprintf("http://%s:26657", c.fullNode.HostName())
+}
+
+// Implements Chain interface
+func (c *CosmosExternalChain) GetGRPCAddress() string {
+	return fmt.Sprintf("%s:9090", c.fullNode.HostName())
+}
+
+// Implements Chain interface
+// GetHostRPCAddress returns the address of the RPC server accessible by the host.
+// This will not return a valid address until the chain has been started.
+func (c *CosmosExternalChain) GetHostRPCAddress() string {
+	return "http://" + c.fullNode.hostRPCPort
+}
+
+// Implements Chain interface
+// GetHostGRPCAddress returns the address of the gRPC server accessible by the host.
+// This will not return a valid address until the chain has been started.
+func (c *CosmosExternalChain) GetHostGRPCAddress() string {
+	return c.fullNode.hostGRPCPort
+}
+
+// Implements Chain interface
+// HomeDir is the home directory of a node running in a docker container. Therefore, this maps to
+// the container's filesystem (not the host).
+func (c *CosmosExternalChain) HomeDir() string {
+	return c.fullNode.HomeDir()
+}
+
+// Implements Chain interface
+// CreateKey creates a test key in the "user" node (either the first fullnode or the first validator if no fullnodes).
+func (c *CosmosExternalChain) CreateKey(ctx context.Context, keyName string) error {
+	return c.fullNode.CreateKey(ctx, keyName)
+}
+
+// Implements Chain interface
+// RecoverKey recovers an existing user from a given mnemonic.
+func (c *CosmosExternalChain) RecoverKey(ctx context.Context, name, mnemonic string) error {
+	return c.fullNode.RecoverKey(ctx, name, mnemonic)
+}
+
+// Implements Chain interface
+// GetAddress fetches the bech32 address for a test key on the "user" node (either the first fullnode or the first validator if no fullnodes).
+func (c *CosmosExternalChain) GetAddress(ctx context.Context, keyName string) ([]byte, error) {
+	b32Addr, err := c.fullNode.KeyBech32(ctx, keyName)
+	if err != nil {
+		return nil, err
+	}
+
+	return types.GetFromBech32(b32Addr, c.Config().Bech32Prefix)
+}
+
+// Implements Chain interface
+// Implements Chain interface
+func (c *CosmosExternalChain) SendFunds(ctx context.Context, keyName string, amount ibc.WalletAmount) error {
+	return c.fullNode.SendFunds(ctx, keyName, amount)
+}
+
+// Implements Chain interface
+// Implements Chain interface
+func (c *CosmosExternalChain) SendIBCTransfer(ctx context.Context, channelID, keyName string, amount ibc.WalletAmount, timeout *ibc.IBCTimeout) (tx ibc.Tx, _ error) {
+	txHash, err := c.fullNode.SendIBCTransfer(ctx, channelID, keyName, amount, timeout)
+	if err != nil {
+		return tx, fmt.Errorf("send ibc transfer: %w", err)
+	}
+	txResp, err := c.fullNode.Transaction(txHash)
+	if err != nil {
+		return tx, fmt.Errorf("failed to get transaction %s: %w", txHash, err)
+	}
+	tx.Height = uint64(txResp.Height)
+	tx.TxHash = txHash
+	// In cosmos, user is charged for entire gas requested, not the actual gas used.
+	tx.GasSpent = txResp.GasWanted
+
+	const evType = "send_packet"
+	events := txResp.Events
+
+	var (
+		seq, _           = tendermint.AttributeValue(events, evType, "packet_sequence")
+		srcPort, _       = tendermint.AttributeValue(events, evType, "packet_src_port")
+		srcChan, _       = tendermint.AttributeValue(events, evType, "packet_src_channel")
+		dstPort, _       = tendermint.AttributeValue(events, evType, "packet_dst_port")
+		dstChan, _       = tendermint.AttributeValue(events, evType, "packet_dst_channel")
+		timeoutHeight, _ = tendermint.AttributeValue(events, evType, "packet_timeout_height")
+		timeoutTs, _     = tendermint.AttributeValue(events, evType, "packet_timeout_timestamp")
+		data, _          = tendermint.AttributeValue(events, evType, "packet_data")
+	)
+	tx.Packet.SourcePort = srcPort
+	tx.Packet.SourceChannel = srcChan
+	tx.Packet.DestPort = dstPort
+	tx.Packet.DestChannel = dstChan
+	tx.Packet.TimeoutHeight = timeoutHeight
+	tx.Packet.Data = []byte(data)
+
+	seqNum, err := strconv.Atoi(seq)
+	if err != nil {
+		return tx, fmt.Errorf("invalid packet sequence from events %s: %w", seq, err)
+	}
+	tx.Packet.Sequence = uint64(seqNum)
+
+	timeoutNano, err := strconv.ParseUint(timeoutTs, 10, 64)
+	if err != nil {
+		return tx, fmt.Errorf("invalid packet timestamp timeout %s: %w", timeoutTs, err)
+	}
+	tx.Packet.TimeoutTimestamp = ibc.Nanoseconds(timeoutNano)
+
+	return tx, nil
+}
+
+// Implements Chain interface
+func (c *CosmosExternalChain) UpgradeProposal(ctx context.Context, keyName string, prop ibc.SoftwareUpgradeProposal) (tx ibc.SoftwareUpgradeTx, _ error) {
+	txHash, err := c.fullNode.UpgradeProposal(ctx, keyName, prop)
+	if err != nil {
+		return tx, fmt.Errorf("failed to submit upgrade proposal: %w", err)
+	}
+	txResp, err := c.fullNode.Transaction(txHash)
+	if err != nil {
+		return tx, fmt.Errorf("failed to get transaction %s: %w", txHash, err)
+	}
+	tx.Height = uint64(txResp.Height)
+	tx.TxHash = txHash
+	// In cosmos, user is charged for entire gas requested, not the actual gas used.
+	tx.GasSpent = txResp.GasWanted
+	events := txResp.Events
+
+	tx.DepositAmount, _ = tendermint.AttributeValue(events, "proposal_deposit", "amount")
+
+	evtSubmitProp := "submit_proposal"
+	tx.ProposalID, _ = tendermint.AttributeValue(events, evtSubmitProp, "proposal_id")
+	tx.ProposalType, _ = tendermint.AttributeValue(events, evtSubmitProp, "proposal_type")
+
+	return tx, nil
+}
+
+// Implements Chain interface
+func (c *CosmosExternalChain) InstantiateContract(ctx context.Context, keyName string, amount ibc.WalletAmount, fileName, initMessage string, needsNoAdminFlag bool) (string, error) {
+	return c.fullNode.InstantiateContract(ctx, keyName, amount, fileName, initMessage, needsNoAdminFlag)
+}
+
+// Implements Chain interface
+func (c *CosmosExternalChain) ExecuteContract(ctx context.Context, keyName string, contractAddress string, message string) error {
+	return c.fullNode.ExecuteContract(ctx, keyName, contractAddress, message)
+}
+
+// Implements Chain interface
+func (c *CosmosExternalChain) DumpContractState(ctx context.Context, contractAddress string, height int64) (*ibc.DumpContractStateResponse, error) {
+	return c.fullNode.DumpContractState(ctx, contractAddress, height)
+}
+
+// Implements Chain interface
+func (c *CosmosExternalChain) CreatePool(ctx context.Context, keyName string, contractAddress string, swapFee float64, exitFee float64, assets []ibc.WalletAmount) error {
+	return c.fullNode.CreatePool(ctx, keyName, contractAddress, swapFee, exitFee, assets)
+}
+
+// Implements Chain interface
+func (c *CosmosExternalChain) GetBalance(ctx context.Context, address string, denom string) (int64, error) {
+	params := &bankTypes.QueryBalanceRequest{Address: address, Denom: denom}
+	grpcAddress := c.fullNode.hostGRPCPort
+	conn, err := grpc.Dial(grpcAddress, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		return 0, err
+	}
+	defer conn.Close()
+
+	queryClient := bankTypes.NewQueryClient(conn)
+	res, err := queryClient.Balance(ctx, params)
+
+	if err != nil {
+		return 0, err
+	}
+
+	return res.Balance.Amount.Int64(), nil
+}
+
+func (c *CosmosExternalChain) GetGasFeesInNativeDenom(gasPaid int64) int64 {
+	gasPrice, _ := strconv.ParseFloat(strings.Replace(c.cfg.GasPrices, c.cfg.Denom, "", 1), 64)
+	fees := float64(gasPaid) * gasPrice
+	return int64(fees)
+}
+
+// Height returns the current block height or an error if unable to get current height.
+func (c *CosmosExternalChain) Height(ctx context.Context) (uint64, error) {
+	res, err := c.TendermintClient.Status(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("tendermint rpc client status: %w", err)
+	}
+	height := res.SyncInfo.LatestBlockHeight
+	return uint64(height), nil
+}
+
+// Acknowledgements implements ibc.Chain, returning all acknowledgments in block at height
+func (c *CosmosExternalChain) Acknowledgements(ctx context.Context, height uint64) ([]ibc.PacketAcknowledgement, error) {
+	var acks []*chanTypes.MsgAcknowledgement
+	err := rangeBlockMessages(ctx, c.cfg.EncodingConfig.InterfaceRegistry, c.TendermintClient, height, func(msg types.Msg) bool {
+		found, ok := msg.(*chanTypes.MsgAcknowledgement)
+		if ok {
+			acks = append(acks, found)
+		}
+		return false
+	})
+	if err != nil {
+		return nil, fmt.Errorf("find acknowledgements at height %d: %w", height, err)
+	}
+	ibcAcks := make([]ibc.PacketAcknowledgement, len(acks))
+	for i, ack := range acks {
+		ack := ack
+		ibcAcks[i] = ibc.PacketAcknowledgement{
+			Acknowledgement: ack.Acknowledgement,
+			Packet: ibc.Packet{
+				Sequence:         ack.Packet.Sequence,
+				SourcePort:       ack.Packet.SourcePort,
+				SourceChannel:    ack.Packet.SourceChannel,
+				DestPort:         ack.Packet.DestinationPort,
+				DestChannel:      ack.Packet.DestinationChannel,
+				Data:             ack.Packet.Data,
+				TimeoutHeight:    ack.Packet.TimeoutHeight.String(),
+				TimeoutTimestamp: ibc.Nanoseconds(ack.Packet.TimeoutTimestamp),
+			},
+		}
+	}
+	return ibcAcks, nil
+}
+
+// Timeouts implements ibc.Chain, returning all timeouts in block at height
+func (c *CosmosExternalChain) Timeouts(ctx context.Context, height uint64) ([]ibc.PacketTimeout, error) {
+	var timeouts []*chanTypes.MsgTimeout
+	err := rangeBlockMessages(ctx, c.cfg.EncodingConfig.InterfaceRegistry, c.TendermintClient, height, func(msg types.Msg) bool {
+		found, ok := msg.(*chanTypes.MsgTimeout)
+		if ok {
+			timeouts = append(timeouts, found)
+		}
+		return false
+	})
+	if err != nil {
+		return nil, fmt.Errorf("find timeouts at height %d: %w", height, err)
+	}
+	ibcTimeouts := make([]ibc.PacketTimeout, len(timeouts))
+	for i, ack := range timeouts {
+		ack := ack
+		ibcTimeouts[i] = ibc.PacketTimeout{
+			Packet: ibc.Packet{
+				Sequence:         ack.Packet.Sequence,
+				SourcePort:       ack.Packet.SourcePort,
+				SourceChannel:    ack.Packet.SourceChannel,
+				DestPort:         ack.Packet.DestinationPort,
+				DestChannel:      ack.Packet.DestinationChannel,
+				Data:             ack.Packet.Data,
+				TimeoutHeight:    ack.Packet.TimeoutHeight.String(),
+				TimeoutTimestamp: ibc.Nanoseconds(ack.Packet.TimeoutTimestamp),
+			},
+		}
+	}
+	return ibcTimeouts, nil
+}

--- a/chainfactory.go
+++ b/chainfactory.go
@@ -104,6 +104,8 @@ func buildChain(log *zap.Logger, testName string, cfg ibc.ChainConfig, numValida
 	switch cfg.Type {
 	case "cosmos":
 		return cosmos.NewCosmosChain(testName, cfg, nv, nf, log), nil
+	case "cosmos_external":
+		return cosmos.NewCosmosExternalChain(log, cfg)
 	case "penumbra":
 		return penumbra.NewPenumbraChain(log, testName, cfg, nv, nf), nil
 	case "polkadot":

--- a/chainset.go
+++ b/chainset.go
@@ -181,7 +181,12 @@ func (cs chainSet) TrackBlocks(ctx context.Context, testName, dbPath, gitSha str
 				return nil
 			}
 			log := cs.log.With(zap.String("chain_id", id))
-			collector := blockdb.NewCollector(log, finder, chaindb, 100*time.Millisecond)
+			initialHeight := uint64(1)
+			height, err := c.Height(ctx)
+			if err == nil {
+				initialHeight = height
+			}
+			collector := blockdb.NewCollector(log, finder, chaindb, 100*time.Millisecond, initialHeight)
 			cs.collectors[j] = collector
 			collector.Collect(ctx)
 			return nil

--- a/examples/state_sync_test.go
+++ b/examples/state_sync_test.go
@@ -93,7 +93,7 @@ func CosmosChainStateSyncTest(t *testing.T, chainName, version string) {
 	firstFullNode := chain.FullNodes[0]
 
 	// Fetch block hash for trusted height.
-	blockRes, err := firstFullNode.Client.Block(ctx, &trustHeight)
+	blockRes, err := firstFullNode.TendermintClient.Block(ctx, &trustHeight)
 	require.NoError(t, err, "failed to fetch trusted block")
 	trustHash := hex.EncodeToString(blockRes.BlockID.Hash)
 

--- a/ibc/types.go
+++ b/ibc/types.go
@@ -14,6 +14,8 @@ type ChainConfig struct {
 	Name string
 	// Chain ID, e.g. cosmoshub-4
 	ChainID string
+	// Address if required for external chains
+	Address string
 	// Docker images required for running chain nodes.
 	Images []DockerImage
 	// Binary to execute for the chain node daemon.
@@ -93,6 +95,10 @@ func (c ChainConfig) MergeChainSpecConfig(other ChainConfig) ChainConfig {
 
 	if other.EncodingConfig != nil {
 		c.EncodingConfig = other.EncodingConfig
+	}
+
+	if other.Address != "" {
+		c.Address = other.Address
 	}
 
 	return c

--- a/internal/blockdb/collect.go
+++ b/internal/blockdb/collect.go
@@ -46,22 +46,24 @@ type BlockSaver interface {
 
 // Collector saves block transactions at regular intervals.
 type Collector struct {
-	finder TxFinder
-	log    *zap.Logger
-	rate   time.Duration
-	saver  BlockSaver
-	cancel context.CancelFunc
+	finder        TxFinder
+	log           *zap.Logger
+	rate          time.Duration
+	saver         BlockSaver
+	cancel        context.CancelFunc
+	initialHeight uint64
 }
 
 // NewCollector creates a valid Collector that polls every duration at rate.
 // The rate should be less than the time it takes to produce a block.
 // Typically, a rate that will collect a few times a second is sufficient such as 100-200ms.
-func NewCollector(log *zap.Logger, finder TxFinder, saver BlockSaver, rate time.Duration) *Collector {
+func NewCollector(log *zap.Logger, finder TxFinder, saver BlockSaver, rate time.Duration, initialHeight uint64) *Collector {
 	return &Collector{
-		finder: finder,
-		log:    log,
-		rate:   rate,
-		saver:  saver,
+		finder:        finder,
+		log:           log,
+		rate:          rate,
+		saver:         saver,
+		initialHeight: initialHeight,
 	}
 }
 
@@ -73,7 +75,7 @@ func (p *Collector) Collect(ctx context.Context) {
 
 	tick := time.NewTicker(p.rate)
 	defer tick.Stop()
-	var height uint64 = 1
+	var height uint64 = p.initialHeight
 	for {
 		select {
 		case <-ctx.Done():

--- a/internal/blockdb/collect_test.go
+++ b/internal/blockdb/collect_test.go
@@ -63,7 +63,7 @@ func TestCollector_Collect(t *testing.T) {
 			return nil
 		})
 
-		collector := NewCollector(nopLog, finder, saver, time.Nanosecond)
+		collector := NewCollector(nopLog, finder, saver, time.Nanosecond, 1)
 		defer collector.Stop()
 
 		ctx, cancel := context.WithCancel(context.Background())
@@ -98,7 +98,7 @@ func TestCollector_Collect(t *testing.T) {
 		})
 		saver := mockBlockSaver(func(ctx context.Context, height uint64, txs []Tx) error { return nil })
 
-		collector := NewCollector(nopLog, finder, saver, time.Nanosecond)
+		collector := NewCollector(nopLog, finder, saver, time.Nanosecond, 1)
 		defer collector.Stop()
 		go collector.Collect(context.Background())
 
@@ -120,7 +120,7 @@ func TestCollector_Collect(t *testing.T) {
 			return errors.New("boom")
 		})
 
-		collector := NewCollector(nopLog, finder, saver, time.Nanosecond)
+		collector := NewCollector(nopLog, finder, saver, time.Nanosecond, 1)
 		defer collector.Stop()
 		go collector.Collect(context.Background())
 
@@ -147,7 +147,7 @@ func TestCollector_Stop(t *testing.T) {
 	})
 	saver := mockBlockSaver(func(ctx context.Context, height uint64, txs []Tx) error { return nil })
 
-	c := NewCollector(zap.NewNop(), finder, saver, time.Millisecond)
+	c := NewCollector(zap.NewNop(), finder, saver, time.Millisecond, 1)
 	defer c.Stop() // Will be stopped explicitly in a few lines, but defer anyway for cleanup just in case.
 
 	n := runtime.NumGoroutine()


### PR DESCRIPTION
Add `CosmosExternalChain` `ibc.Chain` implementation for a mechanism to use existing public chains in tests.

Use `Type: "cosmos_external"` in chain configuration to use this.
