### PR TITLE
chore: move localhost -> 127.0.0.1

### DIFF
--- a/internal/dockerutil/ports.go
+++ b/internal/dockerutil/ports.go
@@ -20,7 +20,7 @@ func (l Listeners) CloseAll() {
 
 // openListenerOnFreePort opens the next free port
 func openListenerOnFreePort() (*net.TCPListener, error) {
-	addr, err := net.ResolveTCPAddr("tcp", "localhost:0")
+	addr, err := net.ResolveTCPAddr("tcp", "127.0.0.1:0")
 	if err != nil {
 		return nil, err
 	}

--- a/internal/dockerutil/strings.go
+++ b/internal/dockerutil/strings.go
@@ -27,7 +27,7 @@ func GetHostPort(cont types.ContainerJSON, portID string) string {
 
 	ip := m[0].HostIP
 	if ip == "0.0.0.0" {
-		ip = "localhost"
+		ip = "127.0.0.1"
 	}
 	return net.JoinHostPort(ip, m[0].HostPort)
 }

--- a/internal/dockerutil/strings_test.go
+++ b/internal/dockerutil/strings_test.go
@@ -40,7 +40,7 @@ func TestGetHostPort(t *testing.T) {
 						},
 					},
 				},
-			}, "test", "localhost:3000",
+			}, "test", "127.0.0.1:3000",
 		},
 
 		{types.ContainerJSON{}, "", ""},

--- a/local-interchain/README.md
+++ b/local-interchain/README.md
@@ -35,7 +35,7 @@ Follow [this guide](./docs/WINDOWS.md) to setup the Windows OS environment for i
 
 ## REST API
 
-A rest API can be found at `curl localhost:8080/` by default. Other actions can take place here such as file uploads, actions, querying chain config information, and more!
+A rest API can be found at `curl 127.0.0.1:8080/` by default. Other actions can take place here such as file uploads, actions, querying chain config information, and more!
 
 Read more about the API [here](./docs/REST_API.md)
 
@@ -52,8 +52,8 @@ Read more about the API [here](./docs/REST_API.md)
   {
     "chain_id": "exampleid-1",
     "chain_name": "example",
-    "rpc_address": "http://localhost:38829",
-    "grpc_address": "localhost:34917",
+    "rpc_address": "http://127.0.0.1:38829",
+    "grpc_address": "127.0.0.1:34917",
     "ibc_paths": []
   }
 ]

--- a/local-interchain/configs/server.json
+++ b/local-interchain/configs/server.json
@@ -1,6 +1,6 @@
 {
 	"server": {
-		"host": "localhost",
+		"host": "127.0.0.1",
 		"port": "8080"
 	}
 }

--- a/local-interchain/docs/REST_API.md
+++ b/local-interchain/docs/REST_API.md
@@ -27,7 +27,7 @@ Since local-interchain exposes a REST API, you can interact with the chains usin
 
 ## Defaults
 
-By default, the API is served at <http://localhost:8080/>. You can modify this before starting the chain via [the configs/server.json configuration file](../configs/server.json).
+By default, the API is served at <http://127.0.0.1:8080/>. You can modify this before starting the chain via [the configs/server.json configuration file](../configs/server.json).
 
 ## Environment Variables
 
@@ -94,7 +94,7 @@ curl -X POST -H "Content-Type: application/json" -d '{
   "chain_id": "localjuno-1",
   "action": "query",
   "cmd": "bank total"
-}' http://localhost:8080/
+}' http://127.0.0.1:8080/
 # {"supply":[{"denom":"ujuno","amount":"110020857635458"}],"pagination":{"next_key":null,"total":"0"}}
 
 
@@ -104,7 +104,7 @@ curl -X POST -H "Content-Type: application/json" -d '{
   "chain_id": "localjuno-1",
   "action": "binary",
   "cmd": "config keyring-backend test"
-}' http://localhost:8080/
+}' http://127.0.0.1:8080/
 
 
 # Execute a Tx sending funds 
@@ -113,7 +113,7 @@ curl -X POST -H "Content-Type: application/json" -d '{
   "chain_id": "localjuno-1",
   "action": "binary",
   "cmd": "tx bank send acc0 juno10r39fueph9fq7a6lgswu4zdsg8t3gxlq670lt0 500ujuno --fees 5000ujuno --node %RPC% --chain-id=%CHAIN_ID% --yes --output json"
-}' http://localhost:8080/
+}' http://127.0.0.1:8080/
 
 
 # Querying said Tx hash returned from above.
@@ -124,7 +124,7 @@ curl -X POST -H "Content-Type: application/json" -d '{
   "chain_id": "localjuno-1",
   "action": "query",
   "cmd": "tx 7C68B0E0AFF733D93636BAD69D645B11C9C11C5C883394E99658BFCC05BF20DD"
-}' http://localhost:8080/
+}' http://127.0.0.1:8080/
 ```
 
 ### Python
@@ -136,7 +136,7 @@ A full Python client can be found in the [scripts folder](../scripts/). This is 
 
 import httpx  # pip install httpx
 
-api = "http://localhost:8080/"
+api = "http://127.0.0.1:8080/"
 
 # Pushes through any packets pending on channel-0 (both ways)
 print(

--- a/local-interchain/docs/WINDOWS.md
+++ b/local-interchain/docs/WINDOWS.md
@@ -106,7 +106,7 @@ cd interchaintest/local-interchain
 3. Run `make install`
 4. Run `local-ic start base.json`
 
-Wait for it to set up and go to *https://localhost:8080/info*, you should see each local chain running in its own docker container `docker ps`
+Wait for it to set up and go to *https://127.0.0.1:8080/info*, you should see each local chain running in its own docker container `docker ps`
 
 Now you are running a complete local wasm IBC-connected environment on a Windows operating system.
 

--- a/local-interchain/scripts/example_req.bash
+++ b/local-interchain/scripts/example_req.bash
@@ -1,6 +1,6 @@
 
 MAKE_REQUEST() {
-    curl http://localhost:8080/ --include --header "Content-Type: application/json" -X $1 --data "$2"
+    curl http://127.0.0.1:8080/ --include --header "Content-Type: application/json" -X $1 --data "$2"
 }
 
 MAKE_REQUEST POST '{"chain_id":"localjuno-1","action":"q","cmd":"bank total"}'

--- a/local-interchain/scripts/helpers/cosmwasm.py
+++ b/local-interchain/scripts/helpers/cosmwasm.py
@@ -41,7 +41,7 @@ def upload_file(rb: RequestBuilder, key_name: str, abs_path: str) -> dict:
 
 class CosmWasm:
     def __init__(self, api: str, chain_id: str, addr_override: str = ""):
-        self.api = api  # http://localhost:8080
+        self.api = api  # http://127.0.0.1:8080
         self.chain_id = chain_id
 
         self.code_id: int = -1
@@ -254,7 +254,7 @@ class CosmWasm:
 if __name__ == "__main__":
     CosmWasm.download_base_contracts()
 
-    cw = CosmWasm(api="http://localhost:8080", chain_id="localjuno-1")
+    cw = CosmWasm(api="http://127.0.0.1:8080", chain_id="localjuno-1")
 
     cw.store_contract("acc0", os.path.join(contracts_storage_dir, "cw721_base.wasm"))
 


### PR DESCRIPTION
closes #402

## summary
This PR moves any tcp references to localhost, and instead uses the direct IP, 127.0.0.1, in its place.

reasons:
- the /etc/hosts lookup itself is more sys calls when it is not required for an ipv4 enviroment
- localhost can reference multiple IP families (ipv6 & ipv4) on lookup. - This could cause unintended issues (overhead: query ipv6, fail, then try ipv4. Machines not routing and only doing v6)
