### PR TITLE
Use ghcr registry for hermes, bump version.

### DIFF
--- a/relayer/hermes/hermes_relayer.go
+++ b/relayer/hermes/hermes_relayer.go
@@ -17,8 +17,8 @@ import (
 
 const (
 	hermes                  = "hermes"
-	defaultContainerImage   = "docker.io/informalsystems/hermes"
-	DefaultContainerVersion = "1.2.0"
+	defaultContainerImage   = "ghcr.io/informalsystems/hermes"
+	DefaultContainerVersion = "1.4.0"
 
 	hermesDefaultUidGid = "1000:1000"
 	hermesHome          = "/home/hermes"


### PR DESCRIPTION
Changes the registry to ghcr which hermes is now using and bumps the version.