### PR TITLE
Adding override flag in CreatChannelOptions.

### DIFF
--- a/ibc/relayer.go
+++ b/ibc/relayer.go
@@ -208,6 +208,8 @@ type CreateChannelOptions struct {
 	Order Order
 
 	Version string
+
+	Override bool
 }
 
 // DefaultChannelOpts returns the default settings for creating an ics20 fungible token transfer channel.
@@ -217,6 +219,7 @@ func DefaultChannelOpts() CreateChannelOptions {
 		DestPortName:   "transfer",
 		Order:          Unordered,
 		Version:        "ics20-1",
+		Override:       false,
 	}
 }
 

--- a/relayer/rly/cosmos_relayer.go
+++ b/relayer/rly/cosmos_relayer.go
@@ -124,14 +124,26 @@ func (commander) AddKey(chainID, keyName, coinType, homeDir string) []string {
 }
 
 func (commander) CreateChannel(pathName string, opts ibc.CreateChannelOptions, homeDir string) []string {
-	return []string{
-		"rly", "tx", "channel", pathName,
-		"--src-port", opts.SourcePortName,
-		"--dst-port", opts.DestPortName,
-		"--order", opts.Order.String(),
-		"--version", opts.Version,
+	if opts.Override {
+		return []string{
+			"rly", "tx", "channel", pathName,
+			"--src-port", opts.SourcePortName,
+			"--dst-port", opts.DestPortName,
+			"--order", opts.Order.String(),
+			"--version", opts.Version,
+			"--override",
+			"--home", homeDir,
+		}
+	} else {
+		return []string{
+			"rly", "tx", "channel", pathName,
+			"--src-port", opts.SourcePortName,
+			"--dst-port", opts.DestPortName,
+			"--order", opts.Order.String(),
+			"--version", opts.Version,
 
-		"--home", homeDir,
+			"--home", homeDir,
+		}
 	}
 }
 


### PR DESCRIPTION
This PR aims to provide an addtion of : 
- Override flag in CreatChannelOptions to have a capability of passing `--override` flag in CreateChannel transaction.