### PR TITLE
Support larger tx sizes from cosmos Broadcaster

### DIFF
--- a/chain/cosmos/broadcaster.go
+++ b/chain/cosmos/broadcaster.go
@@ -14,7 +14,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/tx/signing"
-	authTx "github.com/cosmos/cosmos-sdk/x/auth/tx"
+	authtx "github.com/cosmos/cosmos-sdk/x/auth/tx"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	"github.com/strangelove-ventures/interchaintest/v8/internal/dockerutil"
 	"github.com/strangelove-ventures/interchaintest/v8/testutil"
@@ -224,16 +224,22 @@ func BroadcastTx(ctx context.Context, broadcaster *Broadcaster, broadcastingUser
 		return sdk.TxResponse{}, err
 	}
 
-	resp, err := authTx.QueryTx(cc, respWithTxHash.TxHash)
-	if err != nil {
-		// if we fail to query the tx, it means an error occurred with the original message broadcast.
-		// we should return this instead.
-		originalResp, err := broadcaster.UnmarshalTxResponseBytes(ctx, txBytes)
-		if err != nil {
-			return sdk.TxResponse{}, err
-		}
-		return originalResp, nil
-	}
+	return getFullyPopulatedResponse(cc, respWithTxHash.TxHash)
+}
 
-	return *resp, nil
+// getFullyPopulatedResponse returns a fully populated sdk.TxResponse.
+// the QueryTx function is periodically called until a tx with the given hash
+// has been included in a block.
+func getFullyPopulatedResponse(cc client.Context, txHash string) (sdk.TxResponse, error) {
+	var resp sdk.TxResponse
+	err := testutil.WaitForCondition(time.Second*60, time.Second*5, func() (bool, error) {
+		fullyPopulatedTxResp, err := authtx.QueryTx(cc, txHash)
+		if err != nil {
+			return false, nil
+		}
+
+		resp = *fullyPopulatedTxResp
+		return true, nil
+	})
+	return resp, err
 }


### PR DESCRIPTION
When working on the 08-wasm tests, the `MsgStoreCode` message was quite large, and was not included in a block by the time the `authtx` function was being called. 

This PR adds polling to periodically attempt to fetch the tx. It will fail if the tx is still not found after the interval.