### PR TITLE
Modify CI Test Suite

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,31 +1,11 @@
-name: Run Go Tests
+name: Run End-To-End Tests
 
 on:
   pull_request:
+    branches-ignore:
+      - 'dependabot/go_modules/**'
 
 jobs:
-  test-unit:
-    name: unit-tests
-    runs-on: [self-hosted, linux]
-    steps:
-      # Install and setup go
-      - name: Set up Go 1.19
-        uses: actions/setup-go@v4
-        with:
-          go-version: 1.19
-
-      - name: checkout interchaintest
-        uses: actions/checkout@v3
-
-      # cleanup environment on self-hosted test runner
-      - name: clean
-        run: |-
-          rm -rf ~/.interchaintest
-
-      # run tests
-      - name: run unit tests
-        # -short flag purposefully omitted because there are some longer unit tests
-        run: go test -race -timeout 10m -p 2 $(go list ./... | grep -v /cmd | grep -v /examples)
   test-conformance:
     name: test-conformance
     runs-on: [self-hosted, linux]
@@ -46,7 +26,7 @@ jobs:
 
       # run tests
       - name: run conformance tests
-        run: (go test -race -timeout 30m -v -p 2 ./cmd/interchaintest) || (echo "\n\n*****CHAIN and RELAYER LOGS*****" && cat "$HOME/.interchaintest/logs/interchaintest.log" && exit 1)
+        run: (go test -race -timeout -failfast 30m -v -p 2 ./cmd/interchaintest) || (echo "\n\n*****CHAIN and RELAYER LOGS*****" && cat "$HOME/.interchaintest/logs/interchaintest.log" && exit 1)
   test-ibc-examples:
     name: test-ibc-examples
     runs-on: [self-hosted, linux]
@@ -67,7 +47,7 @@ jobs:
 
       # run tests
       - name: run example ibc tests
-        run: go test -race -timeout 30m -v -p 2 ./examples/ibc
+        run: go test -race -timeout 30m -failfast -v -p 2 ./examples/ibc
   test-cosmos-examples:
     name: test-cosmos-examples
     runs-on: [self-hosted, linux]
@@ -88,4 +68,4 @@ jobs:
 
       # run tests
       - name: run example cosmos tests
-        run: go test -race -timeout 30m -v -p 2 ./examples/cosmos
+        run: go test -race -failfast -timeout 30m -v -p 2 ./examples/cosmos

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,28 @@
+name: Run Unit Tests
+
+on:
+  pull_request:
+
+jobs:
+  test-unit:
+    name: unit-tests
+    runs-on: [self-hosted, linux]
+    steps:
+      # Install and setup go
+      - name: Set up Go 1.19
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.19
+
+      - name: checkout interchaintest
+        uses: actions/checkout@v3
+
+      # cleanup environment on self-hosted test runner
+      - name: clean
+        run: |-
+          rm -rf ~/.interchaintest
+
+      # run tests
+      - name: run unit tests
+        # -short flag purposefully omitted because there are some longer unit tests
+        run: go test -race -timeout 10m -p 2 $(go list ./... | grep -v /cmd | grep -v /examples)


### PR DESCRIPTION
This PR...
- Allows dependabot dependency PR's to be merged with out going through the entire E2E test suite.
- Adds the `-failfast` flag to end-to-end tests

Given how throughout and extensive our end-to-end tests are, I don't think it is necessary to run the entire test suite for dependabot's dependency PR's. The unit-tests and linter may suffice. 

Currently, it can take 30+ minutes for some tests to complete and while we continue to improve reliability of our E2E test suite, some tests still produce false positives. 

The PR will allow us to be more agile and merge PR's quicker.