### PR TITLE
Adds ParamChangeProposal

### DIFF
--- a/chain/cosmos/cosmos_chain.go
+++ b/chain/cosmos/cosmos_chain.go
@@ -304,11 +304,36 @@ func (c *CosmosChain) QueryProposal(ctx context.Context, proposalID string) (*Pr
 	return c.getFullNode().QueryProposal(ctx, proposalID)
 }
 
+// QueryParam returns the param state of a given key.
+func (c *CosmosChain) QueryParam(ctx context.Context, subspace, key string) (*ParamChange, error) {
+	return c.getFullNode().QueryParam(ctx, subspace, key)
+}
+
 // UpgradeProposal submits a software-upgrade governance proposal to the chain.
 func (c *CosmosChain) UpgradeProposal(ctx context.Context, keyName string, prop SoftwareUpgradeProposal) (tx TxProposal, _ error) {
 	txHash, err := c.getFullNode().UpgradeProposal(ctx, keyName, prop)
 	if err != nil {
 		return tx, fmt.Errorf("failed to submit upgrade proposal: %w", err)
+	}
+	return c.txProposal(txHash)
+}
+
+// ParamChangeProposal submits a param-change governance proposal to the chain.
+func (c *CosmosChain) ParamChangeProposal(ctx context.Context, keyName, fileLocation string) (tx TxProposal, _ error) {
+	dat, err := os.ReadFile(fileLocation)
+	if err != nil {
+		return tx, fmt.Errorf("failed to read file: %w", err)
+	}
+
+	var paramChange ParamChangeProposal
+	err = json.Unmarshal(dat, &paramChange)
+	if err != nil {
+		return tx, fmt.Errorf("failed to unmarshal JSON: %w", err)
+	}
+
+	txHash, err := c.getFullNode().ParamChangeProposal(ctx, keyName, paramChange)
+	if err != nil {
+		return tx, fmt.Errorf("failed to submit param-change proposal: %w", err)
 	}
 	return c.txProposal(txHash)
 }
@@ -336,6 +361,7 @@ func (c *CosmosChain) txProposal(txHash string) (tx TxProposal, _ error) {
 	if err != nil {
 		return tx, fmt.Errorf("failed to get transaction %s: %w", txHash, err)
 	}
+
 	tx.Height = uint64(txResp.Height)
 	tx.TxHash = txHash
 	// In cosmos, user is charged for entire gas requested, not the actual gas used.

--- a/chain/cosmos/types.go
+++ b/chain/cosmos/types.go
@@ -62,6 +62,19 @@ type ProposalResponse struct {
 	VotingEndTime    string                   `json:"voting_end_time"`
 }
 
+type ParamChange struct {
+	Subspace string `json:"subspace"`
+	Key      string `json:"key"`
+	Value    any    `json:"value"`
+}
+
+type ParamChangeProposal struct {
+	Title       string        `json:"title"`
+	Description string        `json:"description"`
+	Changes     []ParamChange `json:"changes"`
+	Deposit     string        `json:"deposit"`
+}
+
 type ProposalContent struct {
 	Type        string `json:"@type"`
 	Title       string `json:"title"`

--- a/examples/cosmos/chain_param_change_test.go
+++ b/examples/cosmos/chain_param_change_test.go
@@ -3,6 +3,7 @@ package cosmos_test
 import (
 	"context"
 	"os"
+	"path"
 	"testing"
 
 	"github.com/strangelove-ventures/interchaintest/v4"
@@ -70,7 +71,8 @@ func CosmosChainParamChangeTest(t *testing.T, name, version string) {
 	require.Equal(t, "100", param.Value, "MaxValidators value is not 100")
 
 	current_directory, _ := os.Getwd()
-	param_change_path := current_directory + "/params/IncreaseValidatorsParam.json"
+	param_change_path := path.Join(current_directory, "params", "IncreaseValidatorsParam.json")
+
 	paramTx, err := chain.ParamChangeProposal(ctx, chainUser.KeyName, param_change_path)
 	require.NoError(t, err, "error submitting param change proposal tx")
 

--- a/examples/cosmos/chain_param_change_test.go
+++ b/examples/cosmos/chain_param_change_test.go
@@ -1,0 +1,86 @@
+package cosmos_test
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/strangelove-ventures/interchaintest/v4"
+	"github.com/strangelove-ventures/interchaintest/v4/chain/cosmos"
+	"github.com/strangelove-ventures/interchaintest/v4/ibc"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+)
+
+func TestJunoParamChange(t *testing.T) {
+	CosmosChainParamChangeTest(t, "juno", junoVersion)
+}
+
+func CosmosChainParamChangeTest(t *testing.T, name, version string) {
+	if testing.Short() {
+		t.Skip("skipping in short mode")
+	}
+
+	t.Parallel()
+
+	numVals := 1
+	numFullNodes := 1
+
+	cf := interchaintest.NewBuiltinChainFactory(zaptest.NewLogger(t), []*interchaintest.ChainSpec{
+		{
+			Name:      name,
+			ChainName: name,
+			Version:   version,
+			ChainConfig: ibc.ChainConfig{
+				Denom:         "ujuno",
+				ModifyGenesis: cosmos.ModifyGenesisProposalTime(votingPeriod, maxDepositPeriod),
+			},
+			NumValidators: &numVals,
+			NumFullNodes:  &numFullNodes,
+		},
+	})
+
+	chains, err := cf.Chains(t.Name())
+	require.NoError(t, err)
+
+	chain := chains[0].(*cosmos.CosmosChain)
+
+	ic := interchaintest.NewInterchain().
+		AddChain(chain)
+
+	ctx := context.Background()
+	client, network := interchaintest.DockerSetup(t)
+
+	require.NoError(t, ic.Build(ctx, nil, interchaintest.InterchainBuildOptions{
+		TestName:  t.Name(),
+		Client:    client,
+		NetworkID: network,
+		// BlockDatabaseFile: interchaintest.DefaultBlockDatabaseFilepath(),
+		SkipPathCreation: true,
+	}))
+	t.Cleanup(func() {
+		_ = ic.Close()
+	})
+
+	const userFunds = int64(10_000_000_000)
+	users := interchaintest.GetAndFundTestUsers(t, ctx, t.Name(), userFunds, chain)
+	chainUser := users[0]
+
+	param, _ := chain.QueryParam(ctx, "staking", "MaxValidators")
+	require.Equal(t, "100", param.Value, "MaxValidators value is not 100")
+
+	current_directory, _ := os.Getwd()
+	param_change_path := current_directory + "/params/IncreaseValidatorsParam.json"
+	paramTx, err := chain.ParamChangeProposal(ctx, chainUser.KeyName, param_change_path)
+	require.NoError(t, err, "error submitting param change proposal tx")
+
+	err = chain.VoteOnProposalAllValidators(ctx, paramTx.ProposalID, cosmos.ProposalVoteYes)
+	require.NoError(t, err, "failed to submit votes")
+
+	height, _ := chain.Height(ctx)
+	_, err = cosmos.PollForProposalStatus(ctx, chain, height, height+10, paramTx.ProposalID, cosmos.ProposalStatusPassed)
+	require.NoError(t, err, "proposal status did not change to passed in expected number of blocks")
+
+	param, _ = chain.QueryParam(ctx, "staking", "MaxValidators")
+	require.Equal(t, "110", param.Value, "MaxValidators value is not 110")
+}

--- a/examples/cosmos/params/IncreaseValidatorsParam.json
+++ b/examples/cosmos/params/IncreaseValidatorsParam.json
@@ -1,0 +1,12 @@
+{
+    "title": "Increase validator set to 110",
+    "description": ".",
+    "changes": [
+      {
+        "subspace": "staking",
+        "key": "MaxValidators",
+        "value": 110
+      }
+    ],
+    "deposit": "10000000ujuno"
+}

--- a/examples/cosmos/versions_test.go
+++ b/examples/cosmos/versions_test.go
@@ -3,4 +3,5 @@ package cosmos_test
 const (
 	gaiaVersion    = "v7.1.0"
 	osmosisVersion = "v12.2.0"
+	junoVersion    = "v13.0.1"
 )


### PR DESCRIPTION
Closes #464 . Targeting v4 branch here

## Question
- Once approved, should I make another PR targeting main?

## Changes
- Adds a way to query a subspace param
- ParamChangeProposal
- Example test in action

## Reason
- We need this in v4 for Juno to test lowering unbonding period & the effects on IBC & GlobalFee
- Noble (v3) also has globalfees, so this is helpful to test that too with e2e per the todo https://github.com/strangelove-ventures/noble/pull/146