### PR TITLE
Fixes and wires up `CreateClient`

### DIFF
--- a/examples/ibc/client_creation_test.go
+++ b/examples/ibc/client_creation_test.go
@@ -1,0 +1,146 @@
+package ibc_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/strangelove-ventures/interchaintest/v8"
+	"github.com/strangelove-ventures/interchaintest/v8/chain/cosmos"
+	"github.com/strangelove-ventures/interchaintest/v8/ibc"
+	"github.com/strangelove-ventures/interchaintest/v8/relayer"
+	"github.com/strangelove-ventures/interchaintest/v8/relayer/rly"
+	"github.com/strangelove-ventures/interchaintest/v8/testreporter"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+)
+
+var (
+	numVals      = 1
+	numFullNodes = 0
+)
+
+type relayerImp struct {
+	name           string
+	relayer        ibc.RelayerImplementation
+	relayerVersion string
+}
+
+func TestCreatClient(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping in short mode")
+	}
+
+	t.Parallel()
+
+	var tests = []relayerImp{
+		{
+			name:           "Cosmos Relayer",
+			relayer:        ibc.CosmosRly,
+			relayerVersion: "v2.5.0",
+		},
+		//TODO: Get hermes working and uncomment:
+
+		// {
+		// 	name:           "Hermes",
+		// 	relayer:        ibc.Hermes,
+		// 	relayerVersion: "v1.7.1",
+		// },
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		testname := tt.name
+		t.Run(testname, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+
+			chainSpec := []*interchaintest.ChainSpec{
+				{
+					Name:      "ibc-go-simd",
+					ChainName: "chain1",
+					Version:   "v8.0.0",
+
+					NumValidators: &numVals,
+					NumFullNodes:  &numFullNodes,
+				},
+				{
+					Name:      "ibc-go-simd",
+					ChainName: "chain2",
+					Version:   "v8.0.0",
+
+					NumValidators: &numVals,
+					NumFullNodes:  &numFullNodes,
+				},
+			}
+
+			chains := interchaintest.CreateChainsWithChainSpecs(t, chainSpec)
+
+			client, network := interchaintest.DockerSetup(t)
+
+			chain, counterpartyChain := chains[0].(*cosmos.CosmosChain), chains[1].(*cosmos.CosmosChain)
+
+			rf := interchaintest.NewBuiltinRelayerFactory(
+				tt.relayer,
+				zaptest.NewLogger(t),
+				relayer.CustomDockerImage(
+					rly.DefaultContainerImage,
+					tt.relayerVersion,
+					rly.RlyDefaultUidGid,
+				),
+			)
+
+			r := rf.Build(t, client, network)
+
+			pathName := "ibc-path"
+
+			ic := interchaintest.NewInterchain().
+				AddChain(chain).
+				AddChain(counterpartyChain).
+				AddRelayer(r, "relayer").
+				AddLink(interchaintest.InterchainLink{
+					Chain1:  chain,
+					Chain2:  counterpartyChain,
+					Relayer: r,
+					Path:    pathName,
+				})
+
+			rep := testreporter.NewNopReporter()
+
+			require.NoError(t, ic.Build(ctx, rep.RelayerExecReporter(t), interchaintest.InterchainBuildOptions{
+				TestName:         t.Name(),
+				Client:           client,
+				NetworkID:        network,
+				SkipPathCreation: true,
+			}))
+			t.Cleanup(func() {
+				_ = ic.Close()
+			})
+
+			eRep := rep.RelayerExecReporter(t)
+
+			result := r.Exec(ctx, eRep, []string{"rly", "config", "show", "--home", "/home/relayer"}, []string{})
+
+			fmt.Println("RESULT: ", string(result.Stdout))
+
+			//TODO: need a way to get chain name from relayer config!!
+			require.NoError(t,
+				r.CreateClient(ctx, eRep,
+					chain.Config().Name,             // Does not work
+					counterpartyChain.Config().Name, // Does not work
+					pathName, ibc.CreateClientOptions{},
+				),
+			)
+
+			clientInfo, err := r.GetClients(ctx, eRep, chain.Config().ChainID)
+			require.NoError(t, err)
+
+			// TODO: ensure client exists
+			fmt.Println(clientInfo)
+
+		})
+
+	}
+
+}

--- a/examples/ibc/client_creation_test.go
+++ b/examples/ibc/client_creation_test.go
@@ -7,8 +7,6 @@ import (
 	"github.com/strangelove-ventures/interchaintest/v8"
 	"github.com/strangelove-ventures/interchaintest/v8/chain/cosmos"
 	"github.com/strangelove-ventures/interchaintest/v8/ibc"
-	"github.com/strangelove-ventures/interchaintest/v8/relayer"
-	"github.com/strangelove-ventures/interchaintest/v8/relayer/rly"
 	"github.com/strangelove-ventures/interchaintest/v8/testreporter"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
@@ -20,9 +18,8 @@ var (
 )
 
 type relayerImp struct {
-	name           string
-	relayer        ibc.RelayerImplementation
-	relayerVersion string
+	name       string
+	relayerImp ibc.RelayerImplementation
 }
 
 func TestCreatClient(t *testing.T) {
@@ -34,17 +31,13 @@ func TestCreatClient(t *testing.T) {
 
 	var tests = []relayerImp{
 		{
-			name:           "Cosmos Relayer",
-			relayer:        ibc.CosmosRly,
-			relayerVersion: "v2.5.0",
+			name:       "Cosmos Relayer",
+			relayerImp: ibc.CosmosRly,
 		},
-		//TODO: Get hermes working and uncomment:
-
-		// {
-		// 	name:           "Hermes",
-		// 	relayer:        ibc.Hermes,
-		// 	relayerVersion: "v1.7.1",
-		// },
+		{
+			name:       "Hermes",
+			relayerImp: ibc.Hermes,
+		},
 	}
 
 	for _, tt := range tests {
@@ -81,13 +74,8 @@ func TestCreatClient(t *testing.T) {
 			chain, counterpartyChain := chains[0].(*cosmos.CosmosChain), chains[1].(*cosmos.CosmosChain)
 
 			rf := interchaintest.NewBuiltinRelayerFactory(
-				tt.relayer,
+				tt.relayerImp,
 				zaptest.NewLogger(t),
-				relayer.CustomDockerImage(
-					rly.DefaultContainerImage,
-					tt.relayerVersion,
-					rly.RlyDefaultUidGid,
-				),
 			)
 
 			r := rf.Build(t, client, network)

--- a/ibc/relayer.go
+++ b/ibc/relayer.go
@@ -80,7 +80,7 @@ type Relayer interface {
 	// CreateClient performs the client handshake steps necessary for creating a light client
 	// on src that tracks the state of dst.
 	// Unlike CreateClients, this only creates the client on the destination chain
-	CreateClient(ctx context.Context, rep RelayerExecReporter, srcChainName, dstChainName, pathName string, opts CreateClientOptions) error
+	CreateClient(ctx context.Context, rep RelayerExecReporter, srcChainID, dstChainID, pathName string, opts CreateClientOptions) error
 
 	// CreateConnections performs the connection handshake steps necessary for creating a connection
 	// between the src and dst chains.

--- a/ibc/relayer.go
+++ b/ibc/relayer.go
@@ -77,6 +77,11 @@ type Relayer interface {
 	// on src that tracks the state of dst, and a light client on dst that tracks the state of src.
 	CreateClients(ctx context.Context, rep RelayerExecReporter, pathName string, opts CreateClientOptions) error
 
+	// CreateClient performs the client handshake steps necessary for creating a light client
+	// on src that tracks the state of dst.
+	// Unlike CreateClients, this only creates the client on the destination chain
+	CreateClient(ctx context.Context, rep RelayerExecReporter, srcChainName, dstChainName, pathName string, opts CreateClientOptions) error
+
 	// CreateConnections performs the connection handshake steps necessary for creating a connection
 	// between the src and dst chains.
 	CreateConnections(ctx context.Context, rep RelayerExecReporter, pathName string) error

--- a/relayer/docker.go
+++ b/relayer/docker.go
@@ -228,8 +228,8 @@ func (r *DockerRelayer) CreateClients(ctx context.Context, rep ibc.RelayerExecRe
 	return res.Err
 }
 
-func (r *DockerRelayer) CreateClient(ctx context.Context, rep ibc.RelayerExecReporter, srcChainName, dstChainName, pathName string, opts ibc.CreateClientOptions) error {
-	cmd := r.c.CreateClient(srcChainName, dstChainName, pathName, opts, r.HomeDir())
+func (r *DockerRelayer) CreateClient(ctx context.Context, rep ibc.RelayerExecReporter, srcChainID, dstChainID, pathName string, opts ibc.CreateClientOptions) error {
+	cmd := r.c.CreateClient(srcChainID, dstChainID, pathName, opts, r.HomeDir())
 	res := r.Exec(ctx, rep, cmd, nil)
 	return res.Err
 }
@@ -560,7 +560,7 @@ type RelayerCommander interface {
 	AddKey(chainID, keyName, coinType, signingAlgorithm, homeDir string) []string
 	CreateChannel(pathName string, opts ibc.CreateChannelOptions, homeDir string) []string
 	CreateClients(pathName string, opts ibc.CreateClientOptions, homeDir string) []string
-	CreateClient(srcChainName, dstChainName, pathName string, opts ibc.CreateClientOptions, homeDir string) []string
+	CreateClient(srcChainID, dstChainID, pathName string, opts ibc.CreateClientOptions, homeDir string) []string
 	CreateConnections(pathName, homeDir string) []string
 	Flush(pathName, channelID, homeDir string) []string
 	GeneratePath(srcChainID, dstChainID, pathName, homeDir string) []string

--- a/relayer/docker.go
+++ b/relayer/docker.go
@@ -228,6 +228,12 @@ func (r *DockerRelayer) CreateClients(ctx context.Context, rep ibc.RelayerExecRe
 	return res.Err
 }
 
+func (r *DockerRelayer) CreateClient(ctx context.Context, rep ibc.RelayerExecReporter, srcChainName, dstChainName, pathName string, opts ibc.CreateClientOptions) error {
+	cmd := r.c.CreateClient(srcChainName, dstChainName, pathName, opts, r.HomeDir())
+	res := r.Exec(ctx, rep, cmd, nil)
+	return res.Err
+}
+
 func (r *DockerRelayer) CreateConnections(ctx context.Context, rep ibc.RelayerExecReporter, pathName string) error {
 	cmd := r.c.CreateConnections(pathName, r.HomeDir())
 	res := r.Exec(ctx, rep, cmd, nil)
@@ -554,6 +560,7 @@ type RelayerCommander interface {
 	AddKey(chainID, keyName, coinType, signingAlgorithm, homeDir string) []string
 	CreateChannel(pathName string, opts ibc.CreateChannelOptions, homeDir string) []string
 	CreateClients(pathName string, opts ibc.CreateClientOptions, homeDir string) []string
+	CreateClient(srcChainName, dstChainName, pathName string, opts ibc.CreateClientOptions, homeDir string) []string
 	CreateConnections(pathName, homeDir string) []string
 	Flush(pathName, channelID, homeDir string) []string
 	GeneratePath(srcChainID, dstChainID, pathName, homeDir string) []string

--- a/relayer/hermes/hermes_commander.go
+++ b/relayer/hermes/hermes_commander.go
@@ -185,6 +185,10 @@ func (c commander) CreateClients(pathName string, opts ibc.CreateClientOptions, 
 	panic("create clients implemented in hermes relayer not the commander")
 }
 
+func (c commander) CreateClient(srcChain, dstChainName, pathName string, opts ibc.CreateClientOptions, homeDir string) []string {
+	panic("create client implemented in hermes relayer not the commander")
+}
+
 func (c commander) CreateConnections(pathName string, homeDir string) []string {
 	panic("create connections implemented in hermes relayer not the commander")
 }

--- a/relayer/hermes/hermes_commander.go
+++ b/relayer/hermes/hermes_commander.go
@@ -185,7 +185,7 @@ func (c commander) CreateClients(pathName string, opts ibc.CreateClientOptions, 
 	panic("create clients implemented in hermes relayer not the commander")
 }
 
-func (c commander) CreateClient(srcChain, dstChainName, pathName string, opts ibc.CreateClientOptions, homeDir string) []string {
+func (c commander) CreateClient(srcChainID, dstChainID, pathName string, opts ibc.CreateClientOptions, homeDir string) []string {
 	panic("create client implemented in hermes relayer not the commander")
 }
 

--- a/relayer/hermes/hermes_relayer.go
+++ b/relayer/hermes/hermes_relayer.go
@@ -205,7 +205,7 @@ func (r *Relayer) CreateClients(ctx context.Context, rep ibc.RelayerExecReporter
 }
 
 // TODO: Implement this
-func (r *Relayer) CreateClient(ctx context.Context, rep ibc.RelayerExecReporter, srcChainName, dstChainName, pathName string, opts ibc.CreateClientOptions) error {
+func (r *Relayer) CreateClient(ctx context.Context, rep ibc.RelayerExecReporter, srcChainID, dstChainID, pathName string, opts ibc.CreateClientOptions) error {
 	panic("implement me")
 }
 

--- a/relayer/hermes/hermes_relayer.go
+++ b/relayer/hermes/hermes_relayer.go
@@ -204,6 +204,11 @@ func (r *Relayer) CreateClients(ctx context.Context, rep ibc.RelayerExecReporter
 	return res.Err
 }
 
+// TODO: Implement this
+func (r *Relayer) CreateClient(ctx context.Context, rep ibc.RelayerExecReporter, srcChainName, dstChainName, pathName string, opts ibc.CreateClientOptions) error {
+	panic("implement me")
+}
+
 // RestoreKey restores a key from a mnemonic. In hermes, you must provide a file containing the mnemonic. We need
 // to copy the contents of the mnemonic into a file on disk and then reference the newly created file.
 func (r *Relayer) RestoreKey(ctx context.Context, rep ibc.RelayerExecReporter, cfg ibc.ChainConfig, keyName, mnemonic string) error {

--- a/relayer/hermes/hermes_relayer.go
+++ b/relayer/hermes/hermes_relayer.go
@@ -204,9 +204,35 @@ func (r *Relayer) CreateClients(ctx context.Context, rep ibc.RelayerExecReporter
 	return res.Err
 }
 
-// TODO: Implement this
 func (r *Relayer) CreateClient(ctx context.Context, rep ibc.RelayerExecReporter, srcChainID, dstChainID, pathName string, opts ibc.CreateClientOptions) error {
-	panic("implement me")
+	pathConfig := r.paths[pathName]
+
+	createClientCmd := []string{hermes, "--json", "create", "client", "--host-chain", srcChainID, "--reference-chain", dstChainID}
+	if opts.TrustingPeriod != "" {
+		createClientCmd = append(createClientCmd, "--trusting-period", opts.TrustingPeriod)
+	}
+	if opts.MaxClockDrift != "" {
+		createClientCmd = append(createClientCmd, "--clock-drift", opts.MaxClockDrift)
+	}
+	res := r.Exec(ctx, rep, createClientCmd, nil)
+	if res.Err != nil {
+		return res.Err
+	}
+
+	clientId, err := GetClientIdFromStdout(res.Stdout)
+	if err != nil {
+		return err
+	}
+
+	if pathConfig.chainA.chainID == srcChainID {
+		pathConfig.chainA.chainID = clientId
+	} else if pathConfig.chainB.chainID == srcChainID {
+		pathConfig.chainB.chainID = clientId
+	} else {
+		return fmt.Errorf("%s not found in path config", srcChainID)
+	}
+
+	return res.Err
 }
 
 // RestoreKey restores a key from a mnemonic. In hermes, you must provide a file containing the mnemonic. We need

--- a/relayer/hyperspace/hyperspace_commander.go
+++ b/relayer/hyperspace/hyperspace_commander.go
@@ -102,7 +102,7 @@ func (c *hyperspaceCommander) CreateClients(pathName string, opts ibc.CreateClie
 }
 
 // TODO: Implement if available in hyperspace relayer
-func (hyperspaceCommander) CreateClient(srcChainName, dstChainName, pathName string, opts ibc.CreateClientOptions, homeDir string) []string {
+func (hyperspaceCommander) CreateClient(srcChainID, dstChainID, pathName string, opts ibc.CreateClientOptions, homeDir string) []string {
 	panic("[CreateClient] Not Implemented")
 }
 

--- a/relayer/hyperspace/hyperspace_commander.go
+++ b/relayer/hyperspace/hyperspace_commander.go
@@ -101,6 +101,11 @@ func (c *hyperspaceCommander) CreateClients(pathName string, opts ibc.CreateClie
 	}
 }
 
+// TODO: Implement if available in hyperspace relayer
+func (hyperspaceCommander) CreateClient(srcChainName, dstChainName, pathName string, opts ibc.CreateClientOptions, homeDir string) []string {
+	panic("[CreateClient] Not Implemented")
+}
+
 func (c *hyperspaceCommander) CreateConnections(pathName, homeDir string) []string {
 	fmt.Println("[hyperspace] CreateConnections", pathName, homeDir)
 	_, ok := c.paths[pathName]

--- a/relayer/rly/cosmos_relayer.go
+++ b/relayer/rly/cosmos_relayer.go
@@ -165,8 +165,8 @@ func (commander) CreateClients(pathName string, opts ibc.CreateClientOptions, ho
 	return cmd
 }
 
-func (commander) CreateClient(srcChainName, dstChainName, pathName string, opts ibc.CreateClientOptions, homeDir string) []string {
-	cmd := []string{"rly", "tx", "client", srcChainName, dstChainName, pathName, "--home", homeDir}
+func (commander) CreateClient(srcChainID, dstChainID, pathName string, opts ibc.CreateClientOptions, homeDir string) []string {
+	cmd := []string{"rly", "tx", "client", srcChainID, dstChainID, pathName, "--home", homeDir}
 
 	clientOptions := createClientOptsHelper(opts)
 	cmd = append(cmd, clientOptions...)

--- a/relayer/rly/cosmos_relayer.go
+++ b/relayer/rly/cosmos_relayer.go
@@ -63,7 +63,7 @@ type CosmosRelayerChainConfig struct {
 
 const (
 	DefaultContainerImage   = "ghcr.io/cosmos/relayer"
-	DefaultContainerVersion = "v2.4.1"
+	DefaultContainerVersion = "v2.5.0"
 )
 
 // Capabilities returns the set of capabilities of the Cosmos relayer.
@@ -165,9 +165,8 @@ func (commander) CreateClients(pathName string, opts ibc.CreateClientOptions, ho
 	return cmd
 }
 
-// passing a value of 0 for customeClientTrustingPeriod will use default
-func (commander) CreateClient(pathName, homeDir string, opts ibc.CreateClientOptions) []string {
-	cmd := []string{"rly", "tx", "client", pathName, "--home", homeDir}
+func (commander) CreateClient(srcChainName, dstChainName, pathName string, opts ibc.CreateClientOptions, homeDir string) []string {
+	cmd := []string{"rly", "tx", "client", srcChainName, dstChainName, pathName, "--home", homeDir}
 
 	clientOptions := createClientOptsHelper(opts)
 	cmd = append(cmd, clientOptions...)


### PR DESCRIPTION
Prior to this PR, `createClient` was not wired up.