### PR TITLE
feat: add ReadFile method for reading files from docker fs

### DIFF
--- a/chain/cosmos/chain_node.go
+++ b/chain/cosmos/chain_node.go
@@ -530,6 +530,17 @@ func (tn *ChainNode) CopyFile(ctx context.Context, srcPath, dstPath string) erro
 	return tn.WriteFile(ctx, content, dstPath)
 }
 
+// ReadFile reads the contents of a single file at the specified path in the docker filesystem.
+// relPath describes the location of the file in the docker volume relative to the home directory.
+func (tn *ChainNode) ReadFile(ctx context.Context, relPath string) ([]byte, error) {
+	fr := dockerutil.NewFileRetriever(tn.logger(), tn.DockerClient, tn.TestName)
+	gen, err := fr.SingleFileContent(ctx, tn.VolumeName, relPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read file at %s: %w", relPath, err)
+	}
+	return gen, nil
+}
+
 // CreateKey creates a key in the keyring backend test for the given node
 func (tn *ChainNode) CreateKey(ctx context.Context, name string) error {
 	tn.lock.Lock()


### PR DESCRIPTION
Expose a `ReadFile` method on `ChainNode` so that you can read files from the docker filesystem within test cases that exist in downstream repos.