### PR TITLE
feat: Allow configuring default --gas limit for transactions.

### DIFF
--- a/chain/cosmos/chain_node.go
+++ b/chain/cosmos/chain_node.go
@@ -504,7 +504,7 @@ func (tn *ChainNode) FindTxs(ctx context.Context, height int64) ([]blockdb.Tx, e
 // with the chain node binary.
 func (tn *ChainNode) TxCommand(keyName string, command ...string) []string {
 	command = append([]string{"tx"}, command...)
-	var gasPriceFound, gasAdjustmentFound, feesFound = false, false, false
+	var gasPriceFound, gasAdjustmentFound, gasFound, feesFound = false, false, false, false
 	for i := 0; i < len(command); i++ {
 		if command[i] == "--gas-prices" {
 			gasPriceFound = true
@@ -515,12 +515,18 @@ func (tn *ChainNode) TxCommand(keyName string, command ...string) []string {
 		if command[i] == "--fees" {
 			feesFound = true
 		}
+		if command[i] == "--gas" {
+			gasFound = true
+		}
 	}
 	if !gasPriceFound && !feesFound {
 		command = append(command, "--gas-prices", tn.Chain.Config().GasPrices)
 	}
 	if !gasAdjustmentFound {
 		command = append(command, "--gas-adjustment", strconv.FormatFloat(tn.Chain.Config().GasAdjustment, 'f', -1, 64))
+	}
+	if !gasFound && !feesFound && tn.Chain.Config().Gas != "" {
+		command = append(command, "--gas", tn.Chain.Config().Gas)
 	}
 	return tn.NodeCommand(append(command,
 		"--from", keyName,

--- a/configuredChains.yaml
+++ b/configuredChains.yaml
@@ -340,6 +340,7 @@ gaia:
   denom: uatom
   gas-prices: 0.01uatom
   gas-adjustment: 2.0
+  gas: auto
   trusting-period: 504h
   images:
     - repository: ghcr.io/strangelove-ventures/heighliner/gaia

--- a/ibc/types.go
+++ b/ibc/types.go
@@ -45,7 +45,7 @@ type ChainConfig struct {
 	// Adjustment multiplier for gas fees.
 	GasAdjustment float64 `yaml:"gas-adjustment"`
 	// Default gas limit for transactions. May be empty, "auto", or a number.
-	Gas string `yaml:"gas"`
+	Gas string `yaml:"gas" default:"auto"`
 	// Trusting period of the chain.
 	TrustingPeriod string `yaml:"trusting-period"`
 	// Do not use docker host mount.
@@ -176,6 +176,10 @@ func (c ChainConfig) MergeChainSpecConfig(other ChainConfig) ChainConfig {
 
 	if other.GasAdjustment > 0 {
 		c.GasAdjustment = other.GasAdjustment
+	}
+
+	if other.Gas != "" {
+		c.Gas = other.Gas
 	}
 
 	if other.TrustingPeriod != "" {

--- a/ibc/types.go
+++ b/ibc/types.go
@@ -44,6 +44,8 @@ type ChainConfig struct {
 	GasPrices string `yaml:"gas-prices"`
 	// Adjustment multiplier for gas fees.
 	GasAdjustment float64 `yaml:"gas-adjustment"`
+	// Default gas limit for transactions. May be empty, "auto", or a number.
+	Gas string `yaml:"gas"`
 	// Trusting period of the chain.
 	TrustingPeriod string `yaml:"trusting-period"`
 	// Do not use docker host mount.


### PR DESCRIPTION
It's useful to just set "--gas auto" for all transactions. Right now, --gas auto will be set as the default for gaia chians.