### PR TITLE
feat[v7]: support interchain security in local-interchain

### DIFF
--- a/local-interchain/chains/interchainsecurity.json
+++ b/local-interchain/chains/interchainsecurity.json
@@ -1,23 +1,23 @@
 {
     "chains": [
         {
-            "name": "ics-provider",
-            "binary": "interchain-security-pd",
+            "name": "gaia",
             "chain_id": "localcosmos-1",
-            "denom": "stake",
+            "denom": "uatom",
+            "binary": "gaiad",
             "bech32_prefix": "cosmos",
             "docker_image": {
-                "version": "v3.1.0"
+                "version": "v15.0.0-rc2"
             },
             "gas_prices": "0%DENOM%",
             "chain_type": "cosmos",
             "coin_type": 118,
             "trusting_period": "112h",
-            "gas_adjustment": 2.0,
+            "gas_adjustment": 1.3,
             "number_vals": 1,
             "number_node": 0,
             "debugging": true,
-            "block_time": "500ms",
+            "block_time": "1s",
             "genesis": {
                 "modify": [
                     {
@@ -25,12 +25,19 @@
                         "value": "3s"
                     },
                     {
-                        "key": "app_state.gov.params.max_deposit_period",
-                        "value": "15s"
-                    },
-                    {
-                        "key": "app_state.gov.params.min_deposit.0.denom",
-                        "value": "stake"
+                        "key": "app_state.interchainaccounts.host_genesis_state.params.allow_messages",
+                        "value": [
+                            "/cosmos.bank.v1beta1.MsgSend",
+                            "/cosmos.bank.v1beta1.MsgMultiSend",
+                            "/cosmos.staking.v1beta1.MsgDelegate",
+                            "/cosmos.staking.v1beta1.MsgUndelegate",
+                            "/cosmos.staking.v1beta1.MsgBeginRedelegate",
+                            "/cosmos.staking.v1beta1.MsgRedeemTokensforShares",
+                            "/cosmos.staking.v1beta1.MsgTokenizeShares",
+                            "/cosmos.distribution.v1beta1.MsgWithdrawDelegatorReward",
+                            "/cosmos.distribution.v1beta1.MsgSetWithdrawAddress",
+                            "/ibc.applications.transfer.v1.MsgTransfer"
+                        ]
                     }
                 ],
                 "accounts": [
@@ -44,29 +51,87 @@
             }
         },
         {
-            "ics_consumer_link": "localcosmos-1",
             "name": "ics-consumer",
-            "chain_id": "localconsumer-1",
-            "binary": "interchain-security-cd",
-            "denom": "stake",
-            "bech32_prefix": "cosmos",
+            "chain_id": "localneutron-1",
+            "denom": "untrn",
+            "binary": "neutrond",
+            "bech32_prefix": "neutron",
             "docker_image": {
-                "version": "v3.1.0"
+                "version": "v2.0.2",
+                "repository": "ghcr.io/strangelove-ventures/heighliner/neutron"
             },
-            "gas_prices": "0%DENOM%",
+            "gas_prices": "0.0untrn,0.0uatom",
             "chain_type": "cosmos",
             "coin_type": 118,
-            "trusting_period": "112h",
-            "gas_adjustment": 2.0,
+            "trusting_period": "1197504s",
+            "gas_adjustment": 1.3,
             "number_vals": 1,
             "number_node": 0,
+            "ics_consumer_link": "localcosmos-1",
             "debugging": true,
-            "block_time": "500ms",
+            "block_time": "1s",
             "genesis": {
+                "modify": [
+                    {
+                        "key": "app_state.ccvconsumer.params.soft_opt_out_threshold",
+                        "value": "0.05"
+                    },
+                    {
+                        "key": "app_state.ccvconsumer.params.reward_denoms",
+                        "value": [
+                            "untrn"
+                        ]
+                    },
+                    {
+                        "key": "app_state.ccvconsumer.params.provider_reward_denoms",
+                        "value": [
+                            "uatom"
+                        ]
+                    },
+                    {
+                        "key": "consensus_params.block.max_gas",
+                        "value": "1000000000"
+                    },
+                    {
+                        "key": "app_state.globalfee.params.minimum_gas_prices",
+                        "value": [{
+                            "denom": "untrn",
+                            "amount": "0"
+                        }]
+                    },
+                    {
+                        "key": "app_state.feeburner.params.treasury_address",
+                        "value": "neutron1hj5fveer5cjtn4wd6wstzugjfdxzl0xpznmsky"
+                    },
+                    {
+                        "key": "app_state.tokenfactory.params.fee_collector_address",
+                        "value": "neutron1hj5fveer5cjtn4wd6wstzugjfdxzl0xpznmsky"
+                    },
+                    {
+                        "key": "app_state.interchainaccounts.host_genesis_state.params.allow_messages",
+                        "value": [
+                            "/cosmos.bank.v1beta1.MsgSend",
+                            "/cosmos.bank.v1beta1.MsgMultiSend",
+                            "/cosmos.staking.v1beta1.MsgDelegate",
+                            "/cosmos.staking.v1beta1.MsgUndelegate",
+                            "/cosmos.staking.v1beta1.MsgBeginRedelegate",
+                            "/cosmos.staking.v1beta1.MsgRedeemTokensforShares",
+                            "/cosmos.staking.v1beta1.MsgTokenizeShares",
+                            "/cosmos.distribution.v1beta1.MsgWithdrawDelegatorReward",
+                            "/cosmos.distribution.v1beta1.MsgSetWithdrawAddress",
+                            "/ibc.applications.transfer.v1.MsgTransfer",
+                            "/ibc.lightclients.localhost.v2.ClientState",
+                            "/ibc.core.client.v1.MsgCreateClient",
+                            "/ibc.core.client.v1.Query/ClientState",
+                            "/ibc.core.client.v1.Query/ConsensusState",
+                            "/ibc.core.connection.v1.Query/Connection"
+                        ]
+                    }
+                ],
                 "accounts": [
                     {
                         "name": "acc0",
-                        "address": "cosmos1hj5fveer5cjtn4wd6wstzugjfdxzl0xpxvjjvr",
+                        "address": "neutron1hj5fveer5cjtn4wd6wstzugjfdxzl0xpznmsky",
                         "amount": "10000000000%DENOM%",
                         "mnemonic": "decorate bright ozone fork gallery riot bus exhaust worth way bone indoor calm squirrel merry zero scheme cotton until shop any excess stage laundry"
                     }

--- a/local-interchain/chains/interchainsecurity.json
+++ b/local-interchain/chains/interchainsecurity.json
@@ -1,11 +1,10 @@
 {
     "chains": [
         {
-            "ibc_paths": ["ics-1"],
             "name": "ics-provider",
             "binary": "interchain-security-pd",
             "chain_id": "localcosmos-1",
-            "denom": "uatom",
+            "denom": "stake",
             "bech32_prefix": "cosmos",
             "docker_image": {
                 "version": "v3.1.0"
@@ -23,7 +22,7 @@
                 "modify": [
                     {
                         "key": "app_state.gov.params.voting_period",
-                        "value": "10s"
+                        "value": "3s"
                     },
                     {
                         "key": "app_state.gov.params.max_deposit_period",
@@ -31,7 +30,7 @@
                     },
                     {
                         "key": "app_state.gov.params.min_deposit.0.denom",
-                        "value": "uatom"
+                        "value": "stake"
                     }
                 ],
                 "accounts": [
@@ -46,11 +45,10 @@
         },
         {
             "ics_consumer_link": "localcosmos-1",
-            "ibc_paths": ["ics-1"],
             "name": "ics-consumer",
             "chain_id": "localconsumer-1",
             "binary": "interchain-security-cd",
-            "denom": "untrn",
+            "denom": "stake",
             "bech32_prefix": "cosmos",
             "docker_image": {
                 "version": "v3.1.0"
@@ -65,20 +63,6 @@
             "debugging": true,
             "block_time": "500ms",
             "genesis": {
-                "modify": [
-                    {
-                        "key": "app_state.gov.params.voting_period",
-                        "value": "10s"
-                    },
-                    {
-                        "key": "app_state.gov.params.max_deposit_period",
-                        "value": "15s"
-                    },
-                    {
-                        "key": "app_state.gov.params.min_deposit.0.denom",
-                        "value": "untrn"
-                    }
-                ],
                 "accounts": [
                     {
                         "name": "acc0",

--- a/local-interchain/chains/interchainsecurity.json
+++ b/local-interchain/chains/interchainsecurity.json
@@ -1,0 +1,94 @@
+{
+    "chains": [
+        {
+            "ics_provider_name": "cosmos-provider",
+            "ibc_paths": ["ics-1"],
+            "name": "ics-provider",
+            "binary": "interchain-security-pd",
+            "chain_id": "localcosmos-1",
+            "denom": "uatom",
+            "bech32_prefix": "cosmos",
+            "docker_image": {
+                "version": "v3.1.0"
+            },
+            "gas_prices": "0%DENOM%",
+            "chain_type": "cosmos",
+            "coin_type": 118,
+            "trusting_period": "112h",
+            "gas_adjustment": 2.0,
+            "number_vals": 1,
+            "number_node": 0,
+            "debugging": true,
+            "block_time": "500ms",
+            "genesis": {
+                "modify": [
+                    {
+                        "key": "app_state.gov.params.voting_period",
+                        "value": "10s"
+                    },
+                    {
+                        "key": "app_state.gov.params.max_deposit_period",
+                        "value": "15s"
+                    },
+                    {
+                        "key": "app_state.gov.params.min_deposit.0.denom",
+                        "value": "uatom"
+                    }
+                ],
+                "accounts": [
+                    {
+                        "name": "acc0",
+                        "address": "cosmos1hj5fveer5cjtn4wd6wstzugjfdxzl0xpxvjjvr",
+                        "amount": "10000000000%DENOM%",
+                        "mnemonic": "decorate bright ozone fork gallery riot bus exhaust worth way bone indoor calm squirrel merry zero scheme cotton until shop any excess stage laundry"
+                    }
+                ]
+            }
+        },
+        {
+            "ics_consumer_link": "localcosmos-1",
+            "ibc_paths": ["ics-1"],
+            "name": "ics-consumer",
+            "chain_id": "localconsumer-1",
+            "binary": "interchain-security-cd",
+            "denom": "untrn",
+            "bech32_prefix": "cosmos",
+            "docker_image": {
+                "version": "v3.1.0"
+            },
+            "gas_prices": "0%DENOM%",
+            "chain_type": "cosmos",
+            "coin_type": 118,
+            "trusting_period": "112h",
+            "gas_adjustment": 2.0,
+            "number_vals": 1,
+            "number_node": 0,
+            "debugging": true,
+            "block_time": "500ms",
+            "genesis": {
+                "modify": [
+                    {
+                        "key": "app_state.gov.params.voting_period",
+                        "value": "10s"
+                    },
+                    {
+                        "key": "app_state.gov.params.max_deposit_period",
+                        "value": "15s"
+                    },
+                    {
+                        "key": "app_state.gov.params.min_deposit.0.denom",
+                        "value": "untrn"
+                    }
+                ],
+                "accounts": [
+                    {
+                        "name": "acc0",
+                        "address": "cosmos1hj5fveer5cjtn4wd6wstzugjfdxzl0xpxvjjvr",
+                        "amount": "10000000000%DENOM%",
+                        "mnemonic": "decorate bright ozone fork gallery riot bus exhaust worth way bone indoor calm squirrel merry zero scheme cotton until shop any excess stage laundry"
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/local-interchain/chains/interchainsecurity.json
+++ b/local-interchain/chains/interchainsecurity.json
@@ -1,7 +1,6 @@
 {
     "chains": [
         {
-            "ics_provider_name": "cosmos-provider",
             "ibc_paths": ["ics-1"],
             "name": "ics-provider",
             "binary": "interchain-security-pd",

--- a/local-interchain/interchain/start.go
+++ b/local-interchain/interchain/start.go
@@ -121,7 +121,7 @@ func StartChain(installDir, chainCfgFile string, ac *AppConfig) {
 	client, network := interchaintest.DockerSetup(fakeT)
 
 	// setup a relayer if we have IBC paths to use.
-	if len(ibcpaths) > 0 {
+	if len(ibcpaths) > 0 || len(icsPair) > 0 {
 		rlyCfg := config.Relayer
 
 		relayerType, relayerName := ibc.CosmosRly, "relay"
@@ -150,9 +150,6 @@ func StartChain(installDir, chainCfgFile string, ac *AppConfig) {
 
 		// iterate icsPair
 		for provider, consumers := range icsPair {
-			fmt.Println("provider", provider)
-			fmt.Println("consumers", consumers)
-
 			var p ibc.Chain
 			var c ibc.Chain
 
@@ -169,6 +166,8 @@ func StartChain(installDir, chainCfgFile string, ac *AppConfig) {
 			}
 
 			pathName := fmt.Sprintf("%s-%s", p.Config().ChainID, c.Config().ChainID)
+
+			logger.Info("Adding ICS pair", zap.String("provider", p.Config().ChainID), zap.String("consumer", c.Config().ChainID), zap.String("path", pathName))
 
 			ic = ic.AddProviderConsumerLink(interchaintest.ProviderConsumerLink{
 				Provider: p,

--- a/local-interchain/interchain/types/chain.go
+++ b/local-interchain/interchain/types/chain.go
@@ -16,6 +16,9 @@ type Chain struct {
 	Debugging      bool   `json:"debugging"`
 	BlockTime      string `json:"block_time"`
 
+	// ICSProviderName string `json:"ics_provider_name"` // ex: provider
+	ICSConsumerLink string `json:"ics_consumer_link"` // a consumer sets this to ex: "provider" to connect to them
+
 	// Required
 	Name    string `json:"name" validate:"min=1"`
 	ChainID string `json:"chain_id" validate:"min=3"`

--- a/local-interchain/interchain/types/chain.go
+++ b/local-interchain/interchain/types/chain.go
@@ -16,8 +16,7 @@ type Chain struct {
 	Debugging      bool   `json:"debugging"`
 	BlockTime      string `json:"block_time"`
 
-	// ICSProviderName string `json:"ics_provider_name"` // ex: provider
-	ICSConsumerLink string `json:"ics_consumer_link"` // a consumer sets this to ex: "provider" to connect to them
+	ICSConsumerLink string `json:"ics_consumer_link"` // a consumer sets this to ex: "provider-chain-id" to connect to them
 
 	// Required
 	Name    string `json:"name" validate:"min=1"`


### PR DESCRIPTION
request by timewave

## Summary
Adds ICS support to local-interchain in a user friendly way with only 1 configuration change needed. Supports multiple consumers -> 1 provider

## Integration
Add `"ics_consumer_link": "providerchainid-1",` to your consumer chain. No changes on the provider side is required

## Run
`make install && local-ic start interchainsecurity`