### PR TITLE
fix(v7): take user-configured gas-adjustment into account

### DIFF
--- a/ibc/types.go
+++ b/ibc/types.go
@@ -142,7 +142,7 @@ func (c ChainConfig) MergeChainSpecConfig(other ChainConfig) ChainConfig {
 		c.GasPrices = other.GasPrices
 	}
 
-	if other.GasAdjustment > 0 && c.GasAdjustment == 0 {
+	if other.GasAdjustment > 0 {
 		c.GasAdjustment = other.GasAdjustment
 	}
 


### PR DESCRIPTION
GasAdjustments configured via the ChainConfig were being ignored.