### PR TITLE
automatically calculate gas for TXs

### DIFF
--- a/chain/cosmos/chain_node.go
+++ b/chain/cosmos/chain_node.go
@@ -387,6 +387,7 @@ func (tn *ChainNode) TxCommand(keyName string, command ...string) []string {
 		"--gas-adjustment", fmt.Sprint(tn.Chain.Config().GasAdjustment),
 		"--keyring-backend", keyring.BackendTest,
 		"--output", "json",
+		"--gas", "auto",
 		"-y",
 	)...)
 }


### PR DESCRIPTION
Ran into this issue with wasm contract deployments, which far exceed the default gas costs for chains