### PR TITLE
chore(ci): retry on failed test

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -26,6 +26,9 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
 
+      - name: checkout interchaintest
+        uses: actions/checkout@v4
+
       - name: Go Mod Cache
         uses: actions/cache@v2
         with:
@@ -36,9 +39,6 @@ jobs:
         with:
           path: ${{ steps.go-cache-paths.outputs.go-build }}
           key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
-
-      - name: checkout interchaintest
-        uses: actions/checkout@v4
 
       - name: Download Go Dependencies
         run: |

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -8,16 +8,53 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+env:
+  GO_VERSION: 1.21
+
 jobs:
-  test-conformance:
+  setup-go-cache:
     name: test-conformance
     runs-on: ubuntu-latest
     steps:
-      # Install and setup go
-      - name: Set up Go 1.21
+      - id: go-cache-paths
+        run: |
+          echo "::set-output name=go-build::$(go env GOCACHE)"
+          echo "::set-output name=go-mod::$(go env GOMODCACHE)"
+
+      - name: Set up Go ${{ env.GO_VERSION }}
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Go Mod Cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.go-cache-paths.outputs.go-mod }}
+          key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
+      - name: Go Build Cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.go-cache-paths.outputs.go-build }}
+          key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
+
+      - name: checkout interchaintest
+        uses: actions/checkout@v4
+
+      - name: Download Go Dependencies
+        run: |
+          go mod download
+          cd local-interchain && go mod download
+
+  test-conformance:
+    name: test-conformance
+    runs-on: ubuntu-latest
+    needs: setup-go-cache
+    steps:
+      # Install and setup go
+      - name: Set up Go ${{ env.GO_VERSION}}
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION}}
 
       - name: checkout interchaintest
         uses: actions/checkout@v4
@@ -30,15 +67,17 @@ jobs:
       # run tests
       - name: run conformance tests
         run: (go test -race -timeout 30m -failfast -v -p 2 ./cmd/interchaintest) || (echo "\n\n*****CHAIN and RELAYER LOGS*****" && cat "$HOME/.interchaintest/logs/interchaintest.log" && exit 1)
+
   test-ibc-examples:
     name: test-ibc-examples
     runs-on: ubuntu-latest
+    needs: setup-go-cache
     steps:
       # Install and setup go
-      - name: Set up Go 1.21
+      - name: Set up Go ${{ env.GO_VERSION}}
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: ${{ env.GO_VERSION}}
           cache: false
 
       - name: checkout interchaintest
@@ -52,15 +91,17 @@ jobs:
       # run tests
       - name: run example ibc tests
         run: go test -race -timeout 30m -failfast -v -p 2 ./examples/ibc
+
   test-cosmos-examples:
     name: test-cosmos-examples
     runs-on: ubuntu-latest
+    needs: setup-go-cache
     steps:
       # Install and setup go
-      - name: Set up Go 1.21
+      - name: Set up Go ${{ env.GO_VERSION}}
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: ${{ env.GO_VERSION}}
           cache: false
 
       - name: checkout interchaintest

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -42,8 +42,9 @@ jobs:
 
       - name: Download Go Dependencies
         run: |
+          go mod tidy
           go mod download
-          cd local-interchain && go mod download
+          cd local-interchain && go mod tidy && go mod download
 
   test-conformance:
     name: test-conformance

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   setup-go-cache:
-    name: test-conformance
+    name: setup-go-cache
     runs-on: ubuntu-latest
     steps:
       - id: go-cache-paths

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -10,6 +10,9 @@ concurrency:
 
 env:
   GO_VERSION: 1.21
+  TEST_CONFORMANCE: (go test -race -timeout 30m -failfast -v -p 2 ./cmd/interchaintest) || (echo "\n\n*****CHAIN and RELAYER LOGS*****" && cat "$HOME/.interchaintest/logs/interchaintest.log" && exit 1)
+  TEST_IBC: go test -race -timeout 30m -failfast -v -p 2 ./examples/ibc
+  TEST_COSMOS: go test -race -failfast -timeout 30m -v -p 2 ./examples/cosmos
 
 jobs:
   setup-go-cache:
@@ -49,6 +52,7 @@ jobs:
   test-conformance:
     name: test-conformance
     runs-on: ubuntu-latest
+    continue-on-error: true
     needs: setup-go-cache
     steps:
       # Install and setup go
@@ -60,14 +64,25 @@ jobs:
       - name: checkout interchaintest
         uses: actions/checkout@v4
 
-      # cleanup environment on self-hosted test runner
       - name: clean
         run: |-
           rm -rf ~/.interchaintest
 
-      # run tests
       - name: run conformance tests
-        run: (go test -race -timeout 30m -failfast -v -p 2 ./cmd/interchaintest) || (echo "\n\n*****CHAIN and RELAYER LOGS*****" && cat "$HOME/.interchaintest/logs/interchaintest.log" && exit 1)
+        id: conformance_test
+        run: ${{ env.TEST_CONFORMANCE }}
+
+      - name: Retry Failed Test
+        if: steps.conformance_test.outcome == 'failure'
+        run: |
+          for i in 1 2; do
+            echo "Retry attempt $i"
+            if ${{ env.TEST_CONFORMANCE }}; then
+              echo "Test passed on retry"; exit 0
+            fi
+          done
+          echo "Test failed after retries"
+          exit 1
 
   test-ibc-examples:
     name: test-ibc-examples
@@ -84,14 +99,25 @@ jobs:
       - name: checkout interchaintest
         uses: actions/checkout@v4
 
-      # cleanup environment on self-hosted test runner
       - name: clean
         run: |-
           rm -rf ~/.interchaintest
 
-      # run tests
       - name: run example ibc tests
-        run: go test -race -timeout 30m -failfast -v -p 2 ./examples/ibc
+        id: ibc_test
+        run: ${{ env.TEST_IBC }}
+
+      - name: Retry Failed Test
+        if: steps.ibc_test.outcome == 'failure'
+        run: |
+          for i in 1 2; do
+            echo "Retry attempt $i"
+            if ${{ env.TEST_IBC }}; then
+              echo "Test passed on retry"; exit 0
+            fi
+          done
+          echo "Test failed after retries"
+          exit 1
 
   test-cosmos-examples:
     name: test-cosmos-examples
@@ -108,11 +134,22 @@ jobs:
       - name: checkout interchaintest
         uses: actions/checkout@v4
 
-      # cleanup environment on self-hosted test runner
       - name: clean
         run: |-
           rm -rf ~/.interchaintest
 
-      # run tests
       - name: run example cosmos tests
-        run: go test -race -failfast -timeout 30m -v -p 2 ./examples/cosmos
+        id: cosmos_test
+        run: ${{ env.TEST_COSMOS }}
+
+      - name: Retry Failed Test
+        if: steps.cosmos_test.outcome == 'failure'
+        run: |
+          for i in 1 2; do
+            echo "Retry attempt $i"
+            if ${{ env.TEST_COSMOS }}; then
+              echo "Test passed on retry"; exit 0
+            fi
+          done
+          echo "Test failed after retries"
+          exit 1

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -30,6 +30,9 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
 
+      - name: checkout interchaintest
+        uses: actions/checkout@v4
+
       - name: Go Mod Cache
         uses: actions/cache@v2
         with:
@@ -40,9 +43,6 @@ jobs:
         with:
           path: ${{ steps.go-cache-paths.outputs.go-build }}
           key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
-
-      - name: checkout interchaintest
-        uses: actions/checkout@v4
 
       - name: Download Go Dependencies
         run: |

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -8,8 +8,13 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+env:
+  # -short flag purposefully omitted because there are some longer unit tests
+  COMMAND: go test -race -timeout 10m -failfast -p 2 $(go list ./... | grep -v /cmd | grep -v /examples)
+
 jobs:
   test-unit:
+    continue-on-error: true
     name: unit-tests
     runs-on: ubuntu-latest
     steps:
@@ -22,7 +27,19 @@ jobs:
       - name: checkout interchaintest
         uses: actions/checkout@v4
 
-      # run tests
       - name: run unit tests
-        # -short flag purposefully omitted because there are some longer unit tests
-        run: go test -race -timeout 10m -failfast -p 2 $(go list ./... | grep -v /cmd | grep -v /examples)
+        id: run_test
+        run: ${{ env.COMMAND }}
+
+      - name: Retry Failed Test
+        if: steps.run_test.outcome == 'failure'
+        run: |
+          for i in 1 2; do
+            echo "Retry attempt $i"
+            if  ${{ env.COMMAND }}; then
+              echo "Test passed on retry"
+              exit 0
+            fi
+          done
+          echo "Test failed after retries"
+          exit 1

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -46,8 +46,9 @@ jobs:
 
       - name: Download Go Dependencies
         run: |
+          go mod tidy
           go mod download
-          cd local-interchain && go mod download
+          cd local-interchain && go mod tidy && go mod download
 
       - name: run unit tests
         id: run_test

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -11,6 +11,7 @@ concurrency:
 env:
   # -short flag purposefully omitted because there are some longer unit tests
   COMMAND: go test -race -timeout 10m -failfast -p 2 $(go list ./... | grep -v /cmd | grep -v /examples)
+  GO_VERSION: 1.21
 
 jobs:
   test-unit:
@@ -18,14 +19,35 @@ jobs:
     name: unit-tests
     runs-on: ubuntu-latest
     steps:
+      - id: go-cache-paths
+        run: |
+          echo "::set-output name=go-build::$(go env GOCACHE)"
+          echo "::set-output name=go-mod::$(go env GOMODCACHE)"
+
       # Install and setup go
-      - name: Set up Go 1.21
+      - name: Set up Go ${{ env.GO_VERSION }}
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Go Mod Cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.go-cache-paths.outputs.go-mod }}
+          key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
+      - name: Go Build Cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.go-cache-paths.outputs.go-build }}
+          key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
 
       - name: checkout interchaintest
         uses: actions/checkout@v4
+
+      - name: Download Go Dependencies
+        run: |
+          go mod download
+          cd local-interchain && go mod download
 
       - name: run unit tests
         id: run_test


### PR DESCRIPTION
## Summary
Large amounts of interchaintest usually ends up in failed containers due to docker coordination. This allows for retries on failure without re-running

## TODO: 
- [x] do for e2e
- [x] cache go deps within e2e / unit test (before run) *(note: does not seem caching the deps speeds up in any meaningful way)*
- [ ] Reduce scope of e2e to speed up testing

Credit to Dimi for this retries solution: https://github.com/CosmosContracts/juno/commit/bf140aa60045ba92b83d0cb7f3bc47a2661a4e7e