### PR TITLE
add GetNode() helper

### DIFF
--- a/chain/cosmos/cosmos_chain.go
+++ b/chain/cosmos/cosmos_chain.go
@@ -194,6 +194,10 @@ func (c *CosmosChain) getFullNode() *ChainNode {
 	return c.Validators[0]
 }
 
+func (c *CosmosChain) GetNode() *ChainNode {
+	return c.Validators[0]
+}
+
 // Exec implements ibc.Chain.
 func (c *CosmosChain) Exec(ctx context.Context, cmd []string, env []string) (stdout, stderr []byte, err error) {
 	return c.getFullNode().Exec(ctx, cmd, env)
@@ -390,8 +394,8 @@ func (c *CosmosChain) PushNewWasmClientProposal(ctx context.Context, keyName str
 		return tx, "", err
 	}
 	message := wasmtypes.MsgStoreCode{
-		Signer: types.MustBech32ifyAddressBytes(c.cfg.Bech32Prefix, authtypes.NewModuleAddress(govtypes.ModuleName)),
-		WasmByteCode:   content,
+		Signer:       types.MustBech32ifyAddressBytes(c.cfg.Bech32Prefix, authtypes.NewModuleAddress(govtypes.ModuleName)),
+		WasmByteCode: content,
 	}
 	msg, err := c.cfg.EncodingConfig.Codec.MarshalInterfaceJSON(&message)
 	if err != nil {


### PR DESCRIPTION
Closes #401

## summary
Adds `GetNode()` which just returns validator in index 0.

## reasons
- it is easy to try and grab full_node[0], even if you did not set any (per issue, as well as personally myself) when only a validator is set for speed.

- _'what about getFullNode()? just make that public'_ - if you run any test which add a full node later, it would break previous logic on the val you were operating on (I have had this happen). Thus having a function which ensures to get a valid node, and the same every time is the way to go imo