### PR TITLE
Allow extra startup flags for hermes.

### DIFF
--- a/relayer/hermes/hermes_commander.go
+++ b/relayer/hermes/hermes_commander.go
@@ -16,7 +16,8 @@ import (
 var _ relayer.RelayerCommander = &commander{}
 
 type commander struct {
-	log *zap.Logger
+	log             *zap.Logger
+	extraStartFlags []string
 }
 
 func (c commander) Name() string {
@@ -135,7 +136,9 @@ func (c commander) GetClients(chainID, homeDir string) []string {
 }
 
 func (c commander) StartRelayer(homeDir string, pathNames ...string) []string {
-	return []string{hermes, "--config", fmt.Sprintf("%s/%s", homeDir, hermesConfigPath), "start", "--full-scan"}
+	cmd := []string{hermes, "--config", fmt.Sprintf("%s/%s", homeDir, hermesConfigPath), "start"}
+	cmd = append(cmd, c.extraStartFlags...)
+	return cmd
 }
 
 func (c commander) CreateWallet(keyName, address, mnemonic string) ibc.Wallet {

--- a/relayer/hermes/hermes_relayer.go
+++ b/relayer/hermes/hermes_relayer.go
@@ -62,6 +62,12 @@ type pathChainConfig struct {
 // NewHermesRelayer returns a new hermes relayer.
 func NewHermesRelayer(log *zap.Logger, testName string, cli *client.Client, networkID string, options ...relayer.RelayerOption) *Relayer {
 	c := commander{log: log}
+	for _, opt := range options {
+		switch o := opt.(type) {
+		case relayer.RelayerOptionExtraStartFlags:
+			c.extraStartFlags = o.Flags
+		}
+	}
 	options = append(options, relayer.HomeDir(hermesHome))
 	dr, err := relayer.NewDockerRelayer(context.TODO(), log, testName, cli, networkID, c, options...)
 	if err != nil {


### PR DESCRIPTION
Similarly to `rly`, allows some startup flags to be provided per instantiation instead of hardcoding them in the `StartRelayer` function.

Ideally, none of the tests in interchaintest should be tweaked.