### PR TITLE
fix: ensure that relayer startup flags are consumed properly

### DIFF
--- a/relayer/rly/cosmos_relayer.go
+++ b/relayer/rly/cosmos_relayer.go
@@ -25,7 +25,7 @@ type CosmosRelayer struct {
 }
 
 func NewCosmosRelayer(log *zap.Logger, testName string, cli *client.Client, networkID string, options ...relayer.RelayerOpt) *CosmosRelayer {
-	c := commander{log: log}
+	c := &commander{log: log}
 
 	dr, err := relayer.NewDockerRelayer(context.TODO(), log, testName, cli, networkID, c, options...)
 	if err != nil {


### PR DESCRIPTION
Previously the relayer startup flags were not being used in any of the commands because we were passing the `commander` by value to the `DockerRelayer` constructor and then attempting to mutate the local copy of `commander`