### PR TITLE
generate explicit port bindings

### DIFF
--- a/chain/cosmos/chain_node.go
+++ b/chain/cosmos/chain_node.go
@@ -935,6 +935,11 @@ func (tn *ChainNode) CreateNodeContainer(ctx context.Context) error {
 			zap.String("image", imageRef),
 		)
 
+	pb, err := dockerutil.GeneratePortBindings(sentryPorts)
+	if err != nil {
+		return fmt.Errorf("failed to generate port bindings: %w", err)
+	}
+
 	cc, err := tn.DockerClient.ContainerCreate(
 		ctx,
 		&container.Config{
@@ -951,6 +956,7 @@ func (tn *ChainNode) CreateNodeContainer(ctx context.Context) error {
 		},
 		&container.HostConfig{
 			Binds:           tn.Bind(),
+			PortBindings:    pb,
 			PublishAllPorts: true,
 			AutoRemove:      false,
 			DNS:             []string{},

--- a/chain/internal/tendermint/tendermint_node.go
+++ b/chain/internal/tendermint/tendermint_node.go
@@ -220,6 +220,11 @@ func (tn *TendermintNode) CreateNodeContainer(ctx context.Context, additionalFla
 	cmd = append(cmd, additionalFlags...)
 	fmt.Printf("{%s} -> '%s'\n", tn.Name(), strings.Join(cmd, " "))
 
+	pb, err := dockerutil.GeneratePortBindings(sentryPorts)
+	if err != nil {
+		return fmt.Errorf("failed to generate port bindings: %w", err)
+	}
+
 	cc, err := tn.DockerClient.ContainerCreate(
 		ctx,
 		&container.Config{
@@ -236,6 +241,7 @@ func (tn *TendermintNode) CreateNodeContainer(ctx context.Context, additionalFla
 		},
 		&container.HostConfig{
 			Binds:           tn.Bind(),
+			PortBindings:    pb,
 			PublishAllPorts: true,
 			AutoRemove:      false,
 			DNS:             []string{},

--- a/chain/penumbra/penumbra_app_node.go
+++ b/chain/penumbra/penumbra_app_node.go
@@ -34,6 +34,8 @@ type PenumbraAppNode struct {
 	// Set during StartContainer.
 	hostRPCPort  string
 	hostGRPCPort string
+
+	preStartListeners dockerutil.Listeners
 }
 
 const (
@@ -216,10 +218,12 @@ func (p *PenumbraAppNode) CreateNodeContainer(ctx context.Context) error {
 	cmd := []string{"pd", "start", "--host", "0.0.0.0", "--home", p.HomeDir()}
 	fmt.Printf("{%s} -> '%s'\n", p.Name(), strings.Join(cmd, " "))
 
-	pb, err := dockerutil.GeneratePortBindings(exposedPorts)
+	pb, listeners, err := dockerutil.GeneratePortBindings(exposedPorts)
 	if err != nil {
 		return fmt.Errorf("failed to generate port bindings: %w", err)
 	}
+
+	p.preStartListeners = listeners
 
 	cc, err := p.DockerClient.ContainerCreate(
 		ctx,
@@ -252,6 +256,7 @@ func (p *PenumbraAppNode) CreateNodeContainer(ctx context.Context) error {
 		p.Name(),
 	)
 	if err != nil {
+		p.preStartListeners.CloseAll()
 		return err
 	}
 	p.containerID = cc.ID
@@ -264,7 +269,11 @@ func (p *PenumbraAppNode) StopContainer(ctx context.Context) error {
 }
 
 func (p *PenumbraAppNode) StartContainer(ctx context.Context) error {
-	if err := dockerutil.StartContainer(ctx, p.DockerClient, p.containerID); err != nil {
+	dockerutil.LockPortAssignment()
+	p.preStartListeners.CloseAll()
+	err := dockerutil.StartContainer(ctx, p.DockerClient, p.containerID)
+	dockerutil.UnlockPortAssignment()
+	if err != nil {
 		return err
 	}
 

--- a/chain/penumbra/penumbra_app_node.go
+++ b/chain/penumbra/penumbra_app_node.go
@@ -216,6 +216,11 @@ func (p *PenumbraAppNode) CreateNodeContainer(ctx context.Context) error {
 	cmd := []string{"pd", "start", "--host", "0.0.0.0", "--home", p.HomeDir()}
 	fmt.Printf("{%s} -> '%s'\n", p.Name(), strings.Join(cmd, " "))
 
+	pb, err := dockerutil.GeneratePortBindings(exposedPorts)
+	if err != nil {
+		return fmt.Errorf("failed to generate port bindings: %w", err)
+	}
+
 	cc, err := p.DockerClient.ContainerCreate(
 		ctx,
 		&container.Config{
@@ -233,6 +238,7 @@ func (p *PenumbraAppNode) CreateNodeContainer(ctx context.Context) error {
 		},
 		&container.HostConfig{
 			Binds:           p.Bind(),
+			PortBindings:    pb,
 			PublishAllPorts: true,
 			AutoRemove:      false,
 			DNS:             []string{},

--- a/chain/polkadot/parachain_node.go
+++ b/chain/polkadot/parachain_node.go
@@ -252,6 +252,11 @@ func (pn *ParachainNode) CreateNodeContainer(ctx context.Context) error {
 			zap.String("container", pn.Name()),
 		)
 
+	pb, err := dockerutil.GeneratePortBindings(exposedPorts)
+	if err != nil {
+		return fmt.Errorf("failed to generate port bindings: %w", err)
+	}
+
 	cc, err := pn.DockerClient.ContainerCreate(
 		ctx,
 		&container.Config{
@@ -269,6 +274,7 @@ func (pn *ParachainNode) CreateNodeContainer(ctx context.Context) error {
 		},
 		&container.HostConfig{
 			Binds:           pn.Bind(),
+			PortBindings:    pb,
 			PublishAllPorts: true,
 			AutoRemove:      false,
 			DNS:             []string{},

--- a/chain/polkadot/relay_chain_node.go
+++ b/chain/polkadot/relay_chain_node.go
@@ -228,6 +228,11 @@ func (p *RelayChainNode) CreateNodeContainer(ctx context.Context) error {
 			zap.String("container", p.Name()),
 		)
 
+	pb, err := dockerutil.GeneratePortBindings(exposedPorts)
+	if err != nil {
+		return fmt.Errorf("failed to generate port bindings: %w", err)
+	}
+
 	cc, err := p.DockerClient.ContainerCreate(
 		ctx,
 		&container.Config{
@@ -245,6 +250,7 @@ func (p *RelayChainNode) CreateNodeContainer(ctx context.Context) error {
 		},
 		&container.HostConfig{
 			Binds:           p.Bind(),
+			PortBindings:    pb,
 			PublishAllPorts: true,
 			AutoRemove:      false,
 			DNS:             []string{},

--- a/internal/dockerutil/ports.go
+++ b/internal/dockerutil/ports.go
@@ -1,0 +1,62 @@
+package dockerutil
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/docker/go-connections/nat"
+)
+
+// openListenerOnFreePort opens the next free port
+func openListenerOnFreePort() (*net.TCPListener, error) {
+	addr, err := net.ResolveTCPAddr("tcp", "localhost:0")
+	if err != nil {
+		return nil, err
+	}
+
+	l, err := net.ListenTCP("tcp", addr)
+	if err != nil {
+		return nil, err
+	}
+
+	return l, nil
+}
+
+// nextAvailablePort generates a docker PortBinding by finding the next available port.
+// The listener will be closed in the case of an error, otherwise it will be left open.
+// This allows multiple nextAvailablePort calls to find multiple available ports
+// before closing them so they are available for the PortBinding.
+func nextAvailablePort() (nat.PortBinding, *net.TCPListener, error) {
+	l, err := openListenerOnFreePort()
+	if err != nil {
+		l.Close()
+		return nat.PortBinding{}, nil, err
+	}
+
+	return nat.PortBinding{
+		HostIP:   "0.0.0.0",
+		HostPort: fmt.Sprint(l.Addr().(*net.TCPAddr).Port),
+	}, l, nil
+}
+
+// GeneratePortBindings will find open ports on the local
+// machine and create a PortBinding for every port in the portSet.
+func GeneratePortBindings(portSet nat.PortSet) (nat.PortMap, error) {
+	m := make(nat.PortMap)
+	listeners := make([]*net.TCPListener, 0, len(portSet))
+
+	for p := range portSet {
+		pb, l, err := nextAvailablePort()
+		if err != nil {
+			return nat.PortMap{}, err
+		}
+		listeners = append(listeners, l)
+		m[p] = []nat.PortBinding{pb}
+	}
+
+	for _, l := range listeners {
+		l.Close()
+	}
+
+	return m, nil
+}


### PR DESCRIPTION
Generate explicit port bindings to workaround [docker bug](https://github.com/moby/moby/issues/42442). This retains automatic port allocation functionality by opening temporary listeners on the next available port and holding that listener open until the handoff to docker for the container to consume the port.

Resolves #443 