### PR TITLE
refactor: docker label cleanup for running containers

### DIFF
--- a/chain/cosmos/chain_node.go
+++ b/chain/cosmos/chain_node.go
@@ -216,7 +216,7 @@ func (tn *ChainNode) CliContext() client.Context {
 
 // Name of the test node container
 func (tn *ChainNode) Name() string {
-	return fmt.Sprintf("%s-%s-%s-%d-%s", dockerutil.ICTDockerPrefix, tn.Chain.Config().ChainID, tn.NodeType(), tn.Index, dockerutil.SanitizeContainerName(tn.TestName))
+	return fmt.Sprintf("%s-%s-%d-%s", tn.Chain.Config().ChainID, tn.NodeType(), tn.Index, dockerutil.SanitizeContainerName(tn.TestName))
 }
 
 func (tn *ChainNode) NodeType() string {

--- a/chain/cosmos/sidecar.go
+++ b/chain/cosmos/sidecar.go
@@ -93,10 +93,10 @@ func NewSidecar(
 // on a per validator level.
 func (s *SidecarProcess) Name() string {
 	if s.validatorProcess {
-		return fmt.Sprintf("%s-%s-%s-val-%d-%s", dockerutil.ICTDockerPrefix, s.Chain.Config().ChainID, s.ProcessName, s.Index, dockerutil.SanitizeContainerName(s.TestName))
+		return fmt.Sprintf("-%s-%s-val-%d-%s", s.Chain.Config().ChainID, s.ProcessName, s.Index, dockerutil.SanitizeContainerName(s.TestName))
 	}
 
-	return fmt.Sprintf("%s-%s-%s-%d-%s", dockerutil.ICTDockerPrefix, s.Chain.Config().ChainID, s.ProcessName, s.Index, dockerutil.SanitizeContainerName(s.TestName))
+	return fmt.Sprintf("%s-%s-%d-%s", s.Chain.Config().ChainID, s.ProcessName, s.Index, dockerutil.SanitizeContainerName(s.TestName))
 }
 
 func (s *SidecarProcess) logger() *zap.Logger {

--- a/chain/cosmos/sidecar.go
+++ b/chain/cosmos/sidecar.go
@@ -93,7 +93,7 @@ func NewSidecar(
 // on a per validator level.
 func (s *SidecarProcess) Name() string {
 	if s.validatorProcess {
-		return fmt.Sprintf("-%s-%s-val-%d-%s", s.Chain.Config().ChainID, s.ProcessName, s.Index, dockerutil.SanitizeContainerName(s.TestName))
+		return fmt.Sprintf("%s-%s-val-%d-%s", s.Chain.Config().ChainID, s.ProcessName, s.Index, dockerutil.SanitizeContainerName(s.TestName))
 	}
 
 	return fmt.Sprintf("%s-%s-%d-%s", s.Chain.Config().ChainID, s.ProcessName, s.Index, dockerutil.SanitizeContainerName(s.TestName))

--- a/dockerutil/image.go
+++ b/dockerutil/image.go
@@ -210,7 +210,7 @@ func (image *Image) Start(ctx context.Context, cmd []string, opts ContainerOptio
 	}
 
 	var (
-		containerName = SanitizeContainerName(ICTDockerPrefix + "-" + image.testName + "-" + RandLowerCaseLetterString(6))
+		containerName = SanitizeContainerName(image.testName + "-" + RandLowerCaseLetterString(6))
 		hostName      = CondenseHostName(containerName)
 		logger        = image.log.With(
 			zap.String("command", strings.Join(cmd, " ")),

--- a/dockerutil/strings.go
+++ b/dockerutil/strings.go
@@ -13,8 +13,7 @@ import (
 )
 
 const (
-	ICTDockerPrefix     = "ict"
-	RelayerDockerPrefix = "ictrelayer"
+	ICTDockerPrefix = "interchaintest"
 )
 
 // GetHostPort returns a resource's published port with an address.

--- a/local-interchain/rust/main/src/main.rs
+++ b/local-interchain/rust/main/src/main.rs
@@ -163,7 +163,7 @@ fn test_node_information(node: &Chain) {
 
     node.get_chain_config();
 
-    assert!(node.get_name().starts_with("ict-localjuno-1-val-0"));
+    assert!(node.get_name().starts_with("localjuno-1-val-0"));
     node.get_container_id();
     node.get_host_name();
     node.get_genesis_file_content();

--- a/relayer/docker.go
+++ b/relayer/docker.go
@@ -362,7 +362,7 @@ func (r *DockerRelayer) StartRelayer(ctx context.Context, rep ibc.RelayerExecRep
 
 	containerImage := r.ContainerImage()
 	joinedPaths := strings.Join(pathNames, ".")
-	containerName := fmt.Sprintf("%s-%s-%s-%s", dockerutil.RelayerDockerPrefix, r.c.Name(), joinedPaths, dockerutil.RandLowerCaseLetterString(5))
+	containerName := fmt.Sprintf("%s-%s-%s", r.c.Name(), joinedPaths, dockerutil.RandLowerCaseLetterString(5))
 
 	cmd := r.c.StartRelayer(r.HomeDir(), pathNames...)
 
@@ -492,7 +492,7 @@ func (r *DockerRelayer) pullContainerImageIfNecessary(containerImage ibc.DockerI
 }
 
 func (r *DockerRelayer) Name() string {
-	return dockerutil.RelayerDockerPrefix + "-" + r.c.Name() + "-" + dockerutil.SanitizeContainerName(r.testName)
+	return r.c.Name() + "-" + dockerutil.SanitizeContainerName(r.testName)
 }
 
 // Bind returns the home folder bind point for running the node.
@@ -506,7 +506,7 @@ func (r *DockerRelayer) HomeDir() string {
 }
 
 func (r *DockerRelayer) HostName(pathName string) string {
-	return dockerutil.CondenseHostName(fmt.Sprintf("%s-%s-%s", dockerutil.RelayerDockerPrefix, r.c.Name(), pathName))
+	return dockerutil.CondenseHostName(fmt.Sprintf("%s-%s", r.c.Name(), pathName))
 }
 
 func (r *DockerRelayer) UseDockerNetwork() bool {


### PR DESCRIPTION
closes #1212

## Summary
The proper way to perform https://github.com/strangelove-ventures/interchaintest/pull/1206 (using hidden labels instead of name prefixes). Reverted back to previous formats, keeping the next release non api breaking)

Confirmed to work with relayers
![image](https://github.com/user-attachments/assets/825ed115-7956-4af3-acc8-9b82138a1614)

