### PR TITLE
fix: Parse sequence number as uint instead of int in cosmos SendIBCTransfer

### DIFF
--- a/chain/cosmos/cosmos_chain.go
+++ b/chain/cosmos/cosmos_chain.go
@@ -361,11 +361,11 @@ func (c *CosmosChain) SendIBCTransfer(
 	tx.Packet.TimeoutHeight = timeoutHeight
 	tx.Packet.Data = []byte(data)
 
-	seqNum, err := strconv.Atoi(seq)
+	seqNum, err := strconv.ParseUint(seq, 10, 64)
 	if err != nil {
 		return tx, fmt.Errorf("invalid packet sequence from events %s: %w", seq, err)
 	}
-	tx.Packet.Sequence = uint64(seqNum)
+	tx.Packet.Sequence = seqNum
 
 	timeoutNano, err := strconv.ParseUint(timeoutTs, 10, 64)
 	if err != nil {


### PR DESCRIPTION
## Summary

Sequence numbers are defined as uint64 in the spec:

https://github.com/cosmos/ibc/blob/ded4eb44d8c6b4d32d386728414bec3999fa069a/spec/core/ics-004-channel-and-packet-semantics/README.md?plain=1#L119-L128

Closes #977 