### PR TITLE
feat(v7): override sdk v47 version check with env variable

### DIFF
--- a/chain/cosmos/chain_node.go
+++ b/chain/cosmos/chain_node.go
@@ -726,11 +726,7 @@ func (tn *ChainNode) IsAboveSDK47(ctx context.Context) bool {
 	if tn.Chain.Config().Env != nil {
 		for _, str := range tn.Chain.Config().Env {
 			if strings.Contains(str, "ICT_ABOVE_SDK_47") {
-				if strings.Contains(str, "true") {
-					return true
-				} else {
-					return false
-				}
+				return strings.Contains(str, "true")
 			}
 		}
 	}
@@ -738,11 +734,7 @@ func (tn *ChainNode) IsAboveSDK47(ctx context.Context) bool {
 	// Check OS environment variables for the SDK version.
 	env := os.Getenv("ICT_ABOVE_SDK_47")
 	if env != "" {
-		if env == "true" {
-			return true
-		} else {
-			return false
-		}
+		return env == "true"
 	}
 
 	// In SDK v47, a new genesis core command was added. This spec has many state breaking features

--- a/chain/cosmos/chain_node.go
+++ b/chain/cosmos/chain_node.go
@@ -722,6 +722,29 @@ func (tn *ChainNode) RecoverKey(ctx context.Context, keyName, mnemonic string) e
 }
 
 func (tn *ChainNode) IsAboveSDK47(ctx context.Context) bool {
+	// Check container environment variables for the SDK version.
+	if tn.Chain.Config().Env != nil {
+		for _, str := range tn.Chain.Config().Env {
+			if strings.Contains(str, "ICT_ABOVE_SDK_47") {
+				if strings.Contains(str, "true") {
+					return true
+				} else {
+					return false
+				}
+			}
+		}
+	}
+
+	// Check OS environment variables for the SDK version.
+	env := os.Getenv("ICT_ABOVE_SDK_47")
+	if env != "" {
+		if env == "true" {
+			return true
+		} else {
+			return false
+		}
+	}
+
 	// In SDK v47, a new genesis core command was added. This spec has many state breaking features
 	// so we use this to switch between new and legacy SDK logic.
 	// https://github.com/cosmos/cosmos-sdk/pull/14149

--- a/docs/envOptions.md
+++ b/docs/envOptions.md
@@ -13,3 +13,8 @@
 - `CONTAINER_LOG_TAIL`: Specifies the number of lines to display from container logs. Defaults to 50 lines.
 
 - `ICS_SPAWN_TIME_WAIT`: A go duration (e.g. 2m) that specifies how long to wait for ICS chains to spawn
+
+- `ICT_ABOVE_SDK_47`: (Set via `os.Setenv` or within the IBC Chain Config)
+
+  - Set to `"true"` to run tests that require SDK version 0.47.0 or higher. 
+  - Set to `"false"` to run tests that require SDK version 0.46.0 or lower.


### PR DESCRIPTION
Manually overrides the logic to determine if a chain is running SDK 47 or greater.