### PR TITLE
Use `--gas auto` when executing transactions.

### DIFF
--- a/chain/cosmos/chain_node.go
+++ b/chain/cosmos/chain_node.go
@@ -408,6 +408,7 @@ func (tn *ChainNode) TxCommand(keyName string, command ...string) []string {
 		"--from", keyName,
 		"--gas-prices", tn.Chain.Config().GasPrices,
 		"--gas-adjustment", fmt.Sprint(tn.Chain.Config().GasAdjustment),
+		"--gas", "auto",
 		"--keyring-backend", keyring.BackendTest,
 		"--output", "json",
 		"-y",


### PR DESCRIPTION
Without this change the max_gas for a given transaction defaults to 200_000 which is not enough for any non-trivial smart contract interactions.

Resolves #482 