### PR TITLE
feat: adding query to fetch x/gov module address

### DIFF
--- a/chain/cosmos/chain_node.go
+++ b/chain/cosmos/chain_node.go
@@ -1019,6 +1019,30 @@ func (tn *ChainNode) QueryClientContractCode(ctx context.Context, codeHash strin
 	return err
 }
 
+// GetModuleAddress performs a query to get the address of the specified chain module
+func (tn *ChainNode) GetModuleAddress(ctx context.Context, moduleName string) (string, error) {
+	queryRes, err := tn.GetModuleAccount(ctx, moduleName)
+	if err != nil {
+		return "", err
+	}
+	return queryRes.Account.BaseAccount.Address, nil
+}
+
+// GetModuleAccount performs a query to get the account details of the specified chain module
+func (tn *ChainNode) GetModuleAccount(ctx context.Context, moduleName string) (QueryModuleAccountResponse, error) {
+	stdout, _, err := tn.ExecQuery(ctx, "auth", "module-account", moduleName)
+	if err != nil {
+		return QueryModuleAccountResponse{}, err
+	}
+
+	queryRes := QueryModuleAccountResponse{}
+	err = json.Unmarshal(stdout, &queryRes)
+	if err != nil {
+		return QueryModuleAccountResponse{}, err
+	}
+	return queryRes, nil
+}
+
 // VoteOnProposal submits a vote for the specified proposal.
 func (tn *ChainNode) VoteOnProposal(ctx context.Context, keyName string, proposalID string, vote string) error {
 	_, err := tn.ExecTx(ctx, keyName,

--- a/chain/cosmos/cosmos_chain.go
+++ b/chain/cosmos/cosmos_chain.go
@@ -375,6 +375,16 @@ func (c *CosmosChain) SendIBCTransfer(
 	return tx, nil
 }
 
+// GetGovernanceAddress performs a query to get the address of the chain's x/gov module
+func (c *CosmosChain) GetGovernanceAddress(ctx context.Context) (string, error) {
+	return c.GetModuleAddress(ctx, govtypes.ModuleName)
+}
+
+// GetModuleAddress performs a query to get the address of the specified chain module
+func (c *CosmosChain) GetModuleAddress(ctx context.Context, moduleName string) (string, error) {
+	return c.getFullNode().GetModuleAddress(ctx, moduleName)
+}
+
 // QueryProposal returns the state and details of a governance proposal.
 func (c *CosmosChain) QueryProposal(ctx context.Context, proposalID string) (*ProposalResponse, error) {
 	return c.getFullNode().QueryProposal(ctx, proposalID)

--- a/chain/cosmos/types.go
+++ b/chain/cosmos/types.go
@@ -153,3 +153,15 @@ type DenomAuthorityMetadata struct {
 	// Can be empty for no admin, or a valid address
 	Admin string `protobuf:"bytes,1,opt,name=admin,proto3" json:"admin,omitempty" yaml:"admin"`
 }
+
+type QueryModuleAccountResponse struct {
+	Account struct {
+		BaseAccount struct {
+			AccountNumber string `json:"account_number"`
+			Address       string `json:"address"`
+			PubKey        string `json:"pub_key"`
+			Sequence      string `json:"sequence"`
+		} `json:"base_account"`
+		Name string `json:"name"`
+	} `json:"account"`
+}

--- a/examples/cosmos/chain_miscellaneous_test.go
+++ b/examples/cosmos/chain_miscellaneous_test.go
@@ -88,6 +88,7 @@ func CosmosChainTestMiscellaneous(t *testing.T, name, version string) {
 	testHasCommand(ctx, t, chain)
 	testTokenFactory(ctx, t, chain, users)
 	testAddingNode(ctx, t, chain)
+	testGetGovernanceAddress(ctx, t, chain)
 }
 
 func testBuildDependencies(ctx context.Context, t *testing.T, chain *cosmos.CosmosChain) {
@@ -374,6 +375,13 @@ func testTokenFactory(ctx context.Context, t *testing.T, chain *cosmos.CosmosCha
 	require.NoError(t, err)
 	validateBalance(ctx, t, chain, user, tfDenom, 0)
 
+}
+
+func testGetGovernanceAddress(ctx context.Context, t *testing.T, chain *cosmos.CosmosChain) {
+	govAddr, err := chain.GetGovernanceAddress(ctx)
+	require.NoError(t, err)
+	_, err = sdk.AccAddressFromBech32(govAddr)
+	require.NoError(t, err)
 }
 
 // helpers


### PR DESCRIPTION
- Added helper functions to query a module account information.
- With x/gov v1 types, the governance module address is likely to be used quite often. `chain.GetGovernanceAddress()` would be nice to have 