### PR TITLE
Bump rly default version to v2.3.1

### DIFF
--- a/examples/cosmos/sdk_47_boundary_test.go
+++ b/examples/cosmos/sdk_47_boundary_test.go
@@ -8,8 +8,6 @@ import (
 	"github.com/strangelove-ventures/interchaintest/v7/chain/cosmos"
 	"github.com/strangelove-ventures/interchaintest/v7/conformance"
 	"github.com/strangelove-ventures/interchaintest/v7/ibc"
-	"github.com/strangelove-ventures/interchaintest/v7/relayer"
-	"github.com/strangelove-ventures/interchaintest/v7/relayer/rly"
 	"github.com/strangelove-ventures/interchaintest/v7/testreporter"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
@@ -51,9 +49,6 @@ func TestSDK47Boundary(t *testing.T) {
 	rf := interchaintest.NewBuiltinRelayerFactory(
 		ibc.CosmosRly,
 		zaptest.NewLogger(t),
-		relayer.StartupFlags("-b", "100"),
-		relayer.CustomDockerImage("ghcr.io/cosmos/relayer", "andrew-tendermint_v0.37", rly.RlyDefaultUidGid),
-		relayer.ImagePull(false),
 	)
 
 	r := rf.Build(t, client, network)

--- a/relayer/rly/cosmos_relayer.go
+++ b/relayer/rly/cosmos_relayer.go
@@ -66,7 +66,7 @@ type CosmosRelayerChainConfig struct {
 
 const (
 	DefaultContainerImage   = "ghcr.io/cosmos/relayer"
-	DefaultContainerVersion = "andrew-config_file_lock_for_all_writes"
+	DefaultContainerVersion = "v2.3.1"
 )
 
 // Capabilities returns the set of capabilities of the Cosmos relayer.


### PR DESCRIPTION
Bump rly default version to v2.3.1 and remove custom image for tm v0.37 boundary test