### PR TITLE
Fix usage of broadcast mode sync in broadcaster.go

### DIFF
--- a/chain/cosmos/wallet.go
+++ b/chain/cosmos/wallet.go
@@ -6,6 +6,7 @@ import (
 )
 
 var _ ibc.Wallet = &CosmosWallet{}
+var _ User = &CosmosWallet{}
 
 type CosmosWallet struct {
 	mnemonic string


### PR DESCRIPTION
Previously, when a transaction that was broadcast failed, we ended up discarding the result by returning an empty struct. This fix makes it so that when a tx fails, the result is correctly returned with all of the error messages intact.

This PR also ensures that the CosmosUser implements the User interface.