### PR TITLE
Add attempt limiter to Retry Prune Networks

### DIFF
--- a/internal/dockerutil/setup.go
+++ b/internal/dockerutil/setup.go
@@ -220,6 +220,7 @@ func pruneNetworksWithRetry(ctx context.Context, t DockerSetupTestingT, cli *cli
 		},
 		retry.Context(ctx),
 		retry.DelayType(retry.FixedDelay),
+		retry.Attempts(3),
 	)
 
 	if err != nil {


### PR DESCRIPTION
In the CI, we are constantly seeing errors like this.
This is occurring during after the test, when trying to clean up docker.

```
    setup.go:226: Failed to prune networks during docker cleanup: All attempts fail:
        #1: Error response from daemon: a prune operation is already running
        #2: Error response from daemon: a prune operation is already running
        #3: Error response from daemon: a prune operation is already running
        #4: Error response from daemon: a prune operation is already running
        #5: Error response from daemon: a prune operation is already running
        #6: Error response from daemon: a prune operation is already running
        #7: Error response from daemon: a prune operation is already running
        #8: Error response from daemon: a prune operation is already running
        #9: Error response from daemon: a prune operation is already running
        #10: Error response from daemon: a prune operation is already running
panic: test timed out after 30m0s
```

This retry command will now give up after 3 retries if there is already a network prune in progress.