### PR TITLE
fix(query): StakingQueryDelegationsTo reusing the same object

### DIFF
--- a/chain/cosmos/module_staking.go
+++ b/chain/cosmos/module_staking.go
@@ -109,8 +109,8 @@ func (c *CosmosChain) StakingQueryDelegationsTo(ctx context.Context, validator s
 	}
 
 	var delegations []*stakingtypes.DelegationResponse
-	for _, d := range res.DelegationResponses {
-		delegations = append(delegations, &d)
+	for i := range res.DelegationResponses {
+		delegations = append(delegations, &res.DelegationResponses[i])
 	}
 
 	return delegations, nil


### PR DESCRIPTION
Related to Issue [#1261](https://github.com/strangelove-ventures/interchaintest/issues/1261)

This fix avoids reusing the same object during each iteration of the loop, preventing all elements in delegations from pointing to the same "d".