### PR TITLE
feat: host address override with env variable

### DIFF
--- a/chain/cosmos/chain_node.go
+++ b/chain/cosmos/chain_node.go
@@ -108,18 +108,18 @@ func (tn *ChainNode) WithPreStartNode(preStartNode func(*ChainNode)) *ChainNode 
 type ChainNodes []*ChainNode
 
 const (
-	valKey      = "validator"
-	blockTime   = 2 // seconds
-	p2pPort     = "26656/tcp"
-	rpcPort     = "26657/tcp"
-	grpcPort    = "9090/tcp"
-	apiPort     = "1317/tcp"
-	privValPort = "1234/tcp"
-
+	valKey           = "validator"
+	blockTime        = 2 // seconds
+	p2pPort          = "26656/tcp"
+	rpcPort          = "26657/tcp"
+	grpcPort         = "9090/tcp"
+	apiPort          = "1317/tcp"
+	privValPort      = "1234/tcp"
 	cometMockRawPort = "22331"
 )
 
 var (
+	host        = dockerutil.GetHostAddress() // ICTEST_HOST=A.B.C.D
 	sentryPorts = nat.PortMap{
 		nat.Port(p2pPort):     {},
 		nat.Port(rpcPort):     {},
@@ -345,7 +345,7 @@ func (tn *ChainNode) SetTestConfig(ctx context.Context) error {
 	rpc := make(testutil.Toml)
 
 	// Enable public RPC
-	rpc["laddr"] = "tcp://0.0.0.0:26657"
+	rpc["laddr"] = fmt.Sprintf("tcp://%s:26657", host)
 	if tn.Chain.Config().UsesCometMock() {
 		rpc["laddr"] = fmt.Sprintf("tcp://%s:%s", tn.HostnameCometMock(), cometMockRawPort)
 	}
@@ -372,7 +372,7 @@ func (tn *ChainNode) SetTestConfig(ctx context.Context) error {
 	grpc := make(testutil.Toml)
 
 	// Enable public GRPC
-	grpc["address"] = "0.0.0.0:9090"
+	grpc["address"] = fmt.Sprintf("%s:9090", host)
 
 	a["grpc"] = grpc
 
@@ -381,7 +381,7 @@ func (tn *ChainNode) SetTestConfig(ctx context.Context) error {
 	// Enable public REST API
 	api["enable"] = true
 	api["swagger"] = true
-	api["address"] = "tcp://0.0.0.0:1317"
+	api["address"] = fmt.Sprintf("tcp://%s:1317", host)
 
 	a["api"] = api
 
@@ -1109,7 +1109,7 @@ func (tn *ChainNode) CreateNodeContainer(ctx context.Context) error {
 		}
 		blockTimeFlag := fmt.Sprintf("--block-time=%d", blockTime)
 
-		defaultListenAddr := fmt.Sprintf("tcp://0.0.0.0:%s", cometMockRawPort)
+		defaultListenAddr := fmt.Sprintf("tcp://%s:%s", host, cometMockRawPort)
 		genesisFile := path.Join(tn.HomeDir(), "config", "genesis.json")
 
 		containerName := fmt.Sprintf("cometmock-%s-%d", tn.Name(), rand.Intn(50_000))

--- a/chain/ethereum/ethererum_chain.go
+++ b/chain/ethereum/ethererum_chain.go
@@ -181,7 +181,7 @@ func (c *EthereumChain) Start(testName string, ctx context.Context, additionalGe
 	//   * add additionalGenesisWallet support for relayer wallet, either add genesis accounts or tx after chain starts
 
 	cmd := []string{c.cfg.Bin,
-		"--host", "0.0.0.0", // Anyone can call
+		"--host", dockerutil.GetHostAddress(), // Anyone can call
 		"--block-time", "2", // 2 second block times
 		"--accounts", "10", // We current only use the first account for the faucet, but tests may expect the default
 		"--balance", "10000000", // Genesis accounts loaded with 10mil ether, change as needed

--- a/chain/internal/tendermint/tendermint_node.go
+++ b/chain/internal/tendermint/tendermint_node.go
@@ -202,9 +202,9 @@ func (tn *TendermintNode) SetConfigAndPeers(ctx context.Context, peers string) e
 	rpc := make(testutil.Toml)
 
 	// Enable public RPC
-	rpc["laddr"] = "tcp://0.0.0.0:26657"
+	rpc["laddr"] = "tcp://" + dockerutil.GetHostAddress() + ":26657"
 	if tn.Chain.Config().UsesCometMock() {
-		rpc["laddr"] = "tcp://0.0.0.0:22331"
+		rpc["laddr"] = "tcp://" + dockerutil.GetHostAddress() + ":22331"
 	}
 
 	c["rpc"] = rpc

--- a/chain/penumbra/penumbra_app_node.go
+++ b/chain/penumbra/penumbra_app_node.go
@@ -279,9 +279,9 @@ func (p *PenumbraAppNode) GetAddressBech32m(ctx context.Context, keyName string)
 func (p *PenumbraAppNode) CreateNodeContainer(ctx context.Context, tendermintAddress string) error {
 	cmd := []string{
 		"pd", "start",
-		"--abci-bind", "0.0.0.0:" + strings.Split(abciPort, "/")[0],
-		"--grpc-bind", "0.0.0.0:" + strings.Split(grpcPort, "/")[0],
-		"--metrics-bind", "0.0.0.0:" + strings.Split(metricsPort, "/")[0],
+		"--abci-bind", dockerutil.GetHostAddress() + ":" + strings.Split(abciPort, "/")[0],
+		"--grpc-bind", dockerutil.GetHostAddress() + ":" + strings.Split(grpcPort, "/")[0],
+		"--metrics-bind", dockerutil.GetHostAddress() + ":" + strings.Split(metricsPort, "/")[0],
 		"--tendermint-addr", "http://" + tendermintAddress,
 		"--home", p.HomeDir(),
 	}

--- a/chain/penumbra/penumbra_chain.go
+++ b/chain/penumbra/penumbra_chain.go
@@ -518,7 +518,7 @@ func (c *PenumbraChain) start(ctx context.Context) error {
 			return n.TendermintNode.CreateNodeContainer(
 				egCtx,
 				fmt.Sprintf("--proxy%sapp=tcp://%s:%s", sep, n.PenumbraAppNode.HostName(), strings.Split(abciPort, "/")[0]),
-				"--rpc.laddr=tcp://0.0.0.0:"+tmPort,
+				"--rpc.laddr=tcp://"+dockerutil.GetHostAddress()+":"+tmPort,
 			)
 		})
 

--- a/chain/penumbra/penumbra_client_node.go
+++ b/chain/penumbra/penumbra_client_node.go
@@ -356,7 +356,7 @@ func (p *PenumbraClientNode) CreateNodeContainer(ctx context.Context, pdAddress 
 		"--home", p.HomeDir(),
 		"--node", pdAddress,
 		"start",
-		"--bind-addr", "0.0.0.0:" + strings.Split(pclientdPort, "/")[0],
+		"--bind-addr", dockerutil.GetHostAddress() + ":" + strings.Split(pclientdPort, "/")[0],
 	}
 
 	var env []string

--- a/chain/polkadot/parachain_node.go
+++ b/chain/polkadot/parachain_node.go
@@ -247,7 +247,7 @@ func (pn *ParachainNode) CreateNodeContainer(ctx context.Context) error {
 		"--enable-offchain-indexing=true",
 		"--pruning=archive",
 		fmt.Sprintf("--prometheus-port=%s", strings.Split(prometheusPort, "/")[0]),
-		fmt.Sprintf("--listen-addr=/ip4/0.0.0.0/tcp/%s", strings.Split(nodePort, "/")[0]),
+		fmt.Sprintf("--listen-addr=/ip4/%s/tcp/%s", dockerutil.GetHostAddress(), strings.Split(nodePort, "/")[0]),
 		fmt.Sprintf("--public-addr=%s", multiAddress),
 		"--base-path", pn.NodeHome(),
 		fmt.Sprintf("--chain=%s", pn.ParachainChainSpecFilePathFull()),

--- a/chain/polkadot/relay_chain_node.go
+++ b/chain/polkadot/relay_chain_node.go
@@ -220,7 +220,7 @@ func (p *RelayChainNode) CreateNodeContainer(ctx context.Context) error {
 		"--rpc-methods=unsafe",
 		"--pruning=archive",
 		fmt.Sprintf("--prometheus-port=%s", strings.Split(prometheusPort, "/")[0]),
-		fmt.Sprintf("--listen-addr=/ip4/0.0.0.0/tcp/%s", strings.Split(nodePort, "/")[0]),
+		fmt.Sprintf("--listen-addr=/ip4/%s/tcp/%s", dockerutil.GetHostAddress(), strings.Split(nodePort, "/")[0]),
 		fmt.Sprintf("--public-addr=%s", multiAddress),
 		"--base-path", p.NodeHome(),
 	}

--- a/dockerutil/host.go
+++ b/dockerutil/host.go
@@ -1,0 +1,10 @@
+package dockerutil
+
+import "os"
+
+func GetHostAddress() string {
+	if value, ok := os.LookupEnv("ICTEST_HOST"); ok {
+		return value
+	}
+	return "0.0.0.0"
+}

--- a/dockerutil/ports.go
+++ b/dockerutil/ports.go
@@ -49,7 +49,7 @@ func GetPort(port int) (nat.PortBinding, *net.TCPListener, error) {
 	}
 
 	return nat.PortBinding{
-		HostIP:   "0.0.0.0",
+		HostIP:   GetHostAddress(),
 		HostPort: fmt.Sprint(l.Addr().(*net.TCPAddr).Port),
 	}, l, nil
 }

--- a/dockerutil/strings_test.go
+++ b/dockerutil/strings_test.go
@@ -42,6 +42,19 @@ func TestGetHostPort(t *testing.T) {
 				},
 			}, "test", "0.0.0.0:3000",
 		},
+		{
+			types.ContainerJSON{
+				NetworkSettings: &types.NetworkSettings{
+					NetworkSettingsBase: types.NetworkSettingsBase{
+						Ports: nat.PortMap{
+							nat.Port("test"): []nat.PortBinding{
+								{HostIP: GetHostAddress(), HostPort: "3000"},
+							},
+						},
+					},
+				},
+			}, "test", GetHostAddress() + ":3000",
+		},
 
 		{types.ContainerJSON{}, "", ""},
 		{types.ContainerJSON{NetworkSettings: &types.NetworkSettings{}}, "does-not-matter", ""},

--- a/examples/cosmos/ethermint_test.go
+++ b/examples/cosmos/ethermint_test.go
@@ -14,6 +14,7 @@ import (
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	"github.com/strangelove-ventures/interchaintest/v8"
 	"github.com/strangelove-ventures/interchaintest/v8/chain/cosmos"
+	"github.com/strangelove-ventures/interchaintest/v8/dockerutil"
 	"github.com/strangelove-ventures/interchaintest/v8/ibc"
 	"github.com/strangelove-ventures/interchaintest/v8/testutil"
 	"github.com/stretchr/testify/require"
@@ -86,7 +87,7 @@ func TestEthermintChain(t *testing.T) {
 	}
 
 	jsonRpcOverrides := make(testutil.Toml)
-	jsonRpcOverrides["address"] = "0.0.0.0:8545"
+	jsonRpcOverrides["address"] = dockerutil.GetHostAddress() + ":8545"
 	appTomlOverrides := make(testutil.Toml)
 	appTomlOverrides["json-rpc"] = jsonRpcOverrides
 


### PR DESCRIPTION
[Original issue from discord for local-interchain dind](https://discord.com/channels/669268347736686612/1242819763500220610)



```
Hi,
I am trying to run localchaintest on a GitLab shared runner using GitLab CI/CD. My goal is to perform some tests on it with API calls to REST endpoints. However, I am encountering a problem when using Docker-in-Docker (dind). Specifically, I am unable to successfully run localchaintest.

The issue might be related to the default 0.0.0.0 host binding.
Is there an option to override the 0.0.0.0 host to a different host binding that might resolve this issue?
Are there alternative solutions or best practices for running a testnet within the GitLab CI environment using shared runners?

My error:
\"http://0.0.0.0:26657\": dial tcp 0.0.0.0:26657: connect: connection refused\n#12: post failed: Post 

it would be great to specify container-name by flag

I had in mind another case, running local-ic on Kubernetes. It would be similar use case to gitlab one
```

# TODO:
- [x]  Validate it works (tested with 127.0.0.1 from 0.0.0.0)
- [ ] Validate it works for them with DIND
- [ ] Add to env docs