### PR TITLE
feat[v7]: allow hermes to work with ics

### DIFF
--- a/examples/ibc/ics_test.go
+++ b/examples/ibc/ics_test.go
@@ -20,59 +20,75 @@ func TestICS(t *testing.T) {
 		t.Skip("skipping in short mode")
 	}
 
-	t.Parallel()
+	tests := []relayerImp{
+		{
+			name:       "Cosmos Relayer",
+			relayerImp: ibc.CosmosRly,
+		},
+		{
+			name:       "Hermes",
+			relayerImp: ibc.Hermes,
+		},
+	}
 
-	ctx := context.Background()
+	for _, tt := range tests {
+		tt := tt
+		testname := tt.name
+		t.Run(testname, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
 
-	// Chain Factory
-	cf := interchaintest.NewBuiltinChainFactory(zaptest.NewLogger(t), []*interchaintest.ChainSpec{
-		{Name: "ics-provider", Version: "v3.1.0", ChainConfig: ibc.ChainConfig{GasAdjustment: 1.5}},
-		{Name: "ics-consumer", Version: "v3.1.0"},
-	})
+			// Chain Factory
+			cf := interchaintest.NewBuiltinChainFactory(zaptest.NewLogger(t), []*interchaintest.ChainSpec{
+				{Name: "ics-provider", Version: "v3.1.0", ChainConfig: ibc.ChainConfig{GasAdjustment: 1.5}},
+				{Name: "ics-consumer", Version: "v3.1.0"},
+			})
 
-	chains, err := cf.Chains(t.Name())
-	require.NoError(t, err)
-	provider, consumer := chains[0], chains[1]
+			chains, err := cf.Chains(t.Name())
+			require.NoError(t, err)
+			provider, consumer := chains[0], chains[1]
 
-	// Relayer Factory
-	client, network := interchaintest.DockerSetup(t)
+			// Relayer Factory
+			client, network := interchaintest.DockerSetup(t)
 
-	r := interchaintest.NewBuiltinRelayerFactory(
-		ibc.CosmosRly,
-		zaptest.NewLogger(t),
-	).Build(t, client, network)
+			r := interchaintest.NewBuiltinRelayerFactory(
+				tt.relayerImp,
+				zaptest.NewLogger(t),
+			).Build(t, client, network)
 
-	// Prep Interchain
-	const ibcPath = "ics-path"
-	ic := interchaintest.NewInterchain().
-		AddChain(provider).
-		AddChain(consumer).
-		AddRelayer(r, "relayer").
-		AddProviderConsumerLink(interchaintest.ProviderConsumerLink{
-			Provider: provider,
-			Consumer: consumer,
-			Relayer:  r,
-			Path:     ibcPath,
+			// Prep Interchain
+			const ibcPath = "ics-path"
+			ic := interchaintest.NewInterchain().
+				AddChain(provider).
+				AddChain(consumer).
+				AddRelayer(r, "relayer").
+				AddProviderConsumerLink(interchaintest.ProviderConsumerLink{
+					Provider: provider,
+					Consumer: consumer,
+					Relayer:  r,
+					Path:     ibcPath,
+				})
+
+			// Log location
+			f, err := interchaintest.CreateLogFile(fmt.Sprintf("%d.json", time.Now().Unix()))
+			require.NoError(t, err)
+			// Reporter/logs
+			rep := testreporter.NewReporter(f)
+			eRep := rep.RelayerExecReporter(t)
+
+			// Build interchain
+			err = ic.Build(ctx, eRep, interchaintest.InterchainBuildOptions{
+				TestName:          t.Name(),
+				Client:            client,
+				NetworkID:         network,
+				BlockDatabaseFile: interchaintest.DefaultBlockDatabaseFilepath(),
+
+				SkipPathCreation: false,
+			})
+			require.NoError(t, err, "failed to build interchain")
+
+			err = testutil.WaitForBlocks(ctx, 10, provider, consumer)
+			require.NoError(t, err, "failed to wait for blocks")
 		})
-
-	// Log location
-	f, err := interchaintest.CreateLogFile(fmt.Sprintf("%d.json", time.Now().Unix()))
-	require.NoError(t, err)
-	// Reporter/logs
-	rep := testreporter.NewReporter(f)
-	eRep := rep.RelayerExecReporter(t)
-
-	// Build interchain
-	err = ic.Build(ctx, eRep, interchaintest.InterchainBuildOptions{
-		TestName:          t.Name(),
-		Client:            client,
-		NetworkID:         network,
-		BlockDatabaseFile: interchaintest.DefaultBlockDatabaseFilepath(),
-
-		SkipPathCreation: false,
-	})
-	require.NoError(t, err, "failed to build interchain")
-
-	err = testutil.WaitForBlocks(ctx, 10, provider, consumer)
-	require.NoError(t, err, "failed to wait for blocks")
+	}
 }

--- a/relayer/hermes/hermes_commander.go
+++ b/relayer/hermes/hermes_commander.go
@@ -146,8 +146,7 @@ func (c commander) CreateWallet(keyName, address, mnemonic string) ibc.Wallet {
 }
 
 func (c commander) UpdatePath(pathName, homeDir string, opts ibc.PathUpdateOptions) []string {
-	// TODO: figure out how to implement this.
-	panic("implement me")
+	panic("update path implemented in hermes relayer not the commander")
 }
 
 // the following methods do not have a single command that cleanly maps to a single hermes command without

--- a/relayer/hermes/hermes_relayer.go
+++ b/relayer/hermes/hermes_relayer.go
@@ -289,6 +289,33 @@ func (r *Relayer) RestoreKey(ctx context.Context, rep ibc.RelayerExecReporter, c
 	return nil
 }
 
+func (r *Relayer) UpdatePath(ctx context.Context, rep ibc.RelayerExecReporter, pathName string, opts ibc.PathUpdateOptions) error {
+	// the concept of paths doesn't exist in hermes, but update our in-memory paths so we can use them elsewhere
+	path, ok := r.paths[pathName]
+	if !ok {
+		return fmt.Errorf("path %s not found", pathName)
+	}
+	if opts.SrcChainID != nil {
+		path.chainA.chainID = *opts.SrcChainID
+	}
+	if opts.DstChainID != nil {
+		path.chainB.chainID = *opts.DstChainID
+	}
+	if opts.SrcClientID != nil {
+		path.chainA.clientID = *opts.SrcClientID
+	}
+	if opts.DstClientID != nil {
+		path.chainB.clientID = *opts.DstClientID
+	}
+	if opts.SrcConnID != nil {
+		path.chainA.connectionID = *opts.SrcConnID
+	}
+	if opts.DstConnID != nil {
+		path.chainB.connectionID = *opts.DstConnID
+	}
+	return nil
+}
+
 func (r *Relayer) Flush(ctx context.Context, rep ibc.RelayerExecReporter, pathName string, channelID string) error {
 	path := r.paths[pathName]
 	cmd := []string{hermes, "clear", "packets", "--chain", path.chainA.chainID, "--channel", channelID, "--port", path.chainA.portID}


### PR DESCRIPTION
## Summary

Allows the Hermes relayer to be used with ProviderConsumerChainLinks by implementing UpdatePath; adds a test to the example `ics_test.go`.

I'm not sure how we'd implement the channel filter, but this at least allows for basic ICS tests to be written against hermes.