### PR TITLE
chore: update configured chains to use osmosis consensus min fee

### DIFF
--- a/configuredChains.yaml
+++ b/configuredChains.yaml
@@ -93,7 +93,7 @@ osmosis:
   bin: osmosisd
   bech32-prefix: osmo
   denom: uosmo
-  gas-prices: 0.0uosmo
+  gas-prices: 0.0025uosmo
   gas-adjustment: 1.3
   trusting-period: 336h
   images:


### PR DESCRIPTION
v15.0.0 of Osmosis added a consensus min fee of `0.0025uosmo` (see more [here](https://github.com/osmosis-labs/osmosis/releases/tag/v15.0.0)) so the default settings in `configuredChains.yaml` will result in `insufficient fee` errors.

This was not obvious to me at all without digging through the Osmosis repo so it's probably best we just configure the chain to use this value be default.