### PR TITLE
Update Readme + Mergify Rule for Maintained Branches

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,13 +11,11 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 10
     labels:
-      - dependencies
-      - dont_backport
-      
+      - dependencies      
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
       interval: monthly
     open-pull-requests-limit: 10
     labels:
-      - dont_backport
+      - gh-action-version

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,13 +1,13 @@
 pull_request_rules:
   - name: backport to maintained branches
     conditions:
-      - base=main
-      - label!=dont_backport
+      - base~=^(main|v4|v4-ics|v5|v6)$
+      - label=BACKPORT
     actions:
       backport:
         branches:
-          - v3
-          - v3-ics
+          - main
+          - v4-ics
           - v4
           - v5
           - v6
@@ -21,7 +21,7 @@ pull_request_rules:
   - name: automerge backported PR's for maintained branches
     conditions:
       - label=automerge
-      - base~=^(v3|v3-ics|v4|v5|v6)$
+      - base~=^(v4|v4-ics|v5|v6)$
     actions:
       merge:
         method: squash

--- a/README.md
+++ b/README.md
@@ -25,14 +25,15 @@ It allows users to quickly spin up custom testnets and dev environments to test 
 
 ### Maintained Branches
 
-|                                **Branch Name**                               | **IBC-Go** | **Cosmos-sdk** |
-|:----------------------------------------------------------------------------:|:----------:|:--------------:|
-|                                     main                                     |     v7     |      v0.47     |
-|     [v6](https://github.com/strangelove-ventures/interchaintest/tree/v6)     |     v6     |      v0.46     |
-|     [v5](https://github.com/strangelove-ventures/interchaintest/tree/v5)     |     v5     |      v0.46     |
-|     [v4](https://github.com/strangelove-ventures/interchaintest/tree/v4)     |     v4     |      v0.45     |
-|     [v3](https://github.com/strangelove-ventures/interchaintest/tree/v3)     |     v3     |      v0.45     |
-| [v3-ics](https://github.com/strangelove-ventures/interchaintest/tree/v3-ics) |     v3     |  v0.45.11-ics  |
+|                                **Branch Name**                               | **IBC-Go** | **Cosmos-sdk** |    **Maintained**   |
+|:----------------------------------------------------------------------------:|:----------:|:--------------:|:-------------------:|
+|                                     main                                     |     v7     |      v0.47     |         ✅          |
+|     [v6](https://github.com/strangelove-ventures/interchaintest/tree/v6)     |     v6     |      v0.46     |         ✅          |
+|     [v5](https://github.com/strangelove-ventures/interchaintest/tree/v5)     |     v5     |      v0.46     |         ✅          |
+|     [v4](https://github.com/strangelove-ventures/interchaintest/tree/v4)     |     v4     |      v0.45     |         ✅          |
+| [v4-ics](https://github.com/strangelove-ventures/interchaintest/tree/v4-ics) |     v4     |   v0.45.x-ics  |         ✅          |
+|     [v3](https://github.com/strangelove-ventures/interchaintest/tree/v3)     |     v3     |      v0.45     |❌<br>(June 25 2023) |
+| [v3-ics](https://github.com/strangelove-ventures/interchaintest/tree/v3-ics) |     v3     |  v0.45.11-ics  |❌<br>(April 24 2023)|
 
 ## Table Of Contents
 - [Building Binary](#building-binary)


### PR DESCRIPTION
This PR:

- Updates the `Maintained Branches` Table on the Readme

- Updates the Mergify rule 
   - Will not backport PR's to `v3` OR `v3-ics` anymore
   -  Instead of backporting all PR's EXCEPT if they have a `dont_backport` lable, this changes the rule to only backport PR's that have a `BACKPORT` label.
   - I think this makes more sense as there will most likely be more PR's pointed at specific branches.
   - It also updates the rule to not only backport PR's merged into `main`, but now allows for PR's to be targeted to any of our maintained branches to also be backported. EXAMPLE: PR targeted at `v5` branch with the backport label will also get "backported" into `main`.
   - Because of this rule change, dependabot does not need to label with `dont_backport` anymore

(Branch protection rules already have been updated)

I'm also hoping to use this PR as a test to ensure that backporting works correctly and everything in CI is passing across all branches.