### PR TITLE
fix(v7)!: check transactions succeed after they're included in a block

### DIFF
--- a/chain/cosmos/chain_node.go
+++ b/chain/cosmos/chain_node.go
@@ -552,6 +552,19 @@ func (tn *ChainNode) ExecTx(ctx context.Context, keyName string, command ...stri
 	if err := testutil.WaitForBlocks(ctx, 2, tn); err != nil {
 		return "", err
 	}
+	// The transaction can at first appear to succeed, but then fail when it's actually included in a block.
+	stdout, _, err = tn.ExecQuery(ctx, "tx", output.TxHash)
+	if err != nil {
+		return "", err
+	}
+	output = CosmosTx{}
+	err = json.Unmarshal([]byte(stdout), &output)
+	if err != nil {
+		return "", err
+	}
+	if output.Code != 0 {
+		return output.TxHash, fmt.Errorf("transaction failed with code %d: %s", output.Code, output.RawLog)
+	}
 	return output.TxHash, nil
 }
 


### PR DESCRIPTION
## Summary

Sometimes a transaction returns code 0 initially, but then fails when a validator goes to actually include it in a block. This PR adds code to cosmos' ExecTx to make sure transactions are verified after their inclusion in a block; if they fail at any stage of proceedings, an error is returned.