### PR TITLE
Fix issues with hermes client, channel creation and channel queries.

### DIFF
--- a/relayer/hermes/hermes_commander.go
+++ b/relayer/hermes/hermes_commander.go
@@ -48,13 +48,13 @@ func (c commander) ParseGetChannelsOutput(stdout, stderr string) ([]ibc.ChannelO
 			State:    r.ChannelEnd.State,
 			Ordering: r.ChannelEnd.Ordering,
 			Counterparty: ibc.ChannelCounterparty{
-				PortID:    r.CounterPartyChannelEnd.Remote.PortID,
-				ChannelID: r.CounterPartyChannelEnd.Remote.ChannelID,
+				PortID:    r.ChannelEnd.Remote.PortID,
+				ChannelID: r.ChannelEnd.Remote.ChannelID,
 			},
 			ConnectionHops: r.ChannelEnd.ConnectionHops,
 			Version:        r.ChannelEnd.Version,
-			PortID:         r.ChannelEnd.Remote.PortID,
-			ChannelID:      r.ChannelEnd.Remote.ChannelID,
+			PortID:         r.CounterPartyChannelEnd.Remote.PortID,
+			ChannelID:      r.CounterPartyChannelEnd.Remote.ChannelID,
 		})
 	}
 

--- a/relayer/hermes/hermes_relayer.go
+++ b/relayer/hermes/hermes_relayer.go
@@ -113,7 +113,10 @@ func (r *Relayer) LinkPath(ctx context.Context, rep ibc.RelayerExecReporter, pat
 
 func (r *Relayer) CreateChannel(ctx context.Context, rep ibc.RelayerExecReporter, pathName string, opts ibc.CreateChannelOptions) error {
 	pathConfig := r.paths[pathName]
-	cmd := []string{hermes, "--json", "create", "channel", "--a-chain", pathConfig.chainA.chainID, "--a-port", opts.SourcePortName, "--b-port", opts.DestPortName, "--a-connection", pathConfig.chainA.connectionID}
+	cmd := []string{hermes, "--json", "create", "channel", "--order", opts.Order.String(), "--a-chain", pathConfig.chainA.chainID, "--a-port", opts.SourcePortName, "--b-port", opts.DestPortName, "--a-connection", pathConfig.chainA.connectionID}
+	if opts.Version != "" {
+		cmd = append(cmd, "--channel-version", opts.Version)
+	}
 	res := r.Exec(ctx, rep, cmd, nil)
 	if res.Err != nil {
 		return res.Err
@@ -161,6 +164,9 @@ func (r *Relayer) UpdateClients(ctx context.Context, rep ibc.RelayerExecReporter
 func (r *Relayer) CreateClients(ctx context.Context, rep ibc.RelayerExecReporter, pathName string, opts ibc.CreateClientOptions) error {
 	pathConfig := r.paths[pathName]
 	chainACreateClientCmd := []string{hermes, "--json", "create", "client", "--host-chain", pathConfig.chainA.chainID, "--reference-chain", pathConfig.chainB.chainID}
+	if opts.TrustingPeriod != "0" {
+		chainACreateClientCmd = append(chainACreateClientCmd, "--trusting-period", opts.TrustingPeriod)
+	}
 	res := r.Exec(ctx, rep, chainACreateClientCmd, nil)
 	if res.Err != nil {
 		return res.Err
@@ -173,6 +179,9 @@ func (r *Relayer) CreateClients(ctx context.Context, rep ibc.RelayerExecReporter
 	pathConfig.chainA.clientID = chainAClientId
 
 	chainBCreateClientCmd := []string{hermes, "--json", "create", "client", "--host-chain", pathConfig.chainB.chainID, "--reference-chain", pathConfig.chainA.chainID}
+	if opts.TrustingPeriod != "0" {
+		chainBCreateClientCmd = append(chainBCreateClientCmd, "--trusting-period", opts.TrustingPeriod)
+	}
 	res = r.Exec(ctx, rep, chainBCreateClientCmd, nil)
 	if res.Err != nil {
 		return res.Err


### PR DESCRIPTION
Basically three changes:

 - Fix the endpoints when querying a channel, they were in reverse order.
 - Pass the `channel-version`, if applicable, and `order` during channel creation.
 - Pass the trusting period, if applicable, to the client during creation.

Found while trying to integrate hermes in our e2e tests https://github.com/cosmos/ibc-go/pull/3408