### PR TITLE
Cleaner ExportState via document for SDK v47+

### DIFF
--- a/chain/cosmos/chain_node.go
+++ b/chain/cosmos/chain_node.go
@@ -1043,11 +1043,17 @@ func (tn *ChainNode) ExportState(ctx context.Context, height int64) (string, err
 	tn.lock.Lock()
 	defer tn.lock.Unlock()
 
-	isNewGenesis := tn.Chain.Config().UsingNewGenesisCommand
+	var (
+		doc     = "state_export.json"
+		docPath = path.Join(tn.HomeDir(), doc)
 
-	command := []string{"export", "--height", fmt.Sprint(height)}
+		isNewGenesis = tn.Chain.Config().UsingNewGenesisCommand
+
+		command = []string{"export", "--height", fmt.Sprint(height), "--home", tn.HomeDir()}
+	)
+
 	if isNewGenesis {
-		command = append(command, "--output-document", "state_export.json")
+		command = append(command, "--output-document", docPath)
 	}
 
 	stdout, stderr, err := tn.ExecBin(ctx, command...)
@@ -1056,7 +1062,7 @@ func (tn *ChainNode) ExportState(ctx context.Context, height int64) (string, err
 	}
 
 	if isNewGenesis {
-		content, err := tn.ReadFile(ctx, "state_export.json")
+		content, err := tn.ReadFile(ctx, doc)
 		if err != nil {
 			return "", err
 		}

--- a/chain/cosmos/chain_node.go
+++ b/chain/cosmos/chain_node.go
@@ -1043,10 +1043,10 @@ func (tn *ChainNode) ExportState(ctx context.Context, height int64) (string, err
 	tn.lock.Lock()
 	defer tn.lock.Unlock()
 
-	isNewChain := tn.Chain.Config().UsingNewGenesisCommand
+	isNewGenesis := tn.Chain.Config().UsingNewGenesisCommand
 
 	command := []string{"export", "--height", fmt.Sprint(height)}
-	if isNewChain {
+	if isNewGenesis {
 		command = append(command, "--output-document", "state_export.json")
 	}
 
@@ -1055,7 +1055,7 @@ func (tn *ChainNode) ExportState(ctx context.Context, height int64) (string, err
 		return "", err
 	}
 
-	if isNewChain {
+	if isNewGenesis {
 		content, err := tn.ReadFile(ctx, "state_export.json")
 		if err != nil {
 			return "", err

--- a/examples/cosmos/chain_export_test.go
+++ b/examples/cosmos/chain_export_test.go
@@ -1,0 +1,118 @@
+package cosmos_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/strangelove-ventures/interchaintest/v8"
+	"github.com/strangelove-ventures/interchaintest/v8/chain/cosmos"
+	"github.com/strangelove-ventures/interchaintest/v8/ibc"
+	"github.com/strangelove-ventures/interchaintest/v8/testutil"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
+)
+
+func TestJunoStateExport(t *testing.T) {
+	// SDK v45
+	CosmosChainStateExportTest(t, "juno", "v15.0.0", false)
+	// SDK v47
+	CosmosChainStateExportTest(t, "juno", "v16.0.0", true)
+}
+
+func CosmosChainStateExportTest(t *testing.T, name, version string, useNewGenesisCmd bool) {
+	if testing.Short() {
+		t.Skip("skipping in short mode")
+	}
+
+	numVals := 1
+	numFullNodes := 0
+
+	cf := interchaintest.NewBuiltinChainFactory(zaptest.NewLogger(t), []*interchaintest.ChainSpec{
+		{
+			Name:      name,
+			ChainName: name,
+			Version:   version,
+			ChainConfig: ibc.ChainConfig{
+				Denom:                  "ujuno",
+				UsingNewGenesisCommand: useNewGenesisCmd,
+			},
+			NumValidators: &numVals,
+			NumFullNodes:  &numFullNodes,
+		},
+	})
+
+	chains, err := cf.Chains(t.Name())
+	require.NoError(t, err)
+
+	chain := chains[0].(*cosmos.CosmosChain)
+
+	ic := interchaintest.NewInterchain().
+		AddChain(chain)
+
+	ctx := context.Background()
+	client, network := interchaintest.DockerSetup(t)
+
+	require.NoError(t, ic.Build(ctx, nil, interchaintest.InterchainBuildOptions{
+		TestName:         t.Name(),
+		Client:           client,
+		NetworkID:        network,
+		SkipPathCreation: true,
+	}))
+	t.Cleanup(func() {
+		_ = ic.Close()
+	})
+
+	HaltChainAndExportGenesis(ctx, t, chain, nil, 3)
+}
+
+func HaltChainAndExportGenesis(ctx context.Context, t *testing.T, chain *cosmos.CosmosChain, relayer ibc.Relayer, haltHeight int64) {
+	timeoutCtx, timeoutCtxCancel := context.WithTimeout(ctx, time.Minute*2)
+	defer timeoutCtxCancel()
+
+	err := testutil.WaitForBlocks(timeoutCtx, int(haltHeight), chain)
+	require.NoError(t, err, "chain did not halt at halt height")
+
+	err = chain.StopAllNodes(ctx)
+	require.NoError(t, err, "error stopping node(s)")
+
+	state, err := chain.ExportState(ctx, int64(haltHeight))
+	require.NoError(t, err, "error exporting state")
+
+	appTomlOverrides := make(testutil.Toml)
+
+	appTomlOverrides["halt-height"] = 0
+
+	for _, node := range chain.Nodes() {
+		err := node.OverwriteGenesisFile(ctx, []byte(state))
+		require.NoError(t, err)
+	}
+
+	for _, node := range chain.Nodes() {
+		err := testutil.ModifyTomlConfigFile(
+			ctx,
+			zap.NewExample(),
+			node.DockerClient,
+			node.TestName,
+			node.VolumeName,
+			"config/app.toml",
+			appTomlOverrides,
+		)
+		require.NoError(t, err)
+	}
+
+	err = chain.StartAllNodes(ctx)
+	require.NoError(t, err, "error starting node(s)")
+
+	timeoutCtx, timeoutCtxCancel = context.WithTimeout(ctx, time.Minute*2)
+	defer timeoutCtxCancel()
+
+	err = testutil.WaitForBlocks(timeoutCtx, int(5), chain)
+	require.NoError(t, err, "chain did not produce blocks after halt")
+
+	height, err := chain.Height(ctx)
+	require.NoError(t, err, "error getting height after halt")
+
+	require.Greater(t, int64(height), haltHeight, "height did not increment after halt")
+}

--- a/examples/cosmos/chain_export_test.go
+++ b/examples/cosmos/chain_export_test.go
@@ -80,9 +80,7 @@ func HaltChainAndExportGenesis(ctx context.Context, t *testing.T, chain *cosmos.
 	state, err := chain.ExportState(ctx, int64(haltHeight))
 	require.NoError(t, err, "error exporting state")
 
-	appTomlOverrides := make(testutil.Toml)
-
-	appTomlOverrides["halt-height"] = 0
+	appToml := make(testutil.Toml)
 
 	for _, node := range chain.Nodes() {
 		err := node.OverwriteGenesisFile(ctx, []byte(state))
@@ -97,7 +95,7 @@ func HaltChainAndExportGenesis(ctx context.Context, t *testing.T, chain *cosmos.
 			node.TestName,
 			node.VolumeName,
 			"config/app.toml",
-			appTomlOverrides,
+			appToml,
 		)
 		require.NoError(t, err)
 	}


### PR DESCRIPTION
Closes #721 

## Summary
If a chain is on SDK v47+, we should output exports to a file directly. Then we return the contents from this file instead of returning a messy stdout + err for parsing.

Tests both 45 and 47 usecases