### PR TITLE
Bring up to date with latest Penumbra binary

### DIFF
--- a/chain/penumbra/penumbra_app_node.go
+++ b/chain/penumbra/penumbra_app_node.go
@@ -104,7 +104,7 @@ func (p *PenumbraAppNode) InitValidatorFile(ctx context.Context, valKeyName stri
 }
 
 func (p *PenumbraAppNode) ValidatorDefinitionTemplateFilePathContainer() string {
-	return filepath.Join(p.HomeDir(), "validator.json")
+	return filepath.Join(p.HomeDir(), "validator.toml")
 }
 
 func (p *PenumbraAppNode) ValidatorsInputFileContainer() string {

--- a/chain/penumbra/penumbra_chain.go
+++ b/chain/penumbra/penumbra_chain.go
@@ -17,6 +17,7 @@ import (
 	"github.com/docker/docker/api/types"
 	volumetypes "github.com/docker/docker/api/types/volume"
 	"github.com/docker/docker/client"
+	"github.com/pelletier/go-toml/v2"
 	"github.com/strangelove-ventures/interchaintest/v6/chain/internal/tendermint"
 	"github.com/strangelove-ventures/interchaintest/v6/ibc"
 	"github.com/strangelove-ventures/interchaintest/v6/internal/dockerutil"
@@ -43,18 +44,25 @@ type PenumbraChain struct {
 }
 
 type PenumbraValidatorDefinition struct {
-	IdentityKey    string                           `json:"identity_key"`
-	ConsensusKey   string                           `json:"consensus_key"`
-	Name           string                           `json:"name"`
-	Website        string                           `json:"website"`
-	Description    string                           `json:"description"`
-	FundingStreams []PenumbraValidatorFundingStream `json:"funding_streams"`
-	SequenceNumber int64                            `json:"sequence_number"`
+	SequenceNumber int                              `json:"sequence_number" toml:"sequence_number"`
+	Enabled        bool                             `json:"enabled" toml:"enabled"`
+	Name           string                           `json:"name" toml:"name"`
+	Website        string                           `json:"website" toml:"website"`
+	Description    string                           `json:"description" toml:"description"`
+	IdentityKey    string                           `json:"identity_key" toml:"identity_key"`
+	GovernanceKey  string                           `json:"governance_key" toml:"governance_key"`
+	ConsensusKey   PenumbraConsensusKey             `json:"consensus_key" toml:"consensus_key"`
+	FundingStreams []PenumbraValidatorFundingStream `json:"funding_streams" toml:"funding_stream"`
+}
+
+type PenumbraConsensusKey struct {
+	Type  string `json:"type" toml:"type"`
+	Value string `json:"value" toml:"value"`
 }
 
 type PenumbraValidatorFundingStream struct {
-	Address string `json:"address"`
-	RateBPS int64  `json:"rate_bps"`
+	Address string `json:"address" toml:"address"`
+	RateBPS int64  `json:"rate_bps" toml:"rate_bps"`
 }
 
 type PenumbraGenesisAppStateAllocation struct {
@@ -382,15 +390,17 @@ func (c *PenumbraChain) Start(testName string, ctx context.Context, additionalGe
 			// In all likelihood, the PenumbraAppNode and TendermintNode have the same DockerClient and TestName,
 			// but instantiate a new FileRetriever to be defensive.
 			fr = dockerutil.NewFileRetriever(c.log, v.PenumbraAppNode.DockerClient, v.PenumbraAppNode.TestName)
-			validatorTemplateDefinitionFileBytes, err := fr.SingleFileContent(egCtx, v.PenumbraAppNode.VolumeName, "validator.json")
+			validatorTemplateDefinitionFileBytes, err := fr.SingleFileContent(egCtx, v.PenumbraAppNode.VolumeName, "validator.toml")
 			if err != nil {
 				return fmt.Errorf("error reading validator definition template file: %v", err)
 			}
 			validatorTemplateDefinition := PenumbraValidatorDefinition{}
-			if err := json.Unmarshal(validatorTemplateDefinitionFileBytes, &validatorTemplateDefinition); err != nil {
+			if err := toml.Unmarshal(validatorTemplateDefinitionFileBytes, &validatorTemplateDefinition); err != nil {
 				return fmt.Errorf("error unmarshaling validator definition template key: %v", err)
 			}
-			validatorTemplateDefinition.ConsensusKey = privValKey.PubKey.Value
+			validatorTemplateDefinition.SequenceNumber = i
+			validatorTemplateDefinition.Enabled = true
+			validatorTemplateDefinition.ConsensusKey.Value = privValKey.PubKey.Value
 			validatorTemplateDefinition.Name = fmt.Sprintf("validator-%d", i)
 			validatorTemplateDefinition.Description = fmt.Sprintf("validator-%d description", i)
 			validatorTemplateDefinition.Website = fmt.Sprintf("https://validator-%d", i)

--- a/examples/penumbra/penumbra_chain_test.go
+++ b/examples/penumbra/penumbra_chain_test.go
@@ -23,8 +23,9 @@ func TestPenumbraChainStart(t *testing.T) {
 
 	chains, err := interchaintest.NewBuiltinChainFactory(zaptest.NewLogger(t), []*interchaintest.ChainSpec{
 		{
-			Name:    "penumbra",
-			Version: "040-themisto.1,v0.34.21",
+			Name: "penumbra",
+			// Version: "040-themisto.1,v0.34.23",
+			Version: "045-metis,v0.34.23",
 			ChainConfig: ibc.ChainConfig{
 				ChainID: "penumbra-1",
 			},


### PR DESCRIPTION
This PR makes the `TestPenumbraChainStart` test pass again.

The latest Penumbra binary starts to move some exports from `json` to `toml`.

It should be noted that the key name `funding_streams` is plural in `json` but singular (`funding_stream`) in toml.