### PR TITLE
fix: upgrade proposals for SDK >= 0.47

### DIFF
--- a/chain/cosmos/module_gov.go
+++ b/chain/cosmos/module_gov.go
@@ -57,13 +57,16 @@ func (tn *ChainNode) UpgradeProposal(ctx context.Context, keyName string, prop S
 	if tn.IsAboveSDK47(ctx) {
 		cosmosChain := tn.Chain.(*CosmosChain)
 
-		authority, err := cosmosChain.GetGovernanceAddress(ctx)
-		if err != nil {
-			return "", err
+		if prop.Authority == "" {
+			authority, err := cosmosChain.GetGovernanceAddress(ctx)
+			if err != nil {
+				return "", err
+			}
+			prop.Authority = authority
 		}
 
 		msg := upgradetypes.MsgSoftwareUpgrade{
-			Authority: authority,
+			Authority: prop.Authority,
 			Plan: upgradetypes.Plan{
 				Name:   prop.Name,
 				Height: prop.Height,

--- a/chain/cosmos/module_gov.go
+++ b/chain/cosmos/module_gov.go
@@ -9,9 +9,11 @@ import (
 	"path/filepath"
 	"strconv"
 
+	upgradetypes "cosmossdk.io/x/upgrade/types"
 	govv1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
 	govv1beta1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1beta1"
 	paramsutils "github.com/cosmos/cosmos-sdk/x/params/client/utils"
+
 	"github.com/strangelove-ventures/interchaintest/v8/dockerutil"
 )
 
@@ -52,6 +54,29 @@ func (tn *ChainNode) GovSubmitProposal(ctx context.Context, keyName string, prop
 
 // UpgradeProposal submits a software-upgrade governance proposal to the chain.
 func (tn *ChainNode) UpgradeProposal(ctx context.Context, keyName string, prop SoftwareUpgradeProposal) (string, error) {
+	if tn.IsAboveSDK47(ctx) {
+		cosmosChain := tn.Chain.(*CosmosChain)
+
+		authority, err := cosmosChain.GetGovernanceAddress(ctx)
+		if err != nil {
+			return "", err
+		}
+
+		msg := upgradetypes.MsgSoftwareUpgrade{
+			Authority: authority,
+			Plan: upgradetypes.Plan{
+				Name:   prop.Name,
+				Height: prop.Height,
+				Info:   prop.Info,
+			},
+		}
+
+		proposal, err := cosmosChain.BuildProposal([]ProtoMessage{&msg}, prop.Title, prop.Description, "", prop.Deposit, prop.Proposer, prop.Expedited)
+		if err != nil {
+			return "", err
+		}
+		return tn.SubmitProposal(ctx, keyName, proposal)
+	}
 	command := []string{
 		"gov", "submit-proposal",
 		"software-upgrade", prop.Name,

--- a/chain/cosmos/types.go
+++ b/chain/cosmos/types.go
@@ -70,6 +70,7 @@ type SoftwareUpgradeProposal struct {
 	// SDK v50 only
 	Proposer  string
 	Expedited bool
+	Authority string
 }
 
 // ProposalResponse is the proposal query response.

--- a/chain/cosmos/types.go
+++ b/chain/cosmos/types.go
@@ -66,6 +66,10 @@ type SoftwareUpgradeProposal struct {
 	Description string
 	Height      int64
 	Info        string // optional
+
+	// SDK v50 only
+	Proposer  string
+	Expedited bool
 }
 
 // ProposalResponse is the proposal query response.


### PR DESCRIPTION
There's no more `submit-proposal software-upgrade` command, so it has to go through a full proposal.json