### PR TITLE
fix(v7): prevent concurrent hermes operations on the same chain

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -25,4 +25,4 @@ jobs:
       # run tests
       - name: run unit tests
         # -short flag purposefully omitted because there are some longer unit tests
-        run: go test -race -timeout 10m -failfast -p 2 $(go list ./... | grep -v /cmd | grep -v /examples)
+        run: go test -race -timeout 30m -failfast -p 2 $(go list ./... | grep -v /cmd | grep -v /examples)

--- a/examples/cosmos/sdk_boundary_test.go
+++ b/examples/cosmos/sdk_boundary_test.go
@@ -101,11 +101,10 @@ func TestSDKBoundaries(t *testing.T) {
 			rep := testreporter.NewNopReporter()
 
 			require.NoError(t, ic.Build(ctx, rep.RelayerExecReporter(t), interchaintest.InterchainBuildOptions{
-				TestName:          t.Name(),
-				Client:            client,
-				NetworkID:         network,
-				BlockDatabaseFile: interchaintest.DefaultBlockDatabaseFilepath(),
-				SkipPathCreation:  false,
+				TestName:         t.Name(),
+				Client:           client,
+				NetworkID:        network,
+				SkipPathCreation: false,
 			}))
 			t.Cleanup(func() {
 				_ = ic.Close()

--- a/examples/ibc/ics_test.go
+++ b/examples/ibc/ics_test.go
@@ -95,10 +95,9 @@ func TestICS(t *testing.T) {
 
 						// Build interchain
 						err = ic.Build(ctx, eRep, interchaintest.InterchainBuildOptions{
-							TestName:          t.Name(),
-							Client:            client,
-							NetworkID:         network,
-							BlockDatabaseFile: interchaintest.DefaultBlockDatabaseFilepath(),
+							TestName:  t.Name(),
+							Client:    client,
+							NetworkID: network,
 
 							SkipPathCreation: false,
 						})


### PR DESCRIPTION
## Summary

Allowing concurrent ops can result in `hermes create ...` commands failing because there's sequence numbers being modified by simultaneous commands. This PR adds per-chain locks that must be acquired to e.g. create a connection or channel