### PR TITLE
fix: mergify labeling

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -15,7 +15,7 @@ pull_request_rules:
             - "{{ author }}"
         labels:
           - automerge
-          - backport
+          - backported
         title: "`[BP: {{ destination_branch }} <- #{{ number }}]` {{ title }}"
 
   - name: automerge backported PR's for maintained branches


### PR DESCRIPTION
We don't want Mergify to add the `BACKPORT` label to a PR it already backproted. 😵‍💫 
This will cause to try and backport it again.

Instead lets add a `backported` label.