### PR TITLE
fix: moved '--chain-id' flag from NodeCommand to TxCommand

### DIFF
--- a/chain/cosmos/chain_node.go
+++ b/chain/cosmos/chain_node.go
@@ -410,6 +410,7 @@ func (tn *ChainNode) TxCommand(keyName string, command ...string) []string {
 		"--keyring-backend", keyring.BackendTest,
 		"--output", "json",
 		"-y",
+		"--chain-id", tn.Chain.Config().ChainID,
 	)...)
 }
 
@@ -445,7 +446,6 @@ func (tn *ChainNode) NodeCommand(command ...string) []string {
 	command = tn.BinCommand(command...)
 	return append(command,
 		"--node", fmt.Sprintf("tcp://%s:26657", tn.HostName()),
-		"--chain-id", tn.Chain.Config().ChainID,
 	)
 }
 


### PR DESCRIPTION
## Description

This PR:
- [x] Moves `--chain-id` flag from all node commands to only tx commands because cosmos-sdk no longer supports the flag for queries by default.

closes: #637 