### PR TITLE
add .DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,9 @@ interchaintest.test
 .idea
 /bin
 vendor
+.DS_Store
+chain/.DS_Store
+examples/.DS_Store
+internal/.DS_Store
+relayer/.DS_Store
+


### PR DESCRIPTION
This PR adds the .DS_Store files to .gitignore to make working with interchaintest easier. 
