### PR TITLE
refactor: use cosmos sdk Int type for balances/token amounts

### DIFF
--- a/chain/cosmos/chain_node.go
+++ b/chain/cosmos/chain_node.go
@@ -720,7 +720,7 @@ func (tn *ChainNode) SendIBCTransfer(
 ) (string, error) {
 	command := []string{
 		"ibc-transfer", "transfer", "transfer", channelID,
-		amount.Address, fmt.Sprintf("%d%s", amount.Amount, amount.Denom),
+		amount.Address, fmt.Sprintf("%s%s", amount.Amount.String(), amount.Denom),
 	}
 	if options.Timeout != nil {
 		if options.Timeout.NanoSeconds > 0 {
@@ -738,7 +738,7 @@ func (tn *ChainNode) SendIBCTransfer(
 func (tn *ChainNode) SendFunds(ctx context.Context, keyName string, amount ibc.WalletAmount) error {
 	_, err := tn.ExecTx(ctx,
 		keyName, "bank", "send", keyName,
-		amount.Address, fmt.Sprintf("%d%s", amount.Amount, amount.Denom),
+		amount.Address, fmt.Sprintf("%s%s", amount.Amount.String(), amount.Denom),
 	)
 	return err
 }
@@ -1303,7 +1303,7 @@ func (tn *ChainNode) SendICABankTransfer(ctx context.Context, connectionID, from
 		"amount": []map[string]any{
 			{
 				"denom":  amount.Denom,
-				"amount": amount.Amount,
+				"amount": amount.Amount.String(),
 			},
 		},
 	})

--- a/chain/cosmos/cosmos_chain.go
+++ b/chain/cosmos/cosmos_chain.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"sync"
 
+	"cosmossdk.io/math"
 	"github.com/cosmos/cosmos-sdk/codec"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	cryptocodec "github.com/cosmos/cosmos-sdk/crypto/codec"
@@ -522,12 +523,12 @@ func (c *CosmosChain) ExportState(ctx context.Context, height int64) (string, er
 
 // GetBalance fetches the current balance for a specific account address and denom.
 // Implements Chain interface
-func (c *CosmosChain) GetBalance(ctx context.Context, address string, denom string) (int64, error) {
+func (c *CosmosChain) GetBalance(ctx context.Context, address string, denom string) (math.Int, error) {
 	params := &bankTypes.QueryBalanceRequest{Address: address, Denom: denom}
 	grpcAddress := c.getFullNode().hostGRPCPort
 	conn, err := grpc.Dial(grpcAddress, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
-		return 0, err
+		return math.Int{}, err
 	}
 	defer conn.Close()
 
@@ -535,10 +536,10 @@ func (c *CosmosChain) GetBalance(ctx context.Context, address string, denom stri
 	res, err := queryClient.Balance(ctx, params)
 
 	if err != nil {
-		return 0, err
+		return math.Int{}, err
 	}
 
-	return res.Balance.Amount.Int64(), nil
+	return res.Balance.Amount, nil
 }
 
 // AllBalances fetches an account address's balance for all denoms it holds
@@ -920,7 +921,7 @@ func (c *CosmosChain) Start(testName string, ctx context.Context, additionalGene
 	}
 
 	for _, wallet := range additionalGenesisWallets {
-		if err := validator0.AddGenesisAccount(ctx, wallet.Address, []types.Coin{{Denom: wallet.Denom, Amount: types.NewInt(wallet.Amount)}}); err != nil {
+		if err := validator0.AddGenesisAccount(ctx, wallet.Address, []types.Coin{{Denom: wallet.Denom, Amount: wallet.Amount}}); err != nil {
 			return err
 		}
 	}

--- a/chain/cosmos/poll.go
+++ b/chain/cosmos/poll.go
@@ -71,8 +71,8 @@ func PollForBalance(ctx context.Context, chain *CosmosChain, deltaBlocks uint64,
 		if err != nil {
 			return nil, err
 		}
-		if bal != balance.Amount {
-			return nil, fmt.Errorf("balance (%d) does not match expected: (%d)", bal, balance.Amount)
+		if !balance.Amount.Equal(bal) {
+			return nil, fmt.Errorf("balance (%s) does not match expected: (%s)", bal.String(), balance.Amount.String())
 		}
 		return nil, nil
 	}

--- a/chain/penumbra/penumbra_app_node.go
+++ b/chain/penumbra/penumbra_app_node.go
@@ -138,7 +138,7 @@ func (p *PenumbraAppNode) GenerateGenesisFile(
 	}
 	allocationsCsv := []byte(`"amount","denom","address"\n`)
 	for _, allocation := range allocations {
-		allocationsCsv = append(allocationsCsv, []byte(fmt.Sprintf(`"%d","%s","%s"\n`, allocation.Amount, allocation.Denom, allocation.Address))...)
+		allocationsCsv = append(allocationsCsv, []byte(fmt.Sprintf(`"%s","%s","%s"\n`, allocation.Amount.String(), allocation.Denom, allocation.Address))...)
 	}
 	if err := fw.WriteFile(ctx, p.VolumeName, "allocations.csv", allocationsCsv); err != nil {
 		return fmt.Errorf("error writing allocations to file: %w", err)

--- a/chain/penumbra/penumbra_chain.go
+++ b/chain/penumbra/penumbra_chain.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 
+	"cosmossdk.io/math"
 	"github.com/BurntSushi/toml"
 	"github.com/cosmos/cosmos-sdk/codec"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
@@ -67,9 +68,9 @@ type PenumbraValidatorFundingStream struct {
 }
 
 type PenumbraGenesisAppStateAllocation struct {
-	Amount  int64  `json:"amount"`
-	Denom   string `json:"denom"`
-	Address string `json:"address"`
+	Amount  math.Int `json:"amount"`
+	Denom   string   `json:"denom"`
+	Address string   `json:"address"`
 }
 
 func NewPenumbraChain(log *zap.Logger, testName string, chainConfig ibc.ChainConfig, numValidators int, numFullNodes int) *PenumbraChain {
@@ -236,7 +237,7 @@ func (c *PenumbraChain) Height(ctx context.Context) (uint64, error) {
 }
 
 // Implements Chain interface
-func (c *PenumbraChain) GetBalance(ctx context.Context, address string, denom string) (int64, error) {
+func (c *PenumbraChain) GetBalance(ctx context.Context, address string, denom string) (math.Int, error) {
 	panic("implement me")
 }
 
@@ -434,13 +435,13 @@ func (c *PenumbraChain) Start(testName string, ctx context.Context, additionalGe
 
 			// self delegation
 			allocations[2*i] = PenumbraGenesisAppStateAllocation{
-				Amount:  100_000_000_000,
+				Amount:  math.NewInt(100_000_000_000),
 				Denom:   fmt.Sprintf("udelegation_%s", validatorTemplateDefinition.IdentityKey),
 				Address: validatorTemplateDefinition.FundingStreams[0].Address,
 			}
 			// liquid
 			allocations[2*i+1] = PenumbraGenesisAppStateAllocation{
-				Amount:  1_000_000_000_000,
+				Amount:  math.NewInt(1_000_000_000_000),
 				Denom:   chainCfg.Denom,
 				Address: validatorTemplateDefinition.FundingStreams[0].Address,
 			}

--- a/chain/polkadot/parachain_node.go
+++ b/chain/polkadot/parachain_node.go
@@ -6,9 +6,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"path/filepath"
-	"strconv"
 	"strings"
 
+	"cosmossdk.io/math"
 	"github.com/avast/retry-go/v4"
 	sdktypes "github.com/cosmos/cosmos-sdk/types"
 	"github.com/docker/docker/client"
@@ -152,7 +152,7 @@ func (pn *ParachainNode) GenerateParachainGenesisFile(ctx context.Context, addit
 
 	for _, wallet := range additionalGenesisWallets {
 		balances = append(balances,
-			[]interface{}{wallet.Address, wallet.Amount * parachainScaling},
+			[]interface{}{wallet.Address, wallet.Amount.MulRaw(parachainScaling)},
 		)
 	}
 	if err := dyno.Set(chainSpec, balances, "genesis", "runtime", "balances", "balances"); err != nil {
@@ -305,7 +305,7 @@ func (pn *ParachainNode) Exec(ctx context.Context, cmd []string, env []string) d
 	return job.Run(ctx, cmd, opts)
 }
 
-func (pn *ParachainNode) GetBalance(ctx context.Context, address string, denom string) (int64, error) {
+func (pn *ParachainNode) GetBalance(ctx context.Context, address string, denom string) (math.Int, error) {
 	return GetBalance(pn.api, address)
 }
 
@@ -329,7 +329,7 @@ func (pn *ParachainNode) SendFunds(ctx context.Context, keyName string, amount i
 		"ParachainNode SendFunds",
 		zap.String("From", kp.Address),
 		zap.String("To", amount.Address),
-		zap.String("Amount", strconv.FormatInt(amount.Amount, 10)),
+		zap.String("Amount", amount.Amount.String()),
 	)
 	hash, err := SendFundsTx(pn.api, kp, amount)
 	if err != nil {
@@ -357,7 +357,7 @@ func (pn *ParachainNode) SendIbcFunds(
 		"ParachainNode SendIbcFunds",
 		zap.String("From", kp.Address),
 		zap.String("To", amount.Address),
-		zap.String("Amount", strconv.FormatInt(amount.Amount, 10)),
+		zap.String("Amount", amount.Amount.String()),
 	)
 	hash, err := SendIbcFundsTx(pn.api, kp, channelID, amount, options)
 	if err != nil {
@@ -383,7 +383,7 @@ func (pn *ParachainNode) MintFunds(
 		"ParachainNode MintFunds",
 		zap.String("From", kp.Address),
 		zap.String("To", amount.Address),
-		zap.String("Amount", strconv.FormatInt(amount.Amount, 10)),
+		zap.String("Amount", amount.Amount.String()),
 	)
 	hash, err := MintFundsTx(pn.api, kp, amount)
 	if err != nil {

--- a/chain/polkadot/polkadot_chain.go
+++ b/chain/polkadot/polkadot_chain.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"strings"
 
+	"cosmossdk.io/math"
 	"github.com/99designs/keyring"
 	"github.com/StirlingMarketingGroup/go-namecase"
 	sdktypes "github.com/cosmos/cosmos-sdk/types"
@@ -340,7 +341,7 @@ func (c *PolkadotChain) modifyRelayChainGenesis(ctx context.Context, chainSpec i
 	}
 	for _, wallet := range additionalGenesisWallets {
 		balances = append(balances,
-			[]interface{}{wallet.Address, wallet.Amount * polkadotScaling},
+			[]interface{}{wallet.Address, wallet.Amount.MulRaw(polkadotScaling)},
 		)
 	}
 
@@ -778,7 +779,7 @@ func (c *PolkadotChain) SendIBCTransfer(
 
 // GetBalance fetches the current balance for a specific account address and denom.
 // Implements Chain interface.
-func (c *PolkadotChain) GetBalance(ctx context.Context, address string, denom string) (int64, error) {
+func (c *PolkadotChain) GetBalance(ctx context.Context, address string, denom string) (math.Int, error) {
 	// If denom == polkadot denom, it is a relay chain query, else parachain query
 	if denom == c.cfg.Denom {
 		return c.RelayChainNodes[0].GetBalance(ctx, address, denom)

--- a/chain/polkadot/query.go
+++ b/chain/polkadot/query.go
@@ -1,33 +1,34 @@
 package polkadot
 
 import (
+	"cosmossdk.io/math"
 	gsrpc "github.com/misko9/go-substrate-rpc-client/v4"
 	gstypes "github.com/misko9/go-substrate-rpc-client/v4/types"
 )
 
 // GetBalance fetches the current balance for a specific account address using the SubstrateAPI
-func GetBalance(api *gsrpc.SubstrateAPI, address string) (int64, error) {
+func GetBalance(api *gsrpc.SubstrateAPI, address string) (math.Int, error) {
 	meta, err := api.RPC.State.GetMetadataLatest()
 	if err != nil {
-		return -1, err
+		return math.Int{}, err
 	}
 	pubKey, err := DecodeAddressSS58(address)
 	if err != nil {
-		return -2, err
+		return math.Int{}, err
 	}
 	key, err := gstypes.CreateStorageKey(meta, "System", "Account", pubKey, nil)
 	if err != nil {
-		return -3, err
+		return math.Int{}, err
 	}
 
 	var accountInfo AccountInfo
 	ok, err := api.RPC.State.GetStorageLatest(key, &accountInfo)
 	if err != nil {
-		return -4, err
+		return math.Int{}, err
 	}
 	if !ok {
-		return -5, nil
+		return math.Int{}, nil
 	}
 
-	return accountInfo.Data.Free.Int64(), nil
+	return math.NewIntFromBigInt(accountInfo.Data.Free.Int), nil
 }

--- a/chain/polkadot/relay_chain_node.go
+++ b/chain/polkadot/relay_chain_node.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"cosmossdk.io/math"
 	"github.com/avast/retry-go/v4"
 	"github.com/docker/docker/client"
 	"github.com/docker/go-connections/nat"
@@ -294,6 +295,6 @@ func (p *RelayChainNode) SendFunds(ctx context.Context, keyName string, amount i
 
 // GetBalance fetches the current balance for a specific account address and denom.
 // Implements Chain interface.
-func (p *RelayChainNode) GetBalance(ctx context.Context, address string, denom string) (int64, error) {
+func (p *RelayChainNode) GetBalance(ctx context.Context, address string, denom string) (math.Int, error) {
 	return GetBalance(p.api, address)
 }

--- a/chain/polkadot/tx.go
+++ b/chain/polkadot/tx.go
@@ -29,7 +29,7 @@ func SendFundsTx(api *gsrpc.SubstrateAPI, senderKeypair signature.KeyringPair, a
 		return hash, err
 	}
 
-	call, err := gstypes.NewCall(meta, "Balances.transfer", receiver, gstypes.NewUCompactFromUInt(uint64(amount.Amount)))
+	call, err := gstypes.NewCall(meta, "Balances.transfer", receiver, gstypes.NewUCompact(amount.Amount.BigInt()))
 	if err != nil {
 		return hash, err
 	}
@@ -85,7 +85,7 @@ func SendIbcFundsTx(
 	timestamp := gstypes.NewOptionU64(gstypes.NewU64(0))
 	height := gstypes.NewOptionU64(gstypes.NewU64(3000)) // Must set timestamp or height
 	assetId := gstypes.NewU128(*big.NewInt(assetNum))
-	amount2 := gstypes.NewU128(*big.NewInt(amount.Amount))
+	amount2 := gstypes.NewU128(*amount.Amount.BigInt())
 	memo := gstypes.NewU8(0)
 
 	call, err := gstypes.NewCall(meta, "Ibc.transfer", raw, size, to, channel, timeout, timestamp, height, assetId, amount2, memo)
@@ -124,7 +124,7 @@ func MintFundsTx(
 	}
 
 	assetId := gstypes.NewU128(*big.NewInt(assetNum))
-	amount2 := gstypes.NewUCompactFromUInt(uint64(amount.Amount))
+	amount2 := gstypes.NewUCompact(amount.Amount.BigInt())
 
 	call, err := gstypes.NewCall(meta, "Assets.mint", assetId, receiver, amount2)
 	if err != nil {

--- a/conformance/flush.go
+++ b/conformance/flush.go
@@ -5,8 +5,9 @@ import (
 	"fmt"
 	"testing"
 
+	"cosmossdk.io/math"
 	"github.com/cosmos/cosmos-sdk/types"
-	interchaintest "github.com/strangelove-ventures/interchaintest/v7"
+	"github.com/strangelove-ventures/interchaintest/v7"
 	"github.com/strangelove-ventures/interchaintest/v7/ibc"
 	"github.com/strangelove-ventures/interchaintest/v7/relayer"
 	"github.com/strangelove-ventures/interchaintest/v7/testreporter"
@@ -77,7 +78,7 @@ func TestRelayerFlushing(t *testing.T, ctx context.Context, cf interchaintest.Ch
 	tx, err := c0.SendIBCTransfer(ctx, c0ChannelID, interchaintest.FaucetAccountKeyName, ibc.WalletAmount{
 		Address: c1FaucetAddr,
 		Denom:   c0.Config().Denom,
-		Amount:  txAmount,
+		Amount:  math.NewInt(txAmount),
 	}, ibc.TransferOptions{})
 	req.NoError(err)
 	req.NoError(tx.Validate())

--- a/conformance/test.go
+++ b/conformance/test.go
@@ -407,7 +407,7 @@ func testPacketRelaySuccess(
 		t.Logf("Asserting %s to %s transfer", srcChainCfg.ChainID, dstChainCfg.ChainID)
 		// Assuming these values since the ibc transfers were sent in PreRelayerStart, so balances may have already changed by now
 		srcInitialBalance := math.NewInt(userFaucetFund)
-		dstInitialBalance := math.NewInt(0)
+		dstInitialBalance := math.ZeroInt()
 
 		srcAck, err := testutil.PollForAck(ctx, srcChain, srcTx.Height, srcTx.Height+pollHeightMax, srcTx.Packet)
 		req.NoError(err, "failed to get acknowledgement on source chain")
@@ -438,7 +438,7 @@ func testPacketRelaySuccess(
 		dstUser := testCase.Users[1]
 		dstDenom := dstChainCfg.Denom
 		// Assuming these values since the ibc transfers were sent in PreRelayerStart, so balances may have already changed by now
-		srcInitialBalance := math.NewInt(0)
+		srcInitialBalance := math.ZeroInt()
 		dstInitialBalance := math.NewInt(userFaucetFund)
 
 		dstAck, err := testutil.PollForAck(ctx, dstChain, dstTx.Height, dstTx.Height+pollHeightMax, dstTx.Packet)
@@ -488,7 +488,7 @@ func testPacketRelayFail(
 	for i, srcTx := range testCase.TxCache.Src {
 		// Assuming these values since the ibc transfers were sent in PreRelayerStart, so balances may have already changed by now
 		srcInitialBalance := math.NewInt(userFaucetFund)
-		dstInitialBalance := math.NewInt(0)
+		dstInitialBalance := math.ZeroInt()
 
 		timeout, err := testutil.PollForTimeout(ctx, srcChain, srcTx.Height, srcTx.Height+pollHeightMax, srcTx.Packet)
 		req.NoError(err, "failed to get timeout packet on source chain")
@@ -518,7 +518,7 @@ func testPacketRelayFail(
 	// [BEGIN] assert on destination to source transfer
 	for i, dstTx := range testCase.TxCache.Dst {
 		// Assuming these values since the ibc transfers were sent in PreRelayerStart, so balances may have already changed by now
-		srcInitialBalance := math.NewInt(0)
+		srcInitialBalance := math.ZeroInt()
 		dstInitialBalance := math.NewInt(userFaucetFund)
 
 		timeout, err := testutil.PollForTimeout(ctx, dstChain, dstTx.Height, dstTx.Height+pollHeightMax, dstTx.Packet)

--- a/conformance/test.go
+++ b/conformance/test.go
@@ -35,9 +35,10 @@ import (
 	"testing"
 	"time"
 
+	"cosmossdk.io/math"
 	transfertypes "github.com/cosmos/ibc-go/v7/modules/apps/transfer/types"
 	"github.com/docker/docker/client"
-	interchaintest "github.com/strangelove-ventures/interchaintest/v7"
+	"github.com/strangelove-ventures/interchaintest/v7"
 	"github.com/strangelove-ventures/interchaintest/v7/chain/cosmos"
 	"github.com/strangelove-ventures/interchaintest/v7/ibc"
 	"github.com/strangelove-ventures/interchaintest/v7/internal/dockerutil"
@@ -145,12 +146,12 @@ func sendIBCTransfersFromBothChainsWithTimeout(
 	testCoinSrcToDst := ibc.WalletAmount{
 		Address: srcUser.(*cosmos.CosmosWallet).FormattedAddressWithPrefix(dstChainCfg.Bech32Prefix),
 		Denom:   srcChainCfg.Denom,
-		Amount:  testCoinAmount,
+		Amount:  math.NewInt(testCoinAmount),
 	}
 	testCoinDstToSrc := ibc.WalletAmount{
 		Address: dstUser.(*cosmos.CosmosWallet).FormattedAddressWithPrefix(srcChainCfg.Bech32Prefix),
 		Denom:   dstChainCfg.Denom,
-		Amount:  testCoinAmount,
+		Amount:  math.NewInt(testCoinAmount),
 	}
 
 	var eg errgroup.Group
@@ -405,8 +406,8 @@ func testPacketRelaySuccess(
 	for i, srcTx := range testCase.TxCache.Src {
 		t.Logf("Asserting %s to %s transfer", srcChainCfg.ChainID, dstChainCfg.ChainID)
 		// Assuming these values since the ibc transfers were sent in PreRelayerStart, so balances may have already changed by now
-		srcInitialBalance := userFaucetFund
-		dstInitialBalance := int64(0)
+		srcInitialBalance := math.NewInt(userFaucetFund)
+		dstInitialBalance := math.NewInt(0)
 
 		srcAck, err := testutil.PollForAck(ctx, srcChain, srcTx.Height, srcTx.Height+pollHeightMax, srcTx.Packet)
 		req.NoError(err, "failed to get acknowledgement on source chain")
@@ -425,8 +426,8 @@ func testPacketRelaySuccess(
 		totalFees := srcChain.GetGasFeesInNativeDenom(srcTx.GasSpent)
 		expectedDifference := testCoinAmount + totalFees
 
-		req.Equal(srcInitialBalance-expectedDifference, srcFinalBalance)
-		req.Equal(dstInitialBalance+testCoinAmount, dstFinalBalance)
+		req.True(srcFinalBalance.Equal(srcInitialBalance.SubRaw(expectedDifference)))
+		req.True(dstFinalBalance.Equal(dstInitialBalance.AddRaw(testCoinAmount)))
 	}
 
 	// [END] assert on source to destination transfer
@@ -437,8 +438,8 @@ func testPacketRelaySuccess(
 		dstUser := testCase.Users[1]
 		dstDenom := dstChainCfg.Denom
 		// Assuming these values since the ibc transfers were sent in PreRelayerStart, so balances may have already changed by now
-		srcInitialBalance := int64(0)
-		dstInitialBalance := userFaucetFund
+		srcInitialBalance := math.NewInt(0)
+		dstInitialBalance := math.NewInt(userFaucetFund)
 
 		dstAck, err := testutil.PollForAck(ctx, dstChain, dstTx.Height, dstTx.Height+pollHeightMax, dstTx.Packet)
 		req.NoError(err, "failed to get acknowledgement on destination chain")
@@ -457,8 +458,8 @@ func testPacketRelaySuccess(
 		totalFees := dstChain.GetGasFeesInNativeDenom(dstTx.GasSpent)
 		expectedDifference := testCoinAmount + totalFees
 
-		req.Equal(srcInitialBalance+testCoinAmount, srcFinalBalance)
-		req.Equal(dstInitialBalance-expectedDifference, dstFinalBalance)
+		req.True(srcFinalBalance.Equal(srcInitialBalance.AddRaw(testCoinAmount)))
+		req.True(dstFinalBalance.Equal(dstInitialBalance.SubRaw(expectedDifference)))
 	}
 	//[END] assert on destination to source transfer
 }
@@ -486,8 +487,8 @@ func testPacketRelayFail(
 	// [BEGIN] assert on source to destination transfer
 	for i, srcTx := range testCase.TxCache.Src {
 		// Assuming these values since the ibc transfers were sent in PreRelayerStart, so balances may have already changed by now
-		srcInitialBalance := userFaucetFund
-		dstInitialBalance := int64(0)
+		srcInitialBalance := math.NewInt(userFaucetFund)
+		dstInitialBalance := math.NewInt(0)
 
 		timeout, err := testutil.PollForTimeout(ctx, srcChain, srcTx.Height, srcTx.Height+pollHeightMax, srcTx.Packet)
 		req.NoError(err, "failed to get timeout packet on source chain")
@@ -509,16 +510,16 @@ func testPacketRelayFail(
 
 		totalFees := srcChain.GetGasFeesInNativeDenom(srcTx.GasSpent)
 
-		req.Equal(srcInitialBalance-totalFees, srcFinalBalance)
-		req.Equal(dstInitialBalance, dstFinalBalance)
+		req.True(srcFinalBalance.Equal(srcInitialBalance.SubRaw(totalFees)))
+		req.True(dstFinalBalance.Equal(dstInitialBalance))
 	}
 	// [END] assert on source to destination transfer
 
 	// [BEGIN] assert on destination to source transfer
 	for i, dstTx := range testCase.TxCache.Dst {
 		// Assuming these values since the ibc transfers were sent in PreRelayerStart, so balances may have already changed by now
-		srcInitialBalance := int64(0)
-		dstInitialBalance := userFaucetFund
+		srcInitialBalance := math.NewInt(0)
+		dstInitialBalance := math.NewInt(userFaucetFund)
 
 		timeout, err := testutil.PollForTimeout(ctx, dstChain, dstTx.Height, dstTx.Height+pollHeightMax, dstTx.Packet)
 		req.NoError(err, "failed to get timeout packet on destination chain")
@@ -536,8 +537,8 @@ func testPacketRelayFail(
 
 		totalFees := dstChain.GetGasFeesInNativeDenom(dstTx.GasSpent)
 
-		req.Equal(srcInitialBalance, srcFinalBalance)
-		req.Equal(dstInitialBalance-totalFees, dstFinalBalance)
+		req.True(srcFinalBalance.Equal(srcInitialBalance))
+		req.True(dstFinalBalance.Equal(dstInitialBalance.SubRaw(totalFees)))
 	}
 	// [END] assert on destination to source transfer
 }

--- a/examples/cosmos/light_client_test.go
+++ b/examples/cosmos/light_client_test.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"testing"
 
+	"cosmossdk.io/math"
 	clienttypes "github.com/cosmos/ibc-go/v7/modules/core/02-client/types"
-	interchaintest "github.com/strangelove-ventures/interchaintest/v7"
+	"github.com/strangelove-ventures/interchaintest/v7"
 	"github.com/strangelove-ventures/interchaintest/v7/chain/cosmos"
 	"github.com/strangelove-ventures/interchaintest/v7/ibc"
 	"github.com/strangelove-ventures/interchaintest/v7/testreporter"
@@ -83,7 +84,7 @@ func TestUpdateLightClients(t *testing.T) {
 	transfer := ibc.WalletAmount{
 		Address: dstAddress,
 		Denom:   gaia.Config().Denom,
-		Amount:  amountToSend,
+		Amount:  math.NewInt(amountToSend),
 	}
 	tx, err := gaia.SendIBCTransfer(ctx, chanID, gaiaUser.KeyName(), transfer, ibc.TransferOptions{})
 	require.NoError(t, err)

--- a/examples/ibc/packet_forward_test.go
+++ b/examples/ibc/packet_forward_test.go
@@ -154,7 +154,7 @@ func TestPacketForwardMiddleware(t *testing.T) {
 	secondHopEscrowAccount := transfertypes.GetEscrowAddress(bcChan.PortID, bcChan.ChannelID).String()
 	thirdHopEscrowAccount := transfertypes.GetEscrowAddress(cdChan.PortID, abChan.ChannelID).String()
 
-	zeroBal := math.NewInt(0)
+	zeroBal := math.ZeroInt()
 	transferAmount := math.NewInt(100_000)
 
 	t.Run("multi-hop a->b->c->d", func(t *testing.T) {

--- a/examples/ibc/packet_forward_test.go
+++ b/examples/ibc/packet_forward_test.go
@@ -6,8 +6,9 @@ import (
 	"testing"
 	"time"
 
+	"cosmossdk.io/math"
 	transfertypes "github.com/cosmos/ibc-go/v7/modules/apps/transfer/types"
-	interchaintest "github.com/strangelove-ventures/interchaintest/v7"
+	"github.com/strangelove-ventures/interchaintest/v7"
 	"github.com/strangelove-ventures/interchaintest/v7/chain/cosmos"
 	"github.com/strangelove-ventures/interchaintest/v7/ibc"
 	"github.com/strangelove-ventures/interchaintest/v7/testreporter"
@@ -102,8 +103,8 @@ func TestPacketForwardMiddleware(t *testing.T) {
 		_ = ic.Close()
 	})
 
-	const userFunds = int64(10_000_000_000)
-	users := interchaintest.GetAndFundTestUsers(t, ctx, t.Name(), userFunds, chainA, chainB, chainC, chainD)
+	initBal := math.NewInt(10_000_000_000)
+	users := interchaintest.GetAndFundTestUsers(t, ctx, t.Name(), initBal.Int64(), chainA, chainB, chainC, chainD)
 
 	abChan, err := ibc.GetTransferChannel(ctx, r, eRep, chainID_A, chainID_B)
 	require.NoError(t, err)
@@ -136,8 +137,6 @@ func TestPacketForwardMiddleware(t *testing.T) {
 	// Get original account balances
 	userA, userB, userC, userD := users[0], users[1], users[2], users[3]
 
-	const transferAmount int64 = 100000
-
 	// Compose the prefixed denoms and ibc denom for asserting balances
 	firstHopDenom := transfertypes.GetPrefixedDenom(baChan.PortID, baChan.ChannelID, chainA.Config().Denom)
 	secondHopDenom := transfertypes.GetPrefixedDenom(cbChan.PortID, cbChan.ChannelID, firstHopDenom)
@@ -155,9 +154,11 @@ func TestPacketForwardMiddleware(t *testing.T) {
 	secondHopEscrowAccount := transfertypes.GetEscrowAddress(bcChan.PortID, bcChan.ChannelID).String()
 	thirdHopEscrowAccount := transfertypes.GetEscrowAddress(cdChan.PortID, abChan.ChannelID).String()
 
+	zeroBal := math.NewInt(0)
+	transferAmount := math.NewInt(100_000)
+
 	t.Run("multi-hop a->b->c->d", func(t *testing.T) {
 		// Send packet from Chain A->Chain B->Chain C->Chain D
-
 		transfer := ibc.WalletAmount{
 			Address: userB.FormattedAddress(),
 			Denom:   chainA.Config().Denom,
@@ -209,10 +210,10 @@ func TestPacketForwardMiddleware(t *testing.T) {
 		chainDBalance, err := chainD.GetBalance(ctx, userD.FormattedAddress(), thirdHopIBCDenom)
 		require.NoError(t, err)
 
-		require.Equal(t, userFunds-transferAmount, chainABalance)
-		require.Equal(t, int64(0), chainBBalance)
-		require.Equal(t, int64(0), chainCBalance)
-		require.Equal(t, transferAmount, chainDBalance)
+		require.True(t, chainABalance.Equal(initBal.Sub(transferAmount)))
+		require.True(t, chainBBalance.Equal(zeroBal))
+		require.True(t, chainCBalance.Equal(zeroBal))
+		require.True(t, chainDBalance.Equal(transferAmount))
 
 		firstHopEscrowBalance, err := chainA.GetBalance(ctx, firstHopEscrowAccount, chainA.Config().Denom)
 		require.NoError(t, err)
@@ -223,9 +224,9 @@ func TestPacketForwardMiddleware(t *testing.T) {
 		thirdHopEscrowBalance, err := chainC.GetBalance(ctx, thirdHopEscrowAccount, secondHopIBCDenom)
 		require.NoError(t, err)
 
-		require.Equal(t, transferAmount, firstHopEscrowBalance)
-		require.Equal(t, transferAmount, secondHopEscrowBalance)
-		require.Equal(t, transferAmount, thirdHopEscrowBalance)
+		require.True(t, firstHopEscrowBalance.Equal(transferAmount))
+		require.True(t, secondHopEscrowBalance.Equal(transferAmount))
+		require.True(t, thirdHopEscrowBalance.Equal(transferAmount))
 	})
 
 	t.Run("multi-hop denom unwind d->c->b->a", func(t *testing.T) {
@@ -284,10 +285,10 @@ func TestPacketForwardMiddleware(t *testing.T) {
 		chainABalance, err := chainA.GetBalance(ctx, userA.FormattedAddress(), chainA.Config().Denom)
 		require.NoError(t, err)
 
-		require.Equal(t, int64(0), chainDBalance)
-		require.Equal(t, int64(0), chainCBalance)
-		require.Equal(t, int64(0), chainBBalance)
-		require.Equal(t, userFunds, chainABalance)
+		require.True(t, chainDBalance.Equal(zeroBal))
+		require.True(t, chainCBalance.Equal(zeroBal))
+		require.True(t, chainBBalance.Equal(zeroBal))
+		require.True(t, chainABalance.Equal(initBal))
 
 		// assert balances for IBC escrow accounts
 		firstHopEscrowBalance, err := chainA.GetBalance(ctx, firstHopEscrowAccount, chainA.Config().Denom)
@@ -299,9 +300,9 @@ func TestPacketForwardMiddleware(t *testing.T) {
 		thirdHopEscrowBalance, err := chainC.GetBalance(ctx, thirdHopEscrowAccount, secondHopIBCDenom)
 		require.NoError(t, err)
 
-		require.Equal(t, int64(0), firstHopEscrowBalance)
-		require.Equal(t, int64(0), secondHopEscrowBalance)
-		require.Equal(t, int64(0), thirdHopEscrowBalance)
+		require.True(t, firstHopEscrowBalance.Equal(zeroBal))
+		require.True(t, secondHopEscrowBalance.Equal(zeroBal))
+		require.True(t, thirdHopEscrowBalance.Equal(zeroBal))
 	})
 
 	t.Run("forward ack error refund", func(t *testing.T) {
@@ -344,9 +345,9 @@ func TestPacketForwardMiddleware(t *testing.T) {
 		chainCBalance, err := chainC.GetBalance(ctx, userC.FormattedAddress(), secondHopIBCDenom)
 		require.NoError(t, err)
 
-		require.Equal(t, userFunds, chainABalance)
-		require.Equal(t, int64(0), chainBBalance)
-		require.Equal(t, int64(0), chainCBalance)
+		require.True(t, chainABalance.Equal(initBal))
+		require.True(t, chainBBalance.Equal(zeroBal))
+		require.True(t, chainCBalance.Equal(zeroBal))
 
 		// assert balances for IBC escrow accounts
 		firstHopEscrowBalance, err := chainA.GetBalance(ctx, firstHopEscrowAccount, chainA.Config().Denom)
@@ -355,8 +356,8 @@ func TestPacketForwardMiddleware(t *testing.T) {
 		secondHopEscrowBalance, err := chainB.GetBalance(ctx, secondHopEscrowAccount, firstHopIBCDenom)
 		require.NoError(t, err)
 
-		require.Equal(t, int64(0), firstHopEscrowBalance)
-		require.Equal(t, int64(0), secondHopEscrowBalance)
+		require.True(t, firstHopEscrowBalance.Equal(zeroBal))
+		require.True(t, secondHopEscrowBalance.Equal(zeroBal))
 	})
 
 	t.Run("forward timeout refund", func(t *testing.T) {
@@ -401,9 +402,9 @@ func TestPacketForwardMiddleware(t *testing.T) {
 		chainCBalance, err := chainC.GetBalance(ctx, userC.FormattedAddress(), secondHopIBCDenom)
 		require.NoError(t, err)
 
-		require.Equal(t, userFunds, chainABalance)
-		require.Equal(t, int64(0), chainBBalance)
-		require.Equal(t, int64(0), chainCBalance)
+		require.True(t, chainABalance.Equal(initBal))
+		require.True(t, chainBBalance.Equal(zeroBal))
+		require.True(t, chainCBalance.Equal(zeroBal))
 
 		firstHopEscrowBalance, err := chainA.GetBalance(ctx, firstHopEscrowAccount, chainA.Config().Denom)
 		require.NoError(t, err)
@@ -411,8 +412,8 @@ func TestPacketForwardMiddleware(t *testing.T) {
 		secondHopEscrowBalance, err := chainB.GetBalance(ctx, secondHopEscrowAccount, firstHopIBCDenom)
 		require.NoError(t, err)
 
-		require.Equal(t, int64(0), firstHopEscrowBalance)
-		require.Equal(t, int64(0), secondHopEscrowBalance)
+		require.True(t, firstHopEscrowBalance.Equal(zeroBal))
+		require.True(t, secondHopEscrowBalance.Equal(zeroBal))
 	})
 
 	t.Run("multi-hop ack error refund", func(t *testing.T) {
@@ -473,10 +474,10 @@ func TestPacketForwardMiddleware(t *testing.T) {
 		chainABalance, err := chainA.GetBalance(ctx, userA.FormattedAddress(), chainA.Config().Denom)
 		require.NoError(t, err)
 
-		require.Equal(t, userFunds, chainABalance)
-		require.Equal(t, int64(0), chainBBalance)
-		require.Equal(t, int64(0), chainCBalance)
-		require.Equal(t, int64(0), chainDBalance)
+		require.True(t, chainABalance.Equal(initBal))
+		require.True(t, chainBBalance.Equal(zeroBal))
+		require.True(t, chainCBalance.Equal(zeroBal))
+		require.True(t, chainDBalance.Equal(zeroBal))
 
 		// assert balances for IBC escrow accounts
 		firstHopEscrowBalance, err := chainA.GetBalance(ctx, firstHopEscrowAccount, chainA.Config().Denom)
@@ -488,9 +489,9 @@ func TestPacketForwardMiddleware(t *testing.T) {
 		thirdHopEscrowBalance, err := chainC.GetBalance(ctx, thirdHopEscrowAccount, secondHopIBCDenom)
 		require.NoError(t, err)
 
-		require.Equal(t, int64(0), firstHopEscrowBalance)
-		require.Equal(t, int64(0), secondHopEscrowBalance)
-		require.Equal(t, int64(0), thirdHopEscrowBalance)
+		require.True(t, firstHopEscrowBalance.Equal(zeroBal))
+		require.True(t, secondHopEscrowBalance.Equal(zeroBal))
+		require.True(t, thirdHopEscrowBalance.Equal(zeroBal))
 	})
 
 	t.Run("multi-hop through native chain ack error refund", func(t *testing.T) {
@@ -533,8 +534,8 @@ func TestPacketForwardMiddleware(t *testing.T) {
 		baEscrowBalance, err := chainB.GetBalance(ctx, transfertypes.GetEscrowAddress(baChan.PortID, baChan.ChannelID).String(), chainB.Config().Denom)
 		require.NoError(t, err)
 
-		require.Equal(t, transferAmount, chainABalance)
-		require.Equal(t, transferAmount, baEscrowBalance)
+		require.True(t, chainABalance.Equal(transferAmount))
+		require.True(t, baEscrowBalance.Equal(transferAmount))
 
 		// Send a malformed packet with invalid receiver address from Chain A->Chain B->Chain C->Chain D
 		// This should succeed in the first hop and second hop, then fail to make the third hop.
@@ -593,10 +594,10 @@ func TestPacketForwardMiddleware(t *testing.T) {
 		chainABalance, err = chainA.GetBalance(ctx, userA.FormattedAddress(), baIBCDenom)
 		require.NoError(t, err)
 
-		require.Equal(t, transferAmount, chainABalance)
-		require.Equal(t, userFunds-transferAmount, chainBBalance)
-		require.Equal(t, int64(0), chainCBalance)
-		require.Equal(t, int64(0), chainDBalance)
+		require.True(t, chainABalance.Equal(transferAmount))
+		require.True(t, chainBBalance.Equal(initBal.Sub(transferAmount)))
+		require.True(t, chainCBalance.Equal(zeroBal))
+		require.True(t, chainDBalance.Equal(zeroBal))
 
 		// assert balances for IBC escrow accounts
 		cdEscrowBalance, err := chainC.GetBalance(ctx, transfertypes.GetEscrowAddress(cdChan.PortID, cdChan.ChannelID).String(), bcIBCDenom)
@@ -608,14 +609,13 @@ func TestPacketForwardMiddleware(t *testing.T) {
 		baEscrowBalance, err = chainB.GetBalance(ctx, transfertypes.GetEscrowAddress(baChan.PortID, baChan.ChannelID).String(), chainB.Config().Denom)
 		require.NoError(t, err)
 
-		require.Equal(t, transferAmount, baEscrowBalance)
-		require.Equal(t, int64(0), bcEscrowBalance)
-		require.Equal(t, int64(0), cdEscrowBalance)
+		require.True(t, baEscrowBalance.Equal(transferAmount))
+		require.True(t, bcEscrowBalance.Equal(zeroBal))
+		require.True(t, cdEscrowBalance.Equal(zeroBal))
 	})
 
 	t.Run("forward a->b->a", func(t *testing.T) {
 		// Send packet from Chain A->Chain B->Chain A
-
 		userABalance, err := chainA.GetBalance(ctx, userA.FormattedAddress(), chainA.Config().Denom)
 		require.NoError(t, err, "failed to get user a balance")
 
@@ -655,7 +655,7 @@ func TestPacketForwardMiddleware(t *testing.T) {
 		chainBBalance, err := chainB.GetBalance(ctx, userB.FormattedAddress(), firstHopIBCDenom)
 		require.NoError(t, err)
 
-		require.Equal(t, userABalance, chainABalance)
-		require.Equal(t, userBBalance, chainBBalance)
+		require.True(t, chainABalance.Equal(userABalance))
+		require.True(t, chainBBalance.Equal(userBBalance))
 	})
 }

--- a/examples/ibc/wasm/wasm_ibc_test.go
+++ b/examples/ibc/wasm/wasm_ibc_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"cosmossdk.io/math"
 	"github.com/strangelove-ventures/interchaintest/v7"
 	"github.com/strangelove-ventures/interchaintest/v7/chain/cosmos"
 	"github.com/strangelove-ventures/interchaintest/v7/chain/cosmos/wasm"
@@ -77,8 +78,8 @@ func TestWasmIbc(t *testing.T) {
 	})
 
 	// Create and Fund User Wallets
-	fundAmount := int64(100_000_000)
-	users := interchaintest.GetAndFundTestUsers(t, ctx, "default", int64(fundAmount), juno1, juno2)
+	initBal := math.NewInt(100_000_000)
+	users := interchaintest.GetAndFundTestUsers(t, ctx, "default", initBal.Int64(), juno1, juno2)
 	juno1User := users[0]
 	juno2User := users[1]
 
@@ -87,11 +88,11 @@ func TestWasmIbc(t *testing.T) {
 
 	juno1UserBalInitial, err := juno1.GetBalance(ctx, juno1User.FormattedAddress(), juno1.Config().Denom)
 	require.NoError(t, err)
-	require.Equal(t, fundAmount, juno1UserBalInitial)
+	require.True(t, juno1UserBalInitial.Equal(initBal))
 
 	juno2UserBalInitial, err := juno2.GetBalance(ctx, juno2User.FormattedAddress(), juno2.Config().Denom)
 	require.NoError(t, err)
-	require.Equal(t, fundAmount, juno2UserBalInitial)
+	require.True(t, juno2UserBalInitial.Equal(initBal))
 
 	// Start the relayer
 	err = r.StartRelayer(ctx, eRep, ibcPath)

--- a/examples/ibc/wasm/wasm_icq_test.go
+++ b/examples/ibc/wasm/wasm_icq_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"cosmossdk.io/math"
 	"github.com/strangelove-ventures/interchaintest/v7"
 	cosmosChain "github.com/strangelove-ventures/interchaintest/v7/chain/cosmos"
 	"github.com/strangelove-ventures/interchaintest/v7/chain/cosmos/wasm"
@@ -142,10 +143,10 @@ func TestInterchainQueriesWASM(t *testing.T) {
 	require.NoError(t, err)
 
 	// Fund user accounts so we can query balances
-	chain1UserAmt := int64(10_000_000_000)
-	chain2UserAmt := int64(99_999_999_999)
-	chain1User := interchaintest.GetAndFundTestUsers(t, ctx, t.Name(), chain1UserAmt, chain1)[0]
-	chain2User := interchaintest.GetAndFundTestUsers(t, ctx, t.Name(), chain2UserAmt, chain2)[0]
+	chain1UserAmt := math.NewInt(10_000_000_000)
+	chain2UserAmt := math.NewInt(99_999_999_999)
+	chain1User := interchaintest.GetAndFundTestUsers(t, ctx, t.Name(), chain1UserAmt.Int64(), chain1)[0]
+	chain2User := interchaintest.GetAndFundTestUsers(t, ctx, t.Name(), chain2UserAmt.Int64(), chain2)[0]
 
 	err = testutil.WaitForBlocks(ctx, 5, chain1, chain2)
 	require.NoError(t, err)
@@ -159,11 +160,11 @@ func TestInterchainQueriesWASM(t *testing.T) {
 
 	chain1UserBalInitial, err := chain1.GetBalance(ctx, chain1UserAddress, chain1.Config().Denom)
 	require.NoError(t, err)
-	require.Equal(t, chain1UserAmt, chain1UserBalInitial)
+	require.True(t, chain1UserBalInitial.Equal(chain1UserAmt))
 
 	chain2UserBalInitial, err := chain2.GetBalance(ctx, chain2UserAddress, chain2.Config().Denom)
 	require.NoError(t, err)
-	require.Equal(t, chain2UserAmt, chain2UserBalInitial)
+	require.True(t, chain2UserBalInitial.Equal(chain2UserAmt))
 
 	logger.Info("instantiating contract")
 	initMessage := "{\"default_timeout\": 1000}"

--- a/examples/polkadot/polkadot_chain_test.go
+++ b/examples/polkadot/polkadot_chain_test.go
@@ -5,7 +5,8 @@ import (
 	"fmt"
 	"testing"
 
-	interchaintest "github.com/strangelove-ventures/interchaintest/v7"
+	"cosmossdk.io/math"
+	"github.com/strangelove-ventures/interchaintest/v7"
 	"github.com/strangelove-ventures/interchaintest/v7/chain/polkadot"
 	"github.com/strangelove-ventures/interchaintest/v7/ibc"
 	"github.com/strangelove-ventures/interchaintest/v7/testreporter"
@@ -83,22 +84,24 @@ func TestPolkadotComposableChainStart(t *testing.T) {
 	err = testutil.WaitForBlocks(ctx, 2, chain)
 	require.NoError(t, err, "polkadot chain failed to make blocks")
 
-	PARACHAIN_DEFAULT_AMOUNT := 1_152_921_504_606_847_000
-	RELAYCHAIN_DEFAULT_AMOUNT := 1_100_000_000_000_000_000
-	FAUCET_AMOUNT := 100_000_000_000_000_000 // set in interchain.go/global
+	PARACHAIN_DEFAULT_AMOUNT := math.NewInt(1_152_921_504_606_847_000)
+	RELAYCHAIN_DEFAULT_AMOUNT := math.NewInt(1_100_000_000_000_000_000)
+	FAUCET_AMOUNT := math.NewInt(100_000_000_000_000_000) // set in interchain.go/global
 	//RELAYER_AMOUNT :=                   1_000_000_000_000 // set in interchain.go/global
 
 	// Check the faucet amounts
 	polkadotFaucetAddress, err := polkadotChain.GetAddress(ctx, "faucet")
 	require.NoError(t, err)
+
 	polkadotFaucetAmount, err := polkadotChain.GetBalance(ctx, string(polkadotFaucetAddress), polkadotChain.Config().Denom)
 	require.NoError(t, err)
 	fmt.Println("Polkadot faucet amount: ", polkadotFaucetAmount)
-	require.Equal(t, int64(FAUCET_AMOUNT), polkadotFaucetAmount, "Polkadot faucet amount not expected")
+	require.True(t, polkadotFaucetAmount.Equal(FAUCET_AMOUNT), "Polkadot faucet amount not expected")
+
 	parachainFaucetAmount, err := polkadotChain.GetBalance(ctx, string(polkadotFaucetAddress), "")
 	require.NoError(t, err)
 	fmt.Println("Parachain faucet amount: ", parachainFaucetAmount)
-	require.Equal(t, int64(FAUCET_AMOUNT), parachainFaucetAmount, "Parachain faucet amount not expected")
+	require.True(t, parachainFaucetAmount.Equal(FAUCET_AMOUNT), "Parachain faucet amount not expected")
 
 	// Check alice
 	polkadotAliceAddress, err := polkadotChain.GetAddress(ctx, "alice")
@@ -106,11 +109,12 @@ func TestPolkadotComposableChainStart(t *testing.T) {
 	polkadotAliceAmount, err := polkadotChain.GetBalance(ctx, string(polkadotAliceAddress), polkadotChain.Config().Denom)
 	require.NoError(t, err)
 	fmt.Println("Polkadot alice amount: ", polkadotAliceAmount)
-	require.Equal(t, int64(RELAYCHAIN_DEFAULT_AMOUNT), polkadotAliceAmount, "Relaychain alice amount not expected")
+	require.True(t, polkadotAliceAmount.Equal(RELAYCHAIN_DEFAULT_AMOUNT), "Relaychain alice amount not expected")
+
 	parachainAliceAmount, err := polkadotChain.GetBalance(ctx, string(polkadotAliceAddress), "")
 	require.NoError(t, err)
 	fmt.Println("Parachain alice amount: ", parachainAliceAmount)
-	require.Equal(t, int64(PARACHAIN_DEFAULT_AMOUNT), parachainAliceAmount, "Parachain alice amount not expected")
+	require.True(t, parachainAliceAmount.Equal(PARACHAIN_DEFAULT_AMOUNT), "Parachain alice amount not expected")
 
 	// Check alice stash
 	polkadotAliceStashAddress, err := polkadotChain.GetAddress(ctx, "alicestash")
@@ -118,11 +122,12 @@ func TestPolkadotComposableChainStart(t *testing.T) {
 	polkadotAliceStashAmount, err := polkadotChain.GetBalance(ctx, string(polkadotAliceStashAddress), polkadotChain.Config().Denom)
 	require.NoError(t, err)
 	fmt.Println("Polkadot alice stash amount: ", polkadotAliceStashAmount)
-	require.Equal(t, int64(RELAYCHAIN_DEFAULT_AMOUNT), polkadotAliceStashAmount, "Relaychain alice stash amount not expected")
+	require.True(t, polkadotAliceStashAmount.Equal(RELAYCHAIN_DEFAULT_AMOUNT), "Relaychain alice stash amount not expected")
+
 	parachainAliceStashAmount, err := polkadotChain.GetBalance(ctx, string(polkadotAliceStashAddress), "")
 	require.NoError(t, err)
 	fmt.Println("Parachain alice stash amount: ", parachainAliceStashAmount)
-	require.Equal(t, int64(PARACHAIN_DEFAULT_AMOUNT), parachainAliceStashAmount, "Parachain alice stash amount not expected")
+	require.True(t, parachainAliceStashAmount.Equal(PARACHAIN_DEFAULT_AMOUNT), "Parachain alice stash amount not expected")
 
 	// Check bob
 	polkadotBobAddress, err := polkadotChain.GetAddress(ctx, "bob")
@@ -130,11 +135,12 @@ func TestPolkadotComposableChainStart(t *testing.T) {
 	polkadotBobAmount, err := polkadotChain.GetBalance(ctx, string(polkadotBobAddress), polkadotChain.Config().Denom)
 	require.NoError(t, err)
 	fmt.Println("Polkadot bob amount: ", polkadotBobAmount)
-	require.Equal(t, int64(RELAYCHAIN_DEFAULT_AMOUNT), polkadotBobAmount, "Relaychain bob amount not expected")
+	require.True(t, polkadotBobAmount.Equal(RELAYCHAIN_DEFAULT_AMOUNT), "Relaychain bob amount not expected")
+
 	parachainBobAmount, err := polkadotChain.GetBalance(ctx, string(polkadotBobAddress), "")
 	require.NoError(t, err)
 	fmt.Println("Parachain bob amount: ", parachainBobAmount)
-	require.Equal(t, int64(PARACHAIN_DEFAULT_AMOUNT), parachainBobAmount, "Parachain bob amount not expected")
+	require.True(t, parachainBobAmount.Equal(PARACHAIN_DEFAULT_AMOUNT), "Parachain bob amount not expected")
 
 	// Check bob stash
 	polkadotBobStashAddress, err := polkadotChain.GetAddress(ctx, "bobstash")
@@ -142,30 +148,33 @@ func TestPolkadotComposableChainStart(t *testing.T) {
 	polkadotBobStashAmount, err := polkadotChain.GetBalance(ctx, string(polkadotBobStashAddress), polkadotChain.Config().Denom)
 	require.NoError(t, err)
 	fmt.Println("Polkadot bob stash amount: ", polkadotBobStashAmount)
-	require.Equal(t, int64(RELAYCHAIN_DEFAULT_AMOUNT), polkadotBobStashAmount, "Relaychain bob stash amount not expected")
+	require.True(t, polkadotBobStashAmount.Equal(RELAYCHAIN_DEFAULT_AMOUNT), "Relaychain bob stash amount not expected")
+
 	parachainBobStashAmount, err := polkadotChain.GetBalance(ctx, string(polkadotBobStashAddress), "")
 	require.NoError(t, err)
 	fmt.Println("Parachain bob stash amount: ", parachainBobStashAmount)
-	require.Equal(t, int64(PARACHAIN_DEFAULT_AMOUNT), parachainBobStashAmount, "Parachain bob stash amount not expected")
+	require.True(t, parachainBobStashAmount.Equal(PARACHAIN_DEFAULT_AMOUNT), "Parachain bob stash amount not expected")
 
 	// Fund user1 on both relay and parachain, must wait a block to fund user2 due to same faucet address
-	fundAmount := int64(12_333_000_000_000)
-	users1 := interchaintest.GetAndFundTestUsers(t, ctx, "user1", fundAmount, polkadotChain)
+	fundAmount := math.NewInt(12_333_000_000_000)
+	users1 := interchaintest.GetAndFundTestUsers(t, ctx, "user1", fundAmount.Int64(), polkadotChain)
 	user1 := users1[0]
 	err = testutil.WaitForBlocks(ctx, 2, chain)
 	require.NoError(t, err, "polkadot chain failed to make blocks")
 
 	// Fund user2 on both relay and parachain, check that user1 was funded properly
-	users2 := interchaintest.GetAndFundTestUsers(t, ctx, "user2", fundAmount, polkadotChain)
+	users2 := interchaintest.GetAndFundTestUsers(t, ctx, "user2", fundAmount.Int64(), polkadotChain)
 	user2 := users2[0]
 	polkadotUser1Amount, err := polkadotChain.GetBalance(ctx, user1.FormattedAddress(), polkadotChain.Config().Denom)
 	require.NoError(t, err)
 	fmt.Println("Polkadot user1 amount: ", polkadotUser1Amount)
-	require.Equal(t, fundAmount, polkadotUser1Amount, "Initial polkadot user1 amount not expected")
+	require.True(t, polkadotUser1Amount.Equal(fundAmount), "Initial polkadot user1 amount not expected")
+
 	parachainUser1Amount, err := polkadotChain.GetBalance(ctx, user1.FormattedAddress(), "")
 	require.NoError(t, err)
 	fmt.Println("Parachain user1 amount: ", parachainUser1Amount)
-	require.Equal(t, fundAmount, parachainUser1Amount, "Initial parachain user1 amount not expected")
+	require.True(t, parachainUser1Amount.Equal(fundAmount), "Initial parachain user1 amount not expected")
+
 	err = testutil.WaitForBlocks(ctx, 2, chain)
 	require.NoError(t, err, "polkadot chain failed to make blocks")
 
@@ -173,14 +182,15 @@ func TestPolkadotComposableChainStart(t *testing.T) {
 	polkadotUser2Amount, err := polkadotChain.GetBalance(ctx, user2.FormattedAddress(), polkadotChain.Config().Denom)
 	require.NoError(t, err)
 	fmt.Println("Polkadot user2 amount: ", polkadotUser2Amount)
-	require.Equal(t, fundAmount, polkadotUser2Amount, "Initial polkadot user2 amount not expected")
+	require.True(t, polkadotUser2Amount.Equal(fundAmount), "Initial polkadot user2 amount not expected")
+
 	parachainUser2Amount, err := polkadotChain.GetBalance(ctx, user2.FormattedAddress(), "")
 	require.NoError(t, err)
 	fmt.Println("Parachain user2 amount: ", parachainUser2Amount)
-	require.Equal(t, fundAmount, parachainUser2Amount, "Initial parachain user2 amount not expected")
+	require.True(t, parachainUser2Amount.Equal(fundAmount), "Initial parachain user2 amount not expected")
 
 	// Transfer 1T units from user1 to user2 on both chains
-	txAmount := int64(1_000_000_000_000)
+	txAmount := math.NewInt(1_000_000_000_000)
 	polkadotTxUser1ToUser2 := ibc.WalletAmount{
 		Address: user2.FormattedAddress(),
 		Amount:  txAmount,
@@ -203,18 +213,20 @@ func TestPolkadotComposableChainStart(t *testing.T) {
 	polkadotUser1Amount, err = polkadotChain.GetBalance(ctx, user1.FormattedAddress(), polkadotChain.Config().Denom)
 	require.NoError(t, err)
 	fmt.Println("Polkadot user1 amount: ", polkadotUser1Amount)
-	require.LessOrEqual(t, polkadotUser1Amount, fundAmount-txAmount, "Final polkadot user1 amount not expected")
+	require.True(t, polkadotUser1Amount.LTE(fundAmount.Sub(txAmount)), "Final polkadot user1 amount not expected")
+
 	polkadotUser2Amount, err = polkadotChain.GetBalance(ctx, user2.FormattedAddress(), polkadotChain.Config().Denom)
 	require.NoError(t, err)
 	fmt.Println("Polkadot user2 amount: ", polkadotUser2Amount)
-	require.Equal(t, fundAmount+txAmount, polkadotUser2Amount, "Final polkadot user2 amount not expected")
+	require.True(t, fundAmount.Add(txAmount).Equal(polkadotUser2Amount), "Final polkadot user2 amount not expected")
+
 	parachainUser1Amount, err = polkadotChain.GetBalance(ctx, user1.FormattedAddress(), "")
 	require.NoError(t, err)
 	fmt.Println("Parachain user1 amount: ", parachainUser1Amount)
-	require.LessOrEqual(t, parachainUser1Amount, fundAmount-txAmount, "Final parachain user1 amount not expected")
+	require.True(t, parachainUser1Amount.LTE(fundAmount.Sub(txAmount)), "Final parachain user1 amount not expected")
+
 	parachainUser2Amount, err = polkadotChain.GetBalance(ctx, user2.FormattedAddress(), "")
 	require.NoError(t, err)
 	fmt.Println("Parachain user2 amount: ", parachainUser2Amount)
-	require.Equal(t, fundAmount+txAmount, parachainUser2Amount, "Final parachain user2 amount not expected")
-
+	require.True(t, fundAmount.Add(txAmount).Equal(parachainUser2Amount), "Final parachain user2 amount not expected")
 }

--- a/examples/polkadot/push_wasm_client_code_test.go
+++ b/examples/polkadot/push_wasm_client_code_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"cosmossdk.io/math"
 	"github.com/icza/dyno"
 	"github.com/strangelove-ventures/interchaintest/v7"
 	"github.com/strangelove-ventures/interchaintest/v7/chain/cosmos"
@@ -108,13 +109,13 @@ func TestPushWasmClientCode(t *testing.T) {
 	})
 
 	// Create and Fund User Wallets
-	fundAmount := int64(10_000_000_000)
-	users := interchaintest.GetAndFundTestUsers(t, ctx, "default", int64(fundAmount), simd)
+	fundAmount := math.NewInt(10_000_000_000)
+	users := interchaintest.GetAndFundTestUsers(t, ctx, "default", fundAmount.Int64(), simd)
 	simd1User := users[0]
 
 	simd1UserBalInitial, err := simd.GetBalance(ctx, simd1User.FormattedAddress(), simd.Config().Denom)
 	require.NoError(t, err)
-	require.Equal(t, fundAmount, simd1UserBalInitial)
+	require.True(t, simd1UserBalInitial.Equal(fundAmount))
 
 	simdChain := simd.(*cosmos.CosmosChain)
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/strangelove-ventures/interchaintest/v7
 go 1.19
 
 require (
+	cosmossdk.io/math v1.0.1
 	github.com/99designs/keyring v1.2.2
 	github.com/BurntSushi/toml v1.3.2
 	github.com/ChainSafe/go-schnorrkel/1 v0.0.0-00010101000000-000000000000
@@ -55,7 +56,6 @@ require (
 	cosmossdk.io/depinject v1.0.0-alpha.3 // indirect
 	cosmossdk.io/errors v1.0.0 // indirect
 	cosmossdk.io/log v1.1.1-0.20230704160919-88f2c830b0ca // indirect
-	cosmossdk.io/math v1.0.1 // indirect
 	cosmossdk.io/tools/rosetta v0.2.1 // indirect
 	filippo.io/edwards25519 v1.0.0 // indirect
 	github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4 // indirect

--- a/ibc/chain.go
+++ b/ibc/chain.go
@@ -3,8 +3,8 @@ package ibc
 import (
 	"context"
 
+	"cosmossdk.io/math"
 	"github.com/docker/docker/client"
-	//"github.com/strangelove-ventures/interchaintest/v7/ibc"
 )
 
 type Chain interface {
@@ -64,7 +64,7 @@ type Chain interface {
 	Height(ctx context.Context) (uint64, error)
 
 	// GetBalance fetches the current balance for a specific account address and denom.
-	GetBalance(ctx context.Context, address string, denom string) (int64, error)
+	GetBalance(ctx context.Context, address string, denom string) (math.Int, error)
 
 	// GetGasFeesInNativeDenom gets the fees in native denom for an amount of spent gas.
 	GetGasFeesInNativeDenom(gasPaid int64) int64

--- a/ibc/types.go
+++ b/ibc/types.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 	"strconv"
 
+	"cosmossdk.io/math"
 	"github.com/cosmos/cosmos-sdk/types/module/testutil"
 	ibcexported "github.com/cosmos/ibc-go/v7/modules/core/03-connection/types"
 )
@@ -205,7 +206,7 @@ func (i DockerImage) Ref() string {
 type WalletAmount struct {
 	Address string
 	Denom   string
-	Amount  int64
+	Amount  math.Int
 }
 
 type IBCTimeout struct {

--- a/interchain.go
+++ b/interchain.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"cosmossdk.io/math"
 	"github.com/docker/docker/client"
 	"github.com/strangelove-ventures/interchaintest/v7/ibc"
 	"github.com/strangelove-ventures/interchaintest/v7/testreporter"
@@ -351,7 +352,7 @@ func (ic *Interchain) genesisWalletAmounts(ctx context.Context) (map[ibc.Chain][
 			{
 				Address: faucetAddresses[c],
 				Denom:   c.Config().Denom,
-				Amount:  100_000_000_000_000, // Faucet wallet gets 100T units of denom.
+				Amount:  math.NewInt(100_000_000_000_000), // Faucet wallet gets 100T units of denom.
 			},
 		}
 
@@ -366,7 +367,7 @@ func (ic *Interchain) genesisWalletAmounts(ctx context.Context) (map[ibc.Chain][
 		walletAmounts[c] = append(walletAmounts[c], ibc.WalletAmount{
 			Address: wallet.FormattedAddress(),
 			Denom:   c.Config().Denom,
-			Amount:  1_000_000_000_000, // Every wallet gets 1t units of denom.
+			Amount:  math.NewInt(1_000_000_000_000), // Every wallet gets 1t units of denom.
 		})
 	}
 

--- a/interchain_test.go
+++ b/interchain_test.go
@@ -5,13 +5,14 @@ import (
 	"fmt"
 	"testing"
 
+	"cosmossdk.io/math"
 	"github.com/cosmos/cosmos-sdk/codec"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	cryptocodec "github.com/cosmos/cosmos-sdk/crypto/codec"
 	"github.com/cosmos/cosmos-sdk/crypto/hd"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	interchaintest "github.com/strangelove-ventures/interchaintest/v7"
+	"github.com/strangelove-ventures/interchaintest/v7"
 	"github.com/strangelove-ventures/interchaintest/v7/chain/cosmos"
 	"github.com/strangelove-ventures/interchaintest/v7/ibc"
 	"github.com/strangelove-ventures/interchaintest/v7/relayer/rly"
@@ -200,6 +201,8 @@ func TestInterchain_CreateUser(t *testing.T) {
 		NetworkID: network,
 	}))
 
+	initBal := math.NewInt(10_000)
+
 	t.Run("with mnemonic", func(t *testing.T) {
 		keyName := "mnemonic-user-name"
 
@@ -219,7 +222,7 @@ func TestInterchain_CreateUser(t *testing.T) {
 		require.NoError(t, err)
 		require.NotEmpty(t, mnemonic)
 
-		user, err := interchaintest.GetAndFundTestUserWithMnemonic(ctx, keyName, mnemonic, 10000, gaia0)
+		user, err := interchaintest.GetAndFundTestUserWithMnemonic(ctx, keyName, mnemonic, initBal.Int64(), gaia0)
 		require.NoError(t, err)
 		require.NoError(t, testutil.WaitForBlocks(ctx, 2, gaia0))
 		require.NotEmpty(t, user.Address())
@@ -227,13 +230,12 @@ func TestInterchain_CreateUser(t *testing.T) {
 
 		actualBalance, err := gaia0.GetBalance(ctx, user.FormattedAddress(), gaia0.Config().Denom)
 		require.NoError(t, err)
-		require.Equal(t, int64(10000), actualBalance)
-
+		require.True(t, actualBalance.Equal(initBal))
 	})
 
 	t.Run("without mnemonic", func(t *testing.T) {
 		keyName := "regular-user-name"
-		users := interchaintest.GetAndFundTestUsers(t, ctx, keyName, 10000, gaia0)
+		users := interchaintest.GetAndFundTestUsers(t, ctx, keyName, initBal.Int64(), gaia0)
 		require.NoError(t, testutil.WaitForBlocks(ctx, 2, gaia0))
 		require.Len(t, users, 1)
 		require.NotEmpty(t, users[0].Address())
@@ -241,7 +243,7 @@ func TestInterchain_CreateUser(t *testing.T) {
 
 		actualBalance, err := gaia0.GetBalance(ctx, users[0].FormattedAddress(), gaia0.Config().Denom)
 		require.NoError(t, err)
-		require.Equal(t, int64(10000), actualBalance)
+		require.True(t, actualBalance.Equal(initBal))
 	})
 }
 
@@ -301,7 +303,7 @@ func broadcastTxCosmosChainTest(t *testing.T, relayerImpl ibc.RelayerImplementat
 
 	testUser := interchaintest.GetAndFundTestUsers(t, ctx, "gaia-user-1", 10_000_000, gaia0)[0]
 
-	sendAmount := int64(10000)
+	sendAmount := math.NewInt(10_000)
 
 	t.Run("relayer starts", func(t *testing.T) {
 		require.NoError(t, r.StartRelayer(ctx, eRep, pathName))
@@ -309,7 +311,7 @@ func broadcastTxCosmosChainTest(t *testing.T, relayerImpl ibc.RelayerImplementat
 
 	t.Run("broadcast success", func(t *testing.T) {
 		b := cosmos.NewBroadcaster(t, gaia0.(*cosmos.CosmosChain))
-		transferAmount := sdk.Coin{Denom: gaia0.Config().Denom, Amount: sdk.NewInt(sendAmount)}
+		transferAmount := sdk.Coin{Denom: gaia0.Config().Denom, Amount: sendAmount}
 		memo := ""
 
 		msg := transfertypes.NewMsgTransfer(
@@ -335,7 +337,7 @@ func broadcastTxCosmosChainTest(t *testing.T, relayerImpl ibc.RelayerImplementat
 
 		dstFinalBalance, err := gaia1.GetBalance(ctx, testUser.(*cosmos.CosmosWallet).FormattedAddressWithPrefix(gaia1.Config().Bech32Prefix), dstIbcDenom)
 		require.NoError(t, err, "failed to get balance from dest chain")
-		require.Equal(t, sendAmount, dstFinalBalance)
+		require.True(t, dstFinalBalance.Equal(sendAmount))
 	})
 }
 

--- a/internal/blockdb/messages_view_test.go
+++ b/internal/blockdb/messages_view_test.go
@@ -9,8 +9,9 @@ import (
 	"path/filepath"
 	"testing"
 
+	"cosmossdk.io/math"
 	"github.com/cosmos/cosmos-sdk/types"
-	interchaintest "github.com/strangelove-ventures/interchaintest/v7"
+	"github.com/strangelove-ventures/interchaintest/v7"
 	"github.com/strangelove-ventures/interchaintest/v7/ibc"
 	"github.com/strangelove-ventures/interchaintest/v7/relayer"
 	"github.com/strangelove-ventures/interchaintest/v7/testreporter"
@@ -258,7 +259,7 @@ WHERE type = "/ibc.core.channel.v1.MsgChannelOpenConfirm" AND chain_id = ?
 		transfer := ibc.WalletAmount{
 			Address: gaia1FaucetAddr,
 			Denom:   gaia0.Config().Denom,
-			Amount:  txAmount,
+			Amount:  math.NewInt(txAmount),
 		}
 		tx, err := gaia0.SendIBCTransfer(ctx, gaia0ChannelID, interchaintest.FaucetAccountKeyName, transfer, ibc.TransferOptions{})
 		require.NoError(t, err)

--- a/test_user.go
+++ b/test_user.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"testing"
 
+	"cosmossdk.io/math"
 	"github.com/strangelove-ventures/interchaintest/v7/ibc"
 	"github.com/strangelove-ventures/interchaintest/v7/internal/dockerutil"
 	"github.com/strangelove-ventures/interchaintest/v7/testutil"
@@ -30,7 +31,7 @@ func GetAndFundTestUserWithMnemonic(
 
 	err = chain.SendFunds(ctx, FaucetAccountKeyName, ibc.WalletAmount{
 		Address: user.FormattedAddress(),
-		Amount:  amount,
+		Amount:  math.NewInt(amount),
 		Denom:   chainCfg.Denom,
 	})
 	if err != nil {


### PR DESCRIPTION
Previously we were using `int64` to represent token amounts for things like transfers and balance checks. This becomes problematic when dealing with the EVM or chains like Penumbra where we may need to handle `int128` or `int256`. 

Since Go does not have native support for integer values larger than 64-bits we would need to use the stdlib's [big package](https://pkg.go.dev/math/big#Int). The Cosmos SDK's math package contains its own [Int](https://github.com/cosmos/cosmos-sdk/blob/8aaa776f822392bd506feb16cf454709059265fa/math/int.go#L75-L80) type that is a wrapper around Go's `big.Int` and offers useful helper methods and enforces a 257 bit range by checking overflow, underflow and division by zero. 