### PR TITLE
feat: adding functions for pre-start of node + pre-start of all nodes in a chain

### DIFF
--- a/chain/cosmos/chain_node.go
+++ b/chain/cosmos/chain_node.go
@@ -61,7 +61,8 @@ type ChainNode struct {
 	GrpcConn     *grpc.ClientConn
 	TestName     string
 	Image        ibc.DockerImage
-
+	preStartNode func(*ChainNode)
+	
 	// Additional processes that need to be run on a per-validator basis.
 	Sidecars SidecarProcesses
 
@@ -94,6 +95,12 @@ func NewChainNode(log *zap.Logger, validator bool, chain *CosmosChain, dockerCli
 
 	tn.containerLifecycle = dockerutil.NewContainerLifecycle(log, dockerClient, tn.Name())
 
+	return tn
+}
+
+// WithPreStartNode sets the preStartNode function for the ChainNode
+func (tn *ChainNode) WithPreStartNode(preStartNode func(*ChainNode)) *ChainNode {
+	tn.preStartNode = preStartNode
 	return tn
 }
 
@@ -1183,6 +1190,10 @@ func (tn *ChainNode) StartContainer(ctx context.Context) error {
 				)
 			}
 		}
+	}
+
+	if tn.preStartNode != nil {
+		tn.preStartNode(tn)
 	}
 
 	if err := tn.containerLifecycle.StartContainer(ctx); err != nil {

--- a/chain/cosmos/chain_node.go
+++ b/chain/cosmos/chain_node.go
@@ -62,7 +62,7 @@ type ChainNode struct {
 	TestName     string
 	Image        ibc.DockerImage
 	preStartNode func(*ChainNode)
-	
+
 	// Additional processes that need to be run on a per-validator basis.
 	Sidecars SidecarProcesses
 

--- a/chain/cosmos/ics.go
+++ b/chain/cosmos/ics.go
@@ -313,6 +313,10 @@ func (c *CosmosChain) StartConsumer(testName string, ctx context.Context, additi
 
 	chainNodes := c.Nodes()
 
+	if c.preStartNodes != nil {
+		c.preStartNodes(c)
+	}
+
 	for _, cn := range chainNodes {
 		if err := cn.OverwriteGenesisFile(ctx, genbz); err != nil {
 			return err


### PR DESCRIPTION
## In This PR
- I introduce helper lambda functions that trigger business logic before all nodes in a chain are started (`preStartNodes`), and a function called after a sidecar is started, but before the node is started (`preStartNode`)
- We use these methods in slinky, and would like to get off our [fork](https://github.com/skip-mev/slinky/blob/e369ddea9dff430f8f82c3865327ba6bde541abd/tests/integration/slinky_suite.go#L129)