### PR TITLE
feat: local chain registry endpoint

### DIFF
--- a/ibc/types.go
+++ b/ibc/types.go
@@ -426,7 +426,7 @@ type PathUpdateOptions struct {
 }
 
 type ICSConfig struct {
-	ProviderVerOverride     string `yaml:"provider,omitempty" json:"provider,omitempty"`
-	ConsumerVerOverride     string `yaml:"consumer,omitempty" json:"consumer,omitempty"`
-	ConsumerCopyProviderKey func(int) bool
+	ProviderVerOverride     string         `yaml:"provider,omitempty" json:"provider,omitempty"`
+	ConsumerVerOverride     string         `yaml:"consumer,omitempty" json:"consumer,omitempty"`
+	ConsumerCopyProviderKey func(int) bool `yaml:"-" json:"-"`
 }

--- a/local-interchain/interchain/handlers/chain_registry.go
+++ b/local-interchain/interchain/handlers/chain_registry.go
@@ -1,0 +1,31 @@
+package handlers
+
+import (
+	"net/http"
+	"os"
+)
+
+// If the chain_registry.json file is found within the current running directory, show it as an enpoint.
+// Used in: spawn
+
+type chainRegistry struct {
+	DataJSON []byte `json:"data_json"`
+}
+
+// NewChainRegistry creates a new chainRegistry with the JSON from the file at location.
+func NewChainRegistry(loc string) *chainRegistry {
+	dataJSON, err := os.ReadFile(loc)
+	if err != nil {
+		panic(err)
+	}
+
+	return &chainRegistry{
+		DataJSON: dataJSON,
+	}
+}
+
+func (cr chainRegistry) GetChainRegistry(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	w.Write(cr.DataJSON)
+}

--- a/local-interchain/interchain/router/router.go
+++ b/local-interchain/interchain/router/router.go
@@ -52,6 +52,14 @@ func NewRouter(
 		log.Printf("chain_registry.json not found in %s, not exposing endpoint.", wd)
 	}
 
+	chainRegistryAssetsFile := filepath.Join(wd, "chain_registry_assets.json")
+	if _, err := os.Stat(chainRegistryAssetsFile); err == nil {
+		crH := handlers.NewChainRegistry(chainRegistryAssetsFile)
+		r.HandleFunc("/chain_registry_assets", crH.GetChainRegistry).Methods(http.MethodGet)
+	} else {
+		log.Printf("chain_registry_assets.json not found in %s, not exposing endpoint.", wd)
+	}
+
 	actionsH := handlers.NewActions(ctx, ic, cosmosChains, vals, relayer, eRep, authKey)
 	r.HandleFunc("/", actionsH.PostActions).Methods(http.MethodPost)
 

--- a/local-interchain/interchain/router/router.go
+++ b/local-interchain/interchain/router/router.go
@@ -3,7 +3,10 @@ package router
 import (
 	"context"
 	"encoding/json"
+	"log"
 	"net/http"
+	"os"
+	"path/filepath"
 
 	"github.com/gorilla/mux"
 	ictypes "github.com/strangelove-ventures/interchaintest/local-interchain/interchain/types"
@@ -35,6 +38,19 @@ func NewRouter(
 
 	infoH := handlers.NewInfo(config, installDir, ctx, ic, cosmosChains, vals, relayer, eRep)
 	r.HandleFunc("/info", infoH.GetInfo).Methods(http.MethodGet)
+
+	wd, err := os.Getwd()
+	if err != nil {
+		panic(err)
+	}
+
+	chainRegistryFile := filepath.Join(wd, "chain_registry.json")
+	if _, err := os.Stat(chainRegistryFile); err == nil {
+		crH := handlers.NewChainRegistry(chainRegistryFile)
+		r.HandleFunc("/chain_registry", crH.GetChainRegistry).Methods(http.MethodGet)
+	} else {
+		log.Printf("chain_registry.json not found in %s, not exposing endpoint.", wd)
+	}
 
 	actionsH := handlers.NewActions(ctx, ic, cosmosChains, vals, relayer, eRep, authKey)
 	r.HandleFunc("/", actionsH.PostActions).Methods(http.MethodPost)


### PR DESCRIPTION
ref: https://github.com/rollchains/spawn/pull/194

## Summary

if the chain_registry.json file is found when running `local-ic start <name>`, it will showcase this in an easy to query way. This makes it easy to connect wallets and build existing infra on top. Better UX

![image](https://github.com/user-attachments/assets/c9158d45-68cf-4254-82aa-c8d16a65b3c9)
