### PR TITLE
feat: add ExposeAdditionalPorts config option

### DIFF
--- a/chainspec.go
+++ b/chainspec.go
@@ -62,6 +62,10 @@ func (s *ChainSpec) Config(log *zap.Logger) (*ibc.ChainConfig, error) {
 		}
 	}
 
+	if len(s.ExposeAdditionalPorts) > 0 {
+		s.ChainConfig.ExposeAdditionalPorts = append(s.ChainConfig.ExposeAdditionalPorts, s.ExposeAdditionalPorts...)
+	}
+
 	// s.Name and chainConfig.Name are interchangeable
 	if s.Name == "" && s.ChainConfig.Name != "" {
 		s.Name = s.ChainConfig.Name

--- a/ibc/types.go
+++ b/ibc/types.go
@@ -67,6 +67,9 @@ type ChainConfig struct {
 	// HostPortOverride exposes ports to the host.
 	// To avoid port binding conflicts, ports are only exposed on the 0th validator.
 	HostPortOverride map[int]int `yaml:"host-port-override"`
+	// ExposeAdditionalPorts exposes each port id to the host on a random port. ex: "8080/tcp"
+	// Access the address with ChainNode.GetHostAddress
+	ExposeAdditionalPorts []string
 	// Additional start command arguments
 	AdditionalStartArgs []string
 	// Environment variables for chain nodes
@@ -83,6 +86,10 @@ func (c ChainConfig) Clone() ChainConfig {
 	sidecars := make([]SidecarConfig, len(c.SidecarConfigs))
 	copy(sidecars, c.SidecarConfigs)
 	x.SidecarConfigs = sidecars
+
+	additionalPorts := make([]string, len(c.ExposeAdditionalPorts))
+	copy(additionalPorts, c.ExposeAdditionalPorts)
+	x.ExposeAdditionalPorts = additionalPorts
 
 	if c.CoinDecimals != nil {
 		coinDecimals := *c.CoinDecimals
@@ -204,6 +211,10 @@ func (c ChainConfig) MergeChainSpecConfig(other ChainConfig) ChainConfig {
 
 	if other.Env != nil {
 		c.Env = append(c.Env, other.Env...)
+	}
+
+	if len(other.ExposeAdditionalPorts) > 0 {
+		c.ExposeAdditionalPorts = append(c.ExposeAdditionalPorts, other.ExposeAdditionalPorts...)
 	}
 
 	return c


### PR DESCRIPTION
for cosmos chains, `ExposeAdditionalPorts` takes a list of port ids that will be exposed on all validators and full nodes for the chains on random host ports.

extends the ethermint test by exposing the EVM & verifying the port actually gets exposed.

Resolves cosmos chain portion of #1091 

Happy to make any changes or refactors. I _think_ I updated all the config things that need updated (`Clone` & `MergeChainSpecConfig`), but possible I missed something.