### PR TITLE
feat(cosmos): Additional Helpers

### DIFF
--- a/chain/cosmos/chain_node.go
+++ b/chain/cosmos/chain_node.go
@@ -146,6 +146,10 @@ func (tn *ChainNode) Name() string {
 	return fmt.Sprintf("%s-%s-%d-%s", tn.Chain.Config().ChainID, nodeType, tn.Index, dockerutil.SanitizeContainerName(tn.TestName))
 }
 
+func (tn *ChainNode) ContainerID() string {
+	return tn.containerLifecycle.ContainerID()
+}
+
 // hostname of the test node container
 func (tn *ChainNode) HostName() string {
 	return dockerutil.CondenseHostName(tn.Name())
@@ -619,7 +623,7 @@ func (tn *ChainNode) AddGenesisAccount(ctx context.Context, address string, gene
 		command = append(command, "genesis")
 	}
 
-	command = append(command, "add-genesis-account", address, amount)
+	command = append(command, "add-genesis-account", address, amount, "--chain-id", tn.Chain.Config().ChainID)
 	_, _, err := tn.ExecBin(ctx, command...)
 
 	return err

--- a/chain/cosmos/chain_node.go
+++ b/chain/cosmos/chain_node.go
@@ -669,7 +669,12 @@ func (tn *ChainNode) AddGenesisAccount(ctx context.Context, address string, gene
 		command = append(command, "genesis")
 	}
 
-	command = append(command, "add-genesis-account", address, amount, "--chain-id", tn.Chain.Config().ChainID)
+	command = append(command, "add-genesis-account", address, amount)
+
+	if tn.Chain.Config().UsingChainIDFlagCLI {
+		command = append(command, "--chain-id", tn.Chain.Config().ChainID)
+	}
+
 	_, _, err := tn.ExecBin(ctx, command...)
 
 	return err

--- a/chain/cosmos/cosmos_chain.go
+++ b/chain/cosmos/cosmos_chain.go
@@ -723,6 +723,10 @@ func (c *CosmosChain) Start(testName string, ctx context.Context, additionalGene
 		Denom:  chainCfg.Denom,
 	}
 
+	if chainCfg.ModifyGenesisAmounts != nil {
+		genesisAmount, genesisSelfDelegation = chainCfg.ModifyGenesisAmounts()
+	}
+
 	genesisAmounts := []types.Coin{genesisAmount}
 
 	configFileOverrides := chainCfg.ConfigFileOverrides

--- a/chainspec.go
+++ b/chainspec.go
@@ -142,6 +142,10 @@ func (s *ChainSpec) applyConfigOverrides(cfg ibc.ChainConfig) (*ibc.ChainConfig,
 	if s.PreGenesis != nil {
 		cfg.PreGenesis = s.PreGenesis
 	}
+	if s.ModifyGenesisAmounts != nil {
+		cfg.ModifyGenesisAmounts = s.ModifyGenesisAmounts
+	}
+
 	cfg.UsingNewGenesisCommand = s.UsingNewGenesisCommand
 
 	// Set the version depending on the chain type.

--- a/chainspec.go
+++ b/chainspec.go
@@ -147,6 +147,7 @@ func (s *ChainSpec) applyConfigOverrides(cfg ibc.ChainConfig) (*ibc.ChainConfig,
 	}
 
 	cfg.UsingNewGenesisCommand = s.UsingNewGenesisCommand
+	cfg.UsingChainIDFlagCLI = s.UsingChainIDFlagCLI
 
 	// Set the version depending on the chain type.
 	switch cfg.Type {

--- a/ibc/types.go
+++ b/ibc/types.go
@@ -50,6 +50,8 @@ type ChainConfig struct {
 	EncodingConfig *testutil.TestEncodingConfig
 	// Required when the chain uses the new sub commands for genesis (https://github.com/cosmos/cosmos-sdk/pull/14149)
 	UsingNewGenesisCommand bool `yaml:"using-new-genesis-command"`
+	// Required when the chain requires the chain-id field to be populated for certain commands
+	UsingChainIDFlagCLI bool `yaml:"using-chain-id-flag-cli"`
 	// Configuration describing additional sidecar processes.
 	SidecarConfigs []SidecarConfig
 }

--- a/ibc/types.go
+++ b/ibc/types.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/types/module/testutil"
 	ibcexported "github.com/cosmos/ibc-go/v7/modules/core/03-connection/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 // ChainConfig defines the chain parameters requires to run an interchaintest testnet for a chain.
@@ -40,6 +41,8 @@ type ChainConfig struct {
 	PreGenesis func(ChainConfig) error
 	// When provided, genesis file contents will be altered before sharing for genesis.
 	ModifyGenesis func(ChainConfig, []byte) ([]byte, error)
+	// Modify genesis-amounts
+	ModifyGenesisAmounts func() (sdk.Coin, sdk.Coin)
 	// Override config parameters for files at filepath.
 	ConfigFileOverrides map[string]any
 	// Non-nil will override the encoding config, used for cosmos chains only.


### PR DESCRIPTION
## In This PR
 - I add functionality for retrieving the ContainerID of tendermint nodes in a cosmos-chain
      - This is useful for copying data / directories from specific nodes
 - I add functionality for Modifying the genesis delegation size / amounts for cosmos chains
      - This is necessary for chains that support tokens scaled by 1e18 (evm-chains)
