### PR TITLE
fix: allow use of HostPortOverride with full nodes

### DIFF
--- a/chain/cosmos/chain_node.go
+++ b/chain/cosmos/chain_node.go
@@ -1059,7 +1059,8 @@ func (tn *ChainNode) CreateNodeContainer(ctx context.Context) error {
 		usingPorts[k] = v
 	}
 
-	if tn.Index == 0 && chainCfg.HostPortOverride != nil {
+	// to prevent port binding conflicts, host port overrides are only exposed on the first validator node.
+	if tn.Validator && tn.Index == 0 && chainCfg.HostPortOverride != nil {
 		for intP, extP := range chainCfg.HostPortOverride {
 			usingPorts[nat.Port(fmt.Sprintf("%d/tcp", intP))] = []nat.PortBinding{
 				{

--- a/ibc/types.go
+++ b/ibc/types.go
@@ -64,7 +64,8 @@ type ChainConfig struct {
 	SidecarConfigs []SidecarConfig
 	// CoinDecimals for the chains base micro/nano/atto token configuration.
 	CoinDecimals *int64
-	//HostPortOverride exposes ports to the host
+	// HostPortOverride exposes ports to the host.
+	// To avoid port binding conflicts, ports are only exposed on the 0th validator.
 	HostPortOverride map[int]int `yaml:"host-port-override"`
 	// Additional start command arguments
 	AdditionalStartArgs []string


### PR DESCRIPTION
by exposing the ports defined in HostPortOverride on only the first _validator_ node of the chain, it can now be run with full nodes alongside without port binding conflicts.

For full description of issue, see #1089 