### PR TITLE
feat: PreGenesis now takes the chain instead of the chainconfig

### DIFF
--- a/chain/cosmos/cosmos_chain.go
+++ b/chain/cosmos/cosmos_chain.go
@@ -928,7 +928,7 @@ func (c *CosmosChain) Start(testName string, ctx context.Context, additionalGene
 	}
 
 	if c.cfg.PreGenesis != nil {
-		err := c.cfg.PreGenesis(chainCfg)
+		err := c.cfg.PreGenesis(c)
 		if err != nil {
 			return err
 		}

--- a/chain/cosmos/ics.go
+++ b/chain/cosmos/ics.go
@@ -278,7 +278,7 @@ func (c *CosmosChain) StartConsumer(testName string, ctx context.Context, additi
 	}
 
 	if c.cfg.PreGenesis != nil {
-		err := c.cfg.PreGenesis(chainCfg)
+		err := c.cfg.PreGenesis(c)
 		if err != nil {
 			return err
 		}

--- a/ibc/types.go
+++ b/ibc/types.go
@@ -51,7 +51,7 @@ type ChainConfig struct {
 	// When true, will skip validator gentx flow
 	SkipGenTx bool
 	// When provided, will run before performing gentx and genesis file creation steps for validators.
-	PreGenesis func(ChainConfig) error
+	PreGenesis func(Chain) error
 	// When provided, genesis file contents will be altered before sharing for genesis.
 	ModifyGenesis func(ChainConfig, []byte) ([]byte, error)
 	// Modify genesis-amounts for the validator at the given index


### PR DESCRIPTION
This allows for more dynamic PreGenesis actions, in particular running custom commands on validators. Users should be aware that the chain they're receiving isn't started