### PR TITLE
Free up Runners: No need to run tests after PR gets merged

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,11 +1,7 @@
 name: golangci-lint
 on:
-  push:
-    tags:
-      - v*
-    branches:
-      - main
   pull_request:
+  
 jobs:
   golangci:
     name: lint

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,13 +2,6 @@ name: Run Go Tests
 
 on:
   pull_request:
-  push:
-    branches:
-      - main
-    paths:
-      - "**.go"
-      - "**.mod"
-      - "**.sum"
 
 jobs:
   test-unit:


### PR DESCRIPTION
To free up some runners, I don't think it is necessary to run the CI tests after merging the PR.

These tests only need to be run on pull requests. 