### PR TITLE
docs: point godoc to v7

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 Formerly known as `ibctest`.
 
-[![Go Reference](https://pkg.go.dev/badge/github.com/strangelove-ventures/interchaintest@main.svg)](https://pkg.go.dev/github.com/strangelove-ventures/interchaintest@main)
+[![Go Reference](https://pkg.go.dev/badge/github.com/strangelove-ventures/interchaintest/v7.svg)](https://pkg.go.dev/github.com/strangelove-ventures/interchaintest/v7)
 [![License: Apache-2.0](https://img.shields.io/github/license/strangelove-ventures/interchaintest.svg?style=flat-square)](https://github.com/strangelove-ventures/interchaintest/blob/main/create-test-readme/LICENSE)
 [![Go Report Card](https://goreportcard.com/badge/github.com/strangelove-ventures/interchaintest)](https://goreportcard.com/report/github.com/strangelove-ventures/interchaintest)
 


### PR DESCRIPTION
The current readme points to https://pkg.go.dev/github.com/strangelove-ventures/interchaintest@main which doesn't seem to exist. This PR modifies the path to point to [v7](https://pkg.go.dev/github.com/strangelove-ventures/interchaintest/v7)