### PR TITLE
refactor!: changing block height type from uint64 to int64

### DIFF
--- a/chain/cosmos/chain_node.go
+++ b/chain/cosmos/chain_node.go
@@ -368,17 +368,17 @@ func (tn *ChainNode) SetPeers(ctx context.Context, peers string) error {
 	)
 }
 
-func (tn *ChainNode) Height(ctx context.Context) (uint64, error) {
+func (tn *ChainNode) Height(ctx context.Context) (int64, error) {
 	res, err := tn.Client.Status(ctx)
 	if err != nil {
 		return 0, fmt.Errorf("tendermint rpc client status: %w", err)
 	}
 	height := res.SyncInfo.LatestBlockHeight
-	return uint64(height), nil
+	return height, nil
 }
 
 // FindTxs implements blockdb.BlockSaver.
-func (tn *ChainNode) FindTxs(ctx context.Context, height uint64) ([]blockdb.Tx, error) {
+func (tn *ChainNode) FindTxs(ctx context.Context, height int64) ([]blockdb.Tx, error) {
 	h := int64(height)
 	var eg errgroup.Group
 	var blockRes *coretypes.ResultBlockResults
@@ -402,12 +402,12 @@ func (tn *ChainNode) FindTxs(ctx context.Context, height uint64) ([]blockdb.Tx, 
 
 		sdkTx, err := decodeTX(interfaceRegistry, tx)
 		if err != nil {
-			tn.logger().Info("Failed to decode tx", zap.Uint64("height", height), zap.Error(err))
+			tn.logger().Info("Failed to decode tx", zap.Int64("height", height), zap.Error(err))
 			continue
 		}
 		b, err := encodeTxToJSON(interfaceRegistry, sdkTx)
 		if err != nil {
-			tn.logger().Info("Failed to marshal tx to json", zap.Uint64("height", height), zap.Error(err))
+			tn.logger().Info("Failed to marshal tx to json", zap.Int64("height", height), zap.Error(err))
 			continue
 		}
 		newTx.Data = b

--- a/chain/cosmos/cosmos_chain.go
+++ b/chain/cosmos/cosmos_chain.go
@@ -336,7 +336,7 @@ func (c *CosmosChain) SendIBCTransfer(
 	if txResp.Code != 0 {
 		return tx, fmt.Errorf("error in transaction (code: %d): %s", txResp.Code, txResp.RawLog)
 	}
-	tx.Height = uint64(txResp.Height)
+	tx.Height = int64(txResp.Height)
 	tx.TxHash = txHash
 	// In cosmos, user is charged for entire gas requested, not the actual gas used.
 	tx.GasSpent = txResp.GasWanted
@@ -458,7 +458,7 @@ func (c *CosmosChain) txProposal(txHash string) (tx TxProposal, _ error) {
 	if err != nil {
 		return tx, fmt.Errorf("failed to get transaction %s: %w", txHash, err)
 	}
-	tx.Height = uint64(txResp.Height)
+	tx.Height = int64(txResp.Height)
 	tx.TxHash = txHash
 	// In cosmos, user is charged for entire gas requested, not the actual gas used.
 	tx.GasSpent = txResp.GasWanted
@@ -986,12 +986,12 @@ func (c *CosmosChain) Start(testName string, ctx context.Context, additionalGene
 }
 
 // Height implements ibc.Chain
-func (c *CosmosChain) Height(ctx context.Context) (uint64, error) {
+func (c *CosmosChain) Height(ctx context.Context) (int64, error) {
 	return c.getFullNode().Height(ctx)
 }
 
 // Acknowledgements implements ibc.Chain, returning all acknowledgments in block at height
-func (c *CosmosChain) Acknowledgements(ctx context.Context, height uint64) ([]ibc.PacketAcknowledgement, error) {
+func (c *CosmosChain) Acknowledgements(ctx context.Context, height int64) ([]ibc.PacketAcknowledgement, error) {
 	var acks []*chanTypes.MsgAcknowledgement
 	err := RangeBlockMessages(ctx, c.cfg.EncodingConfig.InterfaceRegistry, c.getFullNode().Client, height, func(msg types.Msg) bool {
 		found, ok := msg.(*chanTypes.MsgAcknowledgement)
@@ -1024,7 +1024,7 @@ func (c *CosmosChain) Acknowledgements(ctx context.Context, height uint64) ([]ib
 }
 
 // Timeouts implements ibc.Chain, returning all timeouts in block at height
-func (c *CosmosChain) Timeouts(ctx context.Context, height uint64) ([]ibc.PacketTimeout, error) {
+func (c *CosmosChain) Timeouts(ctx context.Context, height int64) ([]ibc.PacketTimeout, error) {
 	var timeouts []*chanTypes.MsgTimeout
 	err := RangeBlockMessages(ctx, c.cfg.EncodingConfig.InterfaceRegistry, c.getFullNode().Client, height, func(msg types.Msg) bool {
 		found, ok := msg.(*chanTypes.MsgTimeout)
@@ -1056,7 +1056,7 @@ func (c *CosmosChain) Timeouts(ctx context.Context, height uint64) ([]ibc.Packet
 }
 
 // FindTxs implements blockdb.BlockSaver.
-func (c *CosmosChain) FindTxs(ctx context.Context, height uint64) ([]blockdb.Tx, error) {
+func (c *CosmosChain) FindTxs(ctx context.Context, height int64) ([]blockdb.Tx, error) {
 	fn := c.getFullNode()
 	c.findTxMu.Lock()
 	defer c.findTxMu.Unlock()

--- a/chain/cosmos/cosmos_chain.go
+++ b/chain/cosmos/cosmos_chain.go
@@ -336,7 +336,7 @@ func (c *CosmosChain) SendIBCTransfer(
 	if txResp.Code != 0 {
 		return tx, fmt.Errorf("error in transaction (code: %d): %s", txResp.Code, txResp.RawLog)
 	}
-	tx.Height = int64(txResp.Height)
+	tx.Height = txResp.Height
 	tx.TxHash = txHash
 	// In cosmos, user is charged for entire gas requested, not the actual gas used.
 	tx.GasSpent = txResp.GasWanted
@@ -458,7 +458,7 @@ func (c *CosmosChain) txProposal(txHash string) (tx TxProposal, _ error) {
 	if err != nil {
 		return tx, fmt.Errorf("failed to get transaction %s: %w", txHash, err)
 	}
-	tx.Height = int64(txResp.Height)
+	tx.Height = txResp.Height
 	tx.TxHash = txHash
 	// In cosmos, user is charged for entire gas requested, not the actual gas used.
 	tx.GasSpent = txResp.GasWanted

--- a/chain/cosmos/module_gov.go
+++ b/chain/cosmos/module_gov.go
@@ -55,7 +55,7 @@ func (tn *ChainNode) UpgradeProposal(ctx context.Context, keyName string, prop S
 	command := []string{
 		"gov", "submit-proposal",
 		"software-upgrade", prop.Name,
-		"--upgrade-height", strconv.FormatUint(prop.Height, 10),
+		"--upgrade-height", strconv.FormatInt(prop.Height, 10),
 		"--title", prop.Title,
 		"--description", prop.Description,
 		"--deposit", prop.Deposit,

--- a/chain/cosmos/poll.go
+++ b/chain/cosmos/poll.go
@@ -14,9 +14,9 @@ import (
 )
 
 // PollForProposalStatus attempts to find a proposal with matching ID and status using gov v1.
-func PollForProposalStatusV1(ctx context.Context, chain *CosmosChain, startHeight, maxHeight uint64, proposalID uint64, status govv1.ProposalStatus) (*govv1.Proposal, error) {
+func PollForProposalStatusV1(ctx context.Context, chain *CosmosChain, startHeight, maxHeight int64, proposalID uint64, status govv1.ProposalStatus) (*govv1.Proposal, error) {
 	var pr *govv1.Proposal
-	doPoll := func(ctx context.Context, height uint64) (*govv1.Proposal, error) {
+	doPoll := func(ctx context.Context, height int64) (*govv1.Proposal, error) {
 		p, err := chain.GovQueryProposalV1(ctx, proposalID)
 		if err != nil {
 			return pr, err
@@ -33,9 +33,9 @@ func PollForProposalStatusV1(ctx context.Context, chain *CosmosChain, startHeigh
 }
 
 // PollForProposalStatus attempts to find a proposal with matching ID and status.
-func PollForProposalStatus(ctx context.Context, chain *CosmosChain, startHeight, maxHeight uint64, proposalID uint64, status govv1beta1.ProposalStatus) (*govv1beta1.Proposal, error) {
+func PollForProposalStatus(ctx context.Context, chain *CosmosChain, startHeight, maxHeight int64, proposalID uint64, status govv1beta1.ProposalStatus) (*govv1beta1.Proposal, error) {
 	var zero *govv1beta1.Proposal
-	doPoll := func(ctx context.Context, height uint64) (*govv1beta1.Proposal, error) {
+	doPoll := func(ctx context.Context, height int64) (*govv1beta1.Proposal, error) {
 		p, err := chain.GovQueryProposal(ctx, proposalID)
 		if err != nil {
 			return zero, err
@@ -51,12 +51,12 @@ func PollForProposalStatus(ctx context.Context, chain *CosmosChain, startHeight,
 
 // PollForMessage searches every transaction for a message. Must pass a coded registry capable of decoding the cosmos transaction.
 // fn is optional. Return true from the fn to stop polling and return the found message. If fn is nil, returns the first message to match type T.
-func PollForMessage[T any](ctx context.Context, chain *CosmosChain, registry codectypes.InterfaceRegistry, startHeight, maxHeight uint64, fn func(found T) bool) (T, error) {
+func PollForMessage[T any](ctx context.Context, chain *CosmosChain, registry codectypes.InterfaceRegistry, startHeight, maxHeight int64, fn func(found T) bool) (T, error) {
 	var zero T
 	if fn == nil {
 		fn = func(T) bool { return true }
 	}
-	doPoll := func(ctx context.Context, height uint64) (T, error) {
+	doPoll := func(ctx context.Context, height int64) (T, error) {
 		h := int64(height)
 		block, err := chain.getFullNode().Client.Block(ctx, &h)
 		if err != nil {
@@ -83,12 +83,12 @@ func PollForMessage[T any](ctx context.Context, chain *CosmosChain, registry cod
 }
 
 // PollForBalance polls until the balance matches
-func PollForBalance(ctx context.Context, chain *CosmosChain, deltaBlocks uint64, balance ibc.WalletAmount) error {
+func PollForBalance(ctx context.Context, chain *CosmosChain, deltaBlocks int64, balance ibc.WalletAmount) error {
 	h, err := chain.Height(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get height: %w", err)
 	}
-	doPoll := func(ctx context.Context, height uint64) (any, error) {
+	doPoll := func(ctx context.Context, height int64) (any, error) {
 		bal, err := chain.GetBalance(ctx, balance.Address, balance.Denom)
 		if err != nil {
 			return nil, err

--- a/chain/cosmos/query.go
+++ b/chain/cosmos/query.go
@@ -15,7 +15,7 @@ type blockClient interface {
 
 // RangeBlockMessages iterates through all a block's transactions and each transaction's messages yielding to f.
 // Return true from f to stop iteration.
-func RangeBlockMessages(ctx context.Context, interfaceRegistry codectypes.InterfaceRegistry, client blockClient, height uint64, done func(sdk.Msg) bool) error {
+func RangeBlockMessages(ctx context.Context, interfaceRegistry codectypes.InterfaceRegistry, client blockClient, height int64, done func(sdk.Msg) bool) error {
 	h := int64(height)
 	block, err := client.Block(ctx, &h)
 	if err != nil {

--- a/chain/cosmos/types.go
+++ b/chain/cosmos/types.go
@@ -36,7 +36,7 @@ type ProtoMessage interface {
 // TxProposal contains chain proposal transaction details.
 type TxProposal struct {
 	// The block height.
-	Height uint64
+	Height int64
 	// The transaction hash.
 	TxHash string
 	// Amount of gas charged to the account.
@@ -64,7 +64,7 @@ type SoftwareUpgradeProposal struct {
 	Title       string
 	Name        string
 	Description string
-	Height      uint64
+	Height      int64
 	Info        string // optional
 }
 

--- a/chain/ethereum/ethererum_chain.go
+++ b/chain/ethereum/ethererum_chain.go
@@ -345,13 +345,13 @@ func (c *EthereumChain) SendFunds(ctx context.Context, keyName string, amount ib
 	return err
 }
 
-func (c *EthereumChain) Height(ctx context.Context) (uint64, error) {
+func (c *EthereumChain) Height(ctx context.Context) (int64, error) {
 	cmd := []string{"cast", "block-number", "--rpc-url", c.GetRPCAddress()}
 	stdout, _, err := c.Exec(ctx, cmd, nil)
 	if err != nil {
 		return 0, err
 	}
-	return strconv.ParseUint(strings.TrimSpace(string(stdout)), 10, 64)
+	return strconv.ParseInt(strings.TrimSpace(string(stdout)), 10, 64)
 }
 
 func (c *EthereumChain) GetBalance(ctx context.Context, address string, denom string) (sdkmath.Int, error) {

--- a/chain/ethereum/unimplemented.go
+++ b/chain/ethereum/unimplemented.go
@@ -55,12 +55,12 @@ func (c *EthereumChain) SendIBCTransfer(ctx context.Context, channelID, keyName 
 	return ibc.Tx{}, nil
 }
 
-func (c *EthereumChain) Acknowledgements(ctx context.Context, height uint64) ([]ibc.PacketAcknowledgement, error) {
+func (c *EthereumChain) Acknowledgements(ctx context.Context, height int64) ([]ibc.PacketAcknowledgement, error) {
 	PanicFunctionName()
 	return nil, nil
 }
 
-func (c *EthereumChain) Timeouts(ctx context.Context, height uint64) ([]ibc.PacketTimeout, error) {
+func (c *EthereumChain) Timeouts(ctx context.Context, height int64) ([]ibc.PacketTimeout, error) {
 	PanicFunctionName()
 	return nil, nil
 }

--- a/chain/internal/tendermint/tendermint_node.go
+++ b/chain/internal/tendermint/tendermint_node.go
@@ -237,12 +237,12 @@ func (tn *TendermintNode) GetConfigSeparator() (string, error) {
 	return sep, nil
 }
 
-func (tn *TendermintNode) Height(ctx context.Context) (uint64, error) {
+func (tn *TendermintNode) Height(ctx context.Context) (int64, error) {
 	stat, err := tn.Client.Status(ctx)
 	if err != nil {
 		return 0, fmt.Errorf("tendermint client status: %w", err)
 	}
-	return uint64(stat.SyncInfo.LatestBlockHeight), nil
+	return stat.SyncInfo.LatestBlockHeight, nil
 }
 
 // InitHomeFolder initializes a home folder for the given node

--- a/chain/penumbra/penumbra_chain.go
+++ b/chain/penumbra/penumbra_chain.go
@@ -83,11 +83,11 @@ func NewPenumbraChain(log *zap.Logger, testName string, chainConfig ibc.ChainCon
 	}
 }
 
-func (c *PenumbraChain) Acknowledgements(ctx context.Context, height uint64) ([]ibc.PacketAcknowledgement, error) {
+func (c *PenumbraChain) Acknowledgements(ctx context.Context, height int64) ([]ibc.PacketAcknowledgement, error) {
 	panic("implement me")
 }
 
-func (c *PenumbraChain) Timeouts(ctx context.Context, height uint64) ([]ibc.PacketTimeout, error) {
+func (c *PenumbraChain) Timeouts(ctx context.Context, height int64) ([]ibc.PacketTimeout, error) {
 	panic("implement me")
 }
 
@@ -252,7 +252,7 @@ func (c *PenumbraChain) ExportState(ctx context.Context, height int64) (string, 
 }
 
 // Height returns the current chain block height.
-func (c *PenumbraChain) Height(ctx context.Context) (uint64, error) {
+func (c *PenumbraChain) Height(ctx context.Context) (int64, error) {
 	return c.getFullNode().TendermintNode.Height(ctx)
 }
 

--- a/chain/polkadot/polkadot_chain.go
+++ b/chain/polkadot/polkadot_chain.go
@@ -589,19 +589,19 @@ func (c *PolkadotChain) GetHostGRPCAddress() string {
 
 // Height returns the current block height or an error if unable to get current height.
 // Implements Chain interface.
-func (c *PolkadotChain) Height(ctx context.Context) (uint64, error) {
+func (c *PolkadotChain) Height(ctx context.Context) (int64, error) {
 	if len(c.ParachainNodes) > 0 && len(c.ParachainNodes[0]) > 0 {
 		block, err := c.ParachainNodes[0][0].api.RPC.Chain.GetBlockLatest()
 		if err != nil {
 			return 0, err
 		}
-		return uint64(block.Block.Header.Number), nil
+		return int64(block.Block.Header.Number), nil
 	}
 	block, err := c.RelayChainNodes[0].api.RPC.Chain.GetBlockLatest()
 	if err != nil {
 		return 0, err
 	}
-	return uint64(block.Block.Header.Number), nil
+	return int64(block.Block.Header.Number), nil
 }
 
 // ExportState exports the chain state at specific height.
@@ -815,13 +815,13 @@ func (c *PolkadotChain) GetGasFeesInNativeDenom(gasPaid int64) int64 {
 
 // Acknowledgements returns all acknowledgements in a block at height.
 // Implements Chain interface.
-func (c *PolkadotChain) Acknowledgements(ctx context.Context, height uint64) ([]ibc.PacketAcknowledgement, error) {
+func (c *PolkadotChain) Acknowledgements(ctx context.Context, height int64) ([]ibc.PacketAcknowledgement, error) {
 	panic("[Acknowledgements] not implemented yet")
 }
 
 // Timeouts returns all timeouts in a block at height.
 // Implements Chain interface.
-func (c *PolkadotChain) Timeouts(ctx context.Context, height uint64) ([]ibc.PacketTimeout, error) {
+func (c *PolkadotChain) Timeouts(ctx context.Context, height int64) ([]ibc.PacketTimeout, error) {
 	panic("[Timeouts] not implemented yet")
 }
 
@@ -842,7 +842,7 @@ func (c *PolkadotChain) GetKeyringPair(keyName string) (signature.KeyringPair, e
 }
 
 // FindTxs implements blockdb.BlockSaver (Not implemented yet for polkadot, but we don't want to exit)
-func (c *PolkadotChain) FindTxs(ctx context.Context, height uint64) ([]blockdb.Tx, error) {
+func (c *PolkadotChain) FindTxs(ctx context.Context, height int64) ([]blockdb.Tx, error) {
 	return []blockdb.Tx{}, nil
 }
 

--- a/chainset.go
+++ b/chainset.go
@@ -158,7 +158,7 @@ func (cs chainSet) TrackBlocks(ctx context.Context, testName, dbPath, gitSha str
 		id := c.Config().ChainID
 		finder, ok := c.(blockdb.TxFinder)
 		if !ok {
-			fmt.Fprintf(os.Stderr, `Chain %s is not configured to save blocks; must implement "FindTxs(ctx context.Context, height uint64) ([][]byte, error)"`+"\n", id)
+			fmt.Fprintf(os.Stderr, `Chain %s is not configured to save blocks; must implement "FindTxs(ctx context.Context, height int64) ([][]byte, error)"`+"\n", id)
 			return nil
 		}
 		j := i // Avoid closure on loop variable.

--- a/conformance/test.go
+++ b/conformance/test.go
@@ -52,7 +52,7 @@ import (
 var (
 	userFaucetFund = math.NewInt(10_000_000_000)
 	testCoinAmount = math.NewInt(1_000_000)
-	pollHeightMax  = uint64(50)
+	pollHeightMax  = int64(50)
 )
 
 type TxCache struct {

--- a/examples/cosmos/chain_miscellaneous_test.go
+++ b/examples/cosmos/chain_miscellaneous_test.go
@@ -230,7 +230,7 @@ func testPollForBalance(ctx context.Context, t *testing.T, chain *cosmos.CosmosC
 		Amount:  math.NewInt(1),
 	}
 
-	delta := uint64(3)
+	delta := int64(3)
 
 	ch := make(chan error)
 	go func() {

--- a/examples/cosmos/chain_upgrade_ibc_test.go
+++ b/examples/cosmos/chain_upgrade_ibc_test.go
@@ -20,8 +20,8 @@ import (
 )
 
 const (
-	haltHeightDelta    = int64(10) // will propose upgrade this many blocks in the future
-	blocksAfterUpgrade = uint64(10)
+	haltHeightDelta    = 10 // will propose upgrade this many blocks in the future
+	blocksAfterUpgrade = 10
 	votingPeriod       = "10s"
 	maxDepositPeriod   = "10s"
 )

--- a/examples/cosmos/chain_upgrade_ibc_test.go
+++ b/examples/cosmos/chain_upgrade_ibc_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	haltHeightDelta    = uint64(10) // will propose upgrade this many blocks in the future
+	haltHeightDelta    = int64(10) // will propose upgrade this many blocks in the future
 	blocksAfterUpgrade = uint64(10)
 	votingPeriod       = "10s"
 	maxDepositPeriod   = "10s"

--- a/examples/hyperspace/hyperspace_test.go
+++ b/examples/hyperspace/hyperspace_test.go
@@ -54,7 +54,7 @@ import (
 //     heighliner build -c ibc-go-simd -g local --local
 
 const (
-	heightDelta      = int64(20)
+	heightDelta      = 20
 	votingPeriod     = "30s"
 	maxDepositPeriod = "10s"
 	aliceAddress     = "5yNZjX24n2eg7W6EVamaTXNQbWCwchhThEaSWB7V3GRjtHeL"

--- a/examples/hyperspace/hyperspace_test.go
+++ b/examples/hyperspace/hyperspace_test.go
@@ -54,7 +54,7 @@ import (
 //     heighliner build -c ibc-go-simd -g local --local
 
 const (
-	heightDelta      = uint64(20)
+	heightDelta      = int64(20)
 	votingPeriod     = "30s"
 	maxDepositPeriod = "10s"
 	aliceAddress     = "5yNZjX24n2eg7W6EVamaTXNQbWCwchhThEaSWB7V3GRjtHeL"

--- a/examples/polkadot/push_wasm_client_code_test.go
+++ b/examples/polkadot/push_wasm_client_code_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	heightDelta      = uint64(20)
+	heightDelta      = int64(20)
 	votingPeriod     = "30s"
 	maxDepositPeriod = "10s"
 )

--- a/examples/polkadot/push_wasm_client_code_test.go
+++ b/examples/polkadot/push_wasm_client_code_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	heightDelta      = int64(20)
+	heightDelta      = 20
 	votingPeriod     = "30s"
 	maxDepositPeriod = "10s"
 )

--- a/ibc/chain.go
+++ b/ibc/chain.go
@@ -65,7 +65,7 @@ type Chain interface {
 	SendIBCTransfer(ctx context.Context, channelID, keyName string, amount WalletAmount, options TransferOptions) (Tx, error)
 
 	// Height returns the current block height or an error if unable to get current height.
-	Height(ctx context.Context) (uint64, error)
+	Height(ctx context.Context) (int64, error)
 
 	// GetBalance fetches the current balance for a specific account address and denom.
 	GetBalance(ctx context.Context, address string, denom string) (math.Int, error)
@@ -74,10 +74,10 @@ type Chain interface {
 	GetGasFeesInNativeDenom(gasPaid int64) int64
 
 	// Acknowledgements returns all acknowledgements in a block at height.
-	Acknowledgements(ctx context.Context, height uint64) ([]PacketAcknowledgement, error)
+	Acknowledgements(ctx context.Context, height int64) ([]PacketAcknowledgement, error)
 
 	// Timeouts returns all timeouts in a block at height.
-	Timeouts(ctx context.Context, height uint64) ([]PacketTimeout, error)
+	Timeouts(ctx context.Context, height int64) ([]PacketTimeout, error)
 
 	// BuildWallet will return a chain-specific wallet
 	// If mnemonic != "", it will restore using that mnemonic

--- a/ibc/tx.go
+++ b/ibc/tx.go
@@ -9,7 +9,7 @@ import (
 // Tx is a generalized IBC transaction.
 type Tx struct {
 	// The block height.
-	Height uint64
+	Height int64
 	// The transaction hash.
 	TxHash string
 	// Amount of gas charged to the account.

--- a/ibc/types.go
+++ b/ibc/types.go
@@ -284,7 +284,7 @@ type WalletAmount struct {
 
 type IBCTimeout struct {
 	NanoSeconds uint64
-	Height      uint64
+	Height      int64
 }
 
 type ChannelCounterparty struct {

--- a/internal/blockdb/chain.go
+++ b/internal/blockdb/chain.go
@@ -29,7 +29,7 @@ func (txs transactions) Hash() []byte {
 // SaveBlock tracks a block at height with its transactions.
 // This method is idempotent and can be safely called multiple times with the same arguments.
 // The txs should be human-readable.
-func (chain *Chain) SaveBlock(ctx context.Context, height uint64, txs []Tx) error {
+func (chain *Chain) SaveBlock(ctx context.Context, height int64, txs []Tx) error {
 	k := fmt.Sprintf("%d-%x", height, transactions(txs).Hash())
 	_, err, _ := chain.single.Do(k, func() (any, error) {
 		return nil, chain.saveBlock(ctx, height, txs)
@@ -37,7 +37,7 @@ func (chain *Chain) SaveBlock(ctx context.Context, height uint64, txs []Tx) erro
 	return err
 }
 
-func (chain *Chain) saveBlock(ctx context.Context, height uint64, txs transactions) error {
+func (chain *Chain) saveBlock(ctx context.Context, height int64, txs transactions) error {
 	dbTx, err := chain.db.BeginTx(ctx, nil)
 	if err != nil {
 		return err

--- a/internal/blockdb/collect.go
+++ b/internal/blockdb/collect.go
@@ -36,12 +36,12 @@ type EventAttribute struct {
 
 // TxFinder finds transactions given block at height.
 type TxFinder interface {
-	FindTxs(ctx context.Context, height uint64) ([]Tx, error)
+	FindTxs(ctx context.Context, height int64) ([]Tx, error)
 }
 
 // BlockSaver saves transactions for block at height.
 type BlockSaver interface {
-	SaveBlock(ctx context.Context, height uint64, txs []Tx) error
+	SaveBlock(ctx context.Context, height int64, txs []Tx) error
 }
 
 // Collector saves block transactions at regular intervals.
@@ -73,7 +73,7 @@ func (p *Collector) Collect(ctx context.Context) {
 
 	tick := time.NewTicker(p.rate)
 	defer tick.Stop()
-	var height uint64 = 1
+	var height int64 = 1
 	for {
 		select {
 		case <-ctx.Done():
@@ -86,7 +86,7 @@ func (p *Collector) Collect(ctx context.Context) {
 					continue
 				}
 
-				p.log.Info("Failed to save transactions", zap.Error(err), zap.Uint64("height", height))
+				p.log.Info("Failed to save transactions", zap.Error(err), zap.Int64("height", height))
 				continue
 			}
 			height++
@@ -102,7 +102,7 @@ func (p *Collector) Stop() {
 	p.cancel()
 }
 
-func (p *Collector) saveTxsForHeight(ctx context.Context, height uint64) error {
+func (p *Collector) saveTxsForHeight(ctx context.Context, height int64) error {
 	txs, err := p.finder.FindTxs(ctx, height)
 	if err != nil {
 		return fmt.Errorf("find txs: %w", err)

--- a/internal/blockdb/query_test.go
+++ b/internal/blockdb/query_test.go
@@ -133,7 +133,7 @@ func TestQuery_CosmosMessages(t *testing.T) {
 
 	for i, tx := range txs {
 		require.NotEmpty(t, tx.Raw)
-		err = chain.SaveBlock(ctx, uint64(i+1), []Tx{{Data: []byte(tx.Raw)}})
+		err = chain.SaveBlock(ctx, int64(i+1), []Tx{{Data: []byte(tx.Raw)}})
 		require.NoError(t, err)
 	}
 

--- a/testutil/poll_for_state_test.go
+++ b/testutil/poll_for_state_test.go
@@ -15,7 +15,7 @@ type mockChain struct {
 	HeightCallCount int
 	CurrentHeight   int
 
-	GotHeights []uint64
+	GotHeights []int64
 
 	FoundAcks []ibc.PacketAcknowledgement
 	AckErr    error
@@ -24,16 +24,16 @@ type mockChain struct {
 	TimeoutErr    error
 }
 
-func (m *mockChain) Height(ctx context.Context) (uint64, error) {
+func (m *mockChain) Height(ctx context.Context) (int64, error) {
 	if ctx == nil {
 		panic("nil context")
 	}
 	m.HeightCallCount++
 	defer func() { m.CurrentHeight++ }()
-	return uint64(m.CurrentHeight), m.HeightErr
+	return int64(m.CurrentHeight), m.HeightErr
 }
 
-func (m *mockChain) Acknowledgements(ctx context.Context, height uint64) ([]ibc.PacketAcknowledgement, error) {
+func (m *mockChain) Acknowledgements(ctx context.Context, height int64) ([]ibc.PacketAcknowledgement, error) {
 	if ctx == nil {
 		panic("nil context")
 	}
@@ -41,7 +41,7 @@ func (m *mockChain) Acknowledgements(ctx context.Context, height uint64) ([]ibc.
 	return m.FoundAcks, m.AckErr
 }
 
-func (m *mockChain) Timeouts(ctx context.Context, height uint64) ([]ibc.PacketTimeout, error) {
+func (m *mockChain) Timeouts(ctx context.Context, height int64) ([]ibc.PacketTimeout, error) {
 	if ctx == nil {
 		panic("nil context")
 	}
@@ -64,7 +64,7 @@ func TestPollForAck(t *testing.T) {
 		require.Equal(t, "found", got.Packet.SourceChannel)
 		require.EqualValues(t, 33, got.Packet.Sequence)
 
-		require.Equal(t, []uint64{3}, chain.GotHeights)
+		require.Equal(t, []int64{3}, chain.GotHeights)
 		require.Equal(t, 3, chain.HeightCallCount)
 	})
 
@@ -94,7 +94,7 @@ func TestPollForAck(t *testing.T) {
 		require.Error(t, err)
 		require.EqualError(t, err, "not found")
 		require.ErrorIs(t, err, ErrNotFound)
-		require.Equal(t, []uint64{1, 2, 3}, chain.GotHeights)
+		require.Equal(t, []int64{1, 2, 3}, chain.GotHeights)
 
 		longErr := fmt.Sprintf("%+v", err)
 		require.Contains(t, longErr, "not found")
@@ -124,7 +124,7 @@ func TestPollForTimeout(t *testing.T) {
 		require.Equal(t, "found", got.Packet.SourceChannel)
 		require.EqualValues(t, 33, got.Packet.Sequence)
 
-		require.Equal(t, []uint64{3}, chain.GotHeights)
+		require.Equal(t, []int64{3}, chain.GotHeights)
 		require.Equal(t, 3, chain.HeightCallCount)
 	})
 
@@ -151,7 +151,7 @@ func TestPollForTimeout(t *testing.T) {
 
 		require.Error(t, err)
 		require.ErrorIs(t, err, ErrNotFound)
-		require.Equal(t, []uint64{1, 2, 3}, chain.GotHeights)
+		require.Equal(t, []int64{1, 2, 3}, chain.GotHeights)
 	})
 
 	t.Run("invalid args", func(t *testing.T) {

--- a/testutil/wait.go
+++ b/testutil/wait.go
@@ -10,7 +10,7 @@ import (
 
 // ChainHeighter fetches the current chain block height.
 type ChainHeighter interface {
-	Height(ctx context.Context) (uint64, error)
+	Height(ctx context.Context) (int64, error)
 }
 
 // WaitForBlocks blocks until all chains reach a block height delta equal to or greater than the delta argument.
@@ -46,8 +46,8 @@ func WaitForBlocksUtil(maxBlocks int, fn func(i int) error) error {
 
 // nodesInSync returns an error if the nodes are not in sync with the chain.
 func nodesInSync(ctx context.Context, chain ChainHeighter, nodes []ChainHeighter) error {
-	var chainHeight uint64
-	nodeHeights := make([]uint64, len(nodes))
+	var chainHeight int64
+	nodeHeights := make([]int64, len(nodes))
 	eg, egCtx := errgroup.WithContext(ctx)
 	eg.Go(func() (err error) {
 		chainHeight, err = chain.Height(egCtx)
@@ -94,8 +94,8 @@ func WaitForInSync(ctx context.Context, chain ChainHeighter, nodes ...ChainHeigh
 type height struct {
 	Chain ChainHeighter
 
-	starting uint64
-	current  uint64
+	starting int64
+	current  int64
 }
 
 func (h *height) WaitForDelta(ctx context.Context, delta int) error {
@@ -121,7 +121,7 @@ func (h *height) delta() int {
 	return int(h.current - h.starting)
 }
 
-func (h *height) update(height uint64) {
+func (h *height) update(height int64) {
 	if h.starting == 0 {
 		h.starting = height
 	}

--- a/testutil/wait_test.go
+++ b/testutil/wait_test.go
@@ -16,12 +16,12 @@ type mockChainHeighter struct {
 	Err       error
 }
 
-func (m *mockChainHeighter) Height(ctx context.Context) (uint64, error) {
+func (m *mockChainHeighter) Height(ctx context.Context) (int64, error) {
 	if ctx == nil {
 		panic("nil context")
 	}
 	atomic.AddInt64(&m.CurHeight, 1)
-	return uint64(m.CurHeight), m.Err
+	return m.CurHeight, m.Err
 }
 
 type mockChainHeighterFixed struct {
@@ -29,11 +29,11 @@ type mockChainHeighterFixed struct {
 	Err       error
 }
 
-func (m *mockChainHeighterFixed) Height(ctx context.Context) (uint64, error) {
+func (m *mockChainHeighterFixed) Height(ctx context.Context) (int64, error) {
 	if ctx == nil {
 		panic("nil context")
 	}
-	return uint64(m.CurHeight), m.Err
+	return m.CurHeight, m.Err
 }
 
 func TestWaitForBlocks(t *testing.T) {


### PR DESCRIPTION

CometBFT [(here)](https://github.com/cometbft/cometbft/blob/c920404f6b56fc9c366aee8774c4d011610c564d/proto/cometbft/state/v1/types.proto#L77) and Cosmos-sdk [(here)](https://github.com/cosmos/cosmos-sdk/blob/74dfab268484d3606e9df8cbc66327a6c627f29d/proto/cosmos/base/tendermint/v1beta1/types.proto#L27) both use `int64` to denote block height.

Currently the interchaintest framework uses `uint64` for all height related values.
This PR changes that to use `int64` instead. This would help in preventing frequent typecasting and ensure consistency with upstream types.
