### PR TITLE
fix: error returns for queries in cosmos staking & slashing

### DIFF
--- a/chain/cosmos/module_slashing.go
+++ b/chain/cosmos/module_slashing.go
@@ -18,19 +18,28 @@ func (tn *ChainNode) SlashingUnJail(ctx context.Context, keyName string) error {
 func (c *CosmosChain) SlashingQueryParams(ctx context.Context) (*slashingtypes.Params, error) {
 	res, err := slashingtypes.NewQueryClient(c.GetNode().GrpcConn).
 		Params(ctx, &slashingtypes.QueryParamsRequest{})
-	return &res.Params, err
+	if err != nil {
+		return nil, err
+	}
+	return &res.Params, nil
 }
 
 // SlashingSigningInfo returns signing info for a validator
 func (c *CosmosChain) SlashingQuerySigningInfo(ctx context.Context, consAddress string) (*slashingtypes.ValidatorSigningInfo, error) {
 	res, err := slashingtypes.NewQueryClient(c.GetNode().GrpcConn).
 		SigningInfo(ctx, &slashingtypes.QuerySigningInfoRequest{ConsAddress: consAddress})
-	return &res.ValSigningInfo, err
+	if err != nil {
+		return nil, err
+	}
+	return &res.ValSigningInfo, nil
 }
 
 // SlashingSigningInfos returns all signing infos
 func (c *CosmosChain) SlashingQuerySigningInfos(ctx context.Context) ([]slashingtypes.ValidatorSigningInfo, error) {
 	res, err := slashingtypes.NewQueryClient(c.GetNode().GrpcConn).
 		SigningInfos(ctx, &slashingtypes.QuerySigningInfosRequest{})
-	return res.Info, err
+	if err != nil {
+		return nil, err
+	}
+	return res.Info, nil
 }

--- a/chain/cosmos/module_staking.go
+++ b/chain/cosmos/module_staking.go
@@ -84,97 +84,136 @@ func (tn *ChainNode) StakingCreateValidatorFile(
 func (c *CosmosChain) StakingQueryDelegation(ctx context.Context, valAddr string, delegator string) (*stakingtypes.DelegationResponse, error) {
 	res, err := stakingtypes.NewQueryClient(c.GetNode().GrpcConn).
 		Delegation(ctx, &stakingtypes.QueryDelegationRequest{DelegatorAddr: delegator, ValidatorAddr: valAddr})
-	return res.DelegationResponse, err
+	if err != nil {
+		return nil, err
+	}
+	return res.DelegationResponse, nil
 }
 
 // StakingQueryDelegations returns all delegations for a delegator.
 func (c *CosmosChain) StakingQueryDelegations(ctx context.Context, delegator string) ([]stakingtypes.DelegationResponse, error) {
 	res, err := stakingtypes.NewQueryClient(c.GetNode().GrpcConn).
 		DelegatorDelegations(ctx, &stakingtypes.QueryDelegatorDelegationsRequest{DelegatorAddr: delegator, Pagination: nil})
-	return res.DelegationResponses, err
+	if err != nil {
+		return nil, err
+	}
+	return res.DelegationResponses, nil
 }
 
 // StakingQueryDelegationsTo returns all delegations to a validator.
 func (c *CosmosChain) StakingQueryDelegationsTo(ctx context.Context, validator string) ([]*stakingtypes.DelegationResponse, error) {
 	res, err := stakingtypes.NewQueryClient(c.GetNode().GrpcConn).
 		ValidatorDelegations(ctx, &stakingtypes.QueryValidatorDelegationsRequest{ValidatorAddr: validator})
+	if err != nil {
+		return nil, err
+	}
 
 	var delegations []*stakingtypes.DelegationResponse
 	for _, d := range res.DelegationResponses {
 		delegations = append(delegations, &d)
 	}
 
-	return delegations, err
+	return delegations, nil
 }
 
 // StakingQueryDelegatorValidator returns a validator for a delegator.
 func (c *CosmosChain) StakingQueryDelegatorValidator(ctx context.Context, delegator string, validator string) (*stakingtypes.Validator, error) {
 	res, err := stakingtypes.NewQueryClient(c.GetNode().GrpcConn).
 		DelegatorValidator(ctx, &stakingtypes.QueryDelegatorValidatorRequest{DelegatorAddr: delegator, ValidatorAddr: validator})
-	return &res.Validator, err
+	if err != nil {
+		return nil, err
+	}
+	return &res.Validator, nil
 }
 
 // StakingQueryDelegatorValidators returns all validators for a delegator.
 func (c *CosmosChain) StakingQueryDelegatorValidators(ctx context.Context, delegator string) ([]stakingtypes.Validator, error) {
 	res, err := stakingtypes.NewQueryClient(c.GetNode().GrpcConn).
 		DelegatorValidators(ctx, &stakingtypes.QueryDelegatorValidatorsRequest{DelegatorAddr: delegator})
-	return res.Validators, err
+	if err != nil {
+		return nil, err
+	}
+	return res.Validators, nil
 }
 
 // StakingQueryHistoricalInfo returns the historical info at the given height.
 func (c *CosmosChain) StakingQueryHistoricalInfo(ctx context.Context, height int64) (*stakingtypes.HistoricalInfo, error) {
 	res, err := stakingtypes.NewQueryClient(c.GetNode().GrpcConn).
 		HistoricalInfo(ctx, &stakingtypes.QueryHistoricalInfoRequest{Height: height})
-	return res.Hist, err
+	if err != nil {
+		return nil, err
+	}
+	return res.Hist, nil
 }
 
 // StakingQueryParams returns the staking parameters.
 func (c *CosmosChain) StakingQueryParams(ctx context.Context) (*stakingtypes.Params, error) {
 	res, err := stakingtypes.NewQueryClient(c.GetNode().GrpcConn).
 		Params(ctx, &stakingtypes.QueryParamsRequest{})
-	return &res.Params, err
+	if err != nil {
+		return nil, err
+	}
+	return &res.Params, nil
 }
 
 // StakingQueryPool returns the current staking pool values.
 func (c *CosmosChain) StakingQueryPool(ctx context.Context) (*stakingtypes.Pool, error) {
 	res, err := stakingtypes.NewQueryClient(c.GetNode().GrpcConn).
 		Pool(ctx, &stakingtypes.QueryPoolRequest{})
-	return &res.Pool, err
+	if err != nil {
+		return nil, err
+	}
+	return &res.Pool, nil
 }
 
 // StakingQueryRedelegation returns a redelegation.
 func (c *CosmosChain) StakingQueryRedelegation(ctx context.Context, delegator string, srcValAddr string, dstValAddr string) ([]stakingtypes.RedelegationResponse, error) {
 	res, err := stakingtypes.NewQueryClient(c.GetNode().GrpcConn).
 		Redelegations(ctx, &stakingtypes.QueryRedelegationsRequest{DelegatorAddr: delegator, SrcValidatorAddr: srcValAddr, DstValidatorAddr: dstValAddr})
-	return res.RedelegationResponses, err
+	if err != nil {
+		return nil, err
+	}
+	return res.RedelegationResponses, nil
 }
 
 // StakingQueryUnbondingDelegation returns an unbonding delegation.
 func (c *CosmosChain) StakingQueryUnbondingDelegation(ctx context.Context, delegator string, validator string) (*stakingtypes.UnbondingDelegation, error) {
 	res, err := stakingtypes.NewQueryClient(c.GetNode().GrpcConn).
 		UnbondingDelegation(ctx, &stakingtypes.QueryUnbondingDelegationRequest{DelegatorAddr: delegator, ValidatorAddr: validator})
-	return &res.Unbond, err
+	if err != nil {
+		return nil, err
+	}
+	return &res.Unbond, nil
 }
 
 // StakingQueryUnbondingDelegations returns all unbonding delegations for a delegator.
 func (c *CosmosChain) StakingQueryUnbondingDelegations(ctx context.Context, delegator string) ([]stakingtypes.UnbondingDelegation, error) {
 	res, err := stakingtypes.NewQueryClient(c.GetNode().GrpcConn).
 		DelegatorUnbondingDelegations(ctx, &stakingtypes.QueryDelegatorUnbondingDelegationsRequest{DelegatorAddr: delegator})
-	return res.UnbondingResponses, err
+	if err != nil {
+		return nil, err
+	}
+	return res.UnbondingResponses, nil
 }
 
 // StakingQueryUnbondingDelegationsFrom returns all unbonding delegations from a validator.
 func (c *CosmosChain) StakingQueryUnbondingDelegationsFrom(ctx context.Context, validator string) ([]stakingtypes.UnbondingDelegation, error) {
 	res, err := stakingtypes.NewQueryClient(c.GetNode().GrpcConn).
 		ValidatorUnbondingDelegations(ctx, &stakingtypes.QueryValidatorUnbondingDelegationsRequest{ValidatorAddr: validator})
-	return res.UnbondingResponses, err
+	if err != nil {
+		return nil, err
+	}
+	return res.UnbondingResponses, nil
 }
 
 // StakingQueryValidator returns a validator.
 func (c *CosmosChain) StakingQueryValidator(ctx context.Context, validator string) (*stakingtypes.Validator, error) {
 	res, err := stakingtypes.NewQueryClient(c.GetNode().GrpcConn).
 		Validator(ctx, &stakingtypes.QueryValidatorRequest{ValidatorAddr: validator})
-	return &res.Validator, err
+	if err != nil {
+		return nil, err
+	}
+	return &res.Validator, nil
 }
 
 // StakingQueryValidators returns all validators.
@@ -182,5 +221,8 @@ func (c *CosmosChain) StakingQueryValidators(ctx context.Context, status string)
 	res, err := stakingtypes.NewQueryClient(c.GetNode().GrpcConn).Validators(ctx, &stakingtypes.QueryValidatorsRequest{
 		Status: status,
 	})
-	return res.Validators, err
+	if err != nil {
+		return nil, err
+	}
+	return res.Validators, nil
 }


### PR DESCRIPTION
the queries tend to reply with a nil result when they fail, so trying to access that result will cause a panic