### PR TITLE
feat(consensus): alternate engine support - gordian

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v4
         with:
-          version: v1.54
+          version: v1.61.0
           only-new-issues: true
           args: --timeout=10m
 

--- a/chain/cosmos/cli/has_command.go
+++ b/chain/cosmos/cli/has_command.go
@@ -1,0 +1,20 @@
+package cli
+
+import "strings"
+
+func HasCommand(err error) bool {
+	if err == nil {
+		return true
+	}
+
+	if strings.Contains(string(err.Error()), "Error: unknown command") {
+		return false
+	}
+
+	// cmd just needed more arguments, but it is a valid command (ex: appd tx bank send)
+	if strings.Contains(string(err.Error()), "Error: accepts") {
+		return true
+	}
+
+	return false
+}

--- a/chain/cosmos/consensus/cometbft.go
+++ b/chain/cosmos/consensus/cometbft.go
@@ -10,18 +10,16 @@ import (
 	ctypes "github.com/cometbft/cometbft/rpc/core/types"
 	"github.com/strangelove-ventures/interchaintest/v8/chain/cosmos/cli"
 	"github.com/strangelove-ventures/interchaintest/v8/dockerutil"
-	"google.golang.org/grpc"
 )
 
 var _ Client = (*CometBFTClient)(nil)
 
 type CometBFTClient struct {
-	Client   rpcclient.Client
-	GrpcConn *grpc.ClientConn
+	Client rpcclient.Client
 }
 
 // NewCometBFTClient creates a new CometBFTClient.
-func NewCometBFTClient(remote string, client *http.Client, grpcConn *grpc.ClientConn) (*CometBFTClient, error) {
+func NewCometBFTClient(remote string, client *http.Client) (*CometBFTClient, error) {
 	rpcClient, err := rpchttp.NewWithClient(remote, "/websocket", client)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create CometBFT client: %w", err)
@@ -32,8 +30,7 @@ func NewCometBFTClient(remote string, client *http.Client, grpcConn *grpc.Client
 	}
 
 	return &CometBFTClient{
-		Client:   rpcClient,
-		GrpcConn: grpcConn,
+		Client: rpcClient,
 	}, nil
 }
 
@@ -75,11 +72,6 @@ func (c *CometBFTClient) Height(ctx context.Context) (int64, error) {
 	}
 
 	return s.SyncInfo.LatestBlockHeight, nil
-}
-
-// GrpcClient implements Client.
-func (c *CometBFTClient) GrpcClient() *grpc.ClientConn {
-	return c.GrpcConn
 }
 
 // Block implements Client.

--- a/chain/cosmos/consensus/cometbft.go
+++ b/chain/cosmos/consensus/cometbft.go
@@ -34,15 +34,15 @@ func NewCometBFTClient(remote string, client *http.Client) (*CometBFTClient, err
 	}, nil
 }
 
+// ClientType implements Client.
+func (c *CometBFTClient) ClientType() ClientType {
+	return CometBFT
+}
+
 // IsClient implements Client.
 func (c *CometBFTClient) IsClient(ctx context.Context, img *dockerutil.Image, bin string) bool {
 	res := img.Run(ctx, []string{bin, "cometbft"}, dockerutil.ContainerOptions{})
 	return cli.HasCommand(res.Err)
-}
-
-// Name implements Client.
-func (c *CometBFTClient) Name() string {
-	return "cometbft"
 }
 
 // IsSynced implements Client.

--- a/chain/cosmos/consensus/cometbft.go
+++ b/chain/cosmos/consensus/cometbft.go
@@ -8,6 +8,8 @@ import (
 	rpcclient "github.com/cometbft/cometbft/rpc/client"
 	rpchttp "github.com/cometbft/cometbft/rpc/client/http"
 	ctypes "github.com/cometbft/cometbft/rpc/core/types"
+	"github.com/strangelove-ventures/interchaintest/v8/chain/cosmos/cli"
+	"github.com/strangelove-ventures/interchaintest/v8/dockerutil"
 	"google.golang.org/grpc"
 )
 
@@ -35,6 +37,17 @@ func NewCometBFTClient(remote string, client *http.Client, grpcConn *grpc.Client
 	}, nil
 }
 
+// IsClient implements Client.
+func (c *CometBFTClient) IsClient(ctx context.Context, img *dockerutil.Image, bin string) bool {
+	res := img.Run(ctx, []string{bin, "cometbft"}, dockerutil.ContainerOptions{})
+	return cli.HasCommand(res.Err)
+}
+
+// Name implements Client.
+func (c *CometBFTClient) Name() string {
+	return "cometbft"
+}
+
 // IsSynced implements Client.
 func (c *CometBFTClient) IsSynced(ctx context.Context) error {
 	stat, err := c.Client.Status(ctx)
@@ -50,7 +63,7 @@ func (c *CometBFTClient) IsSynced(ctx context.Context) error {
 }
 
 // StartupFlags implements Client.
-func (c *CometBFTClient) StartFlags() string {
+func (c *CometBFTClient) StartFlags(context.Context) string {
 	return "--x-crisis-skip-assert-invariants"
 }
 
@@ -62,11 +75,6 @@ func (c *CometBFTClient) Height(ctx context.Context) (int64, error) {
 	}
 
 	return s.SyncInfo.LatestBlockHeight, nil
-}
-
-// Name implements Client.
-func (c *CometBFTClient) Name() string {
-	return "cometbft"
 }
 
 // GrpcClient implements Client.

--- a/chain/cosmos/consensus/cometbft.go
+++ b/chain/cosmos/consensus/cometbft.go
@@ -1,0 +1,90 @@
+package consensus
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	rpcclient "github.com/cometbft/cometbft/rpc/client"
+	rpchttp "github.com/cometbft/cometbft/rpc/client/http"
+	ctypes "github.com/cometbft/cometbft/rpc/core/types"
+	"google.golang.org/grpc"
+)
+
+var _ Client = (*CometBFTClient)(nil)
+
+type CometBFTClient struct {
+	Client   rpcclient.Client
+	GrpcConn *grpc.ClientConn
+}
+
+// NewCometBFTClient creates a new CometBFTClient.
+func NewCometBFTClient(remote string, client *http.Client, grpcConn *grpc.ClientConn) (*CometBFTClient, error) {
+	rpcClient, err := rpchttp.NewWithClient(remote, "/websocket", client)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create CometBFT client: %w", err)
+	}
+
+	if rpcClient == nil {
+		return nil, fmt.Errorf("failed to create CometBFT client: rpc client is nil")
+	}
+
+	return &CometBFTClient{
+		Client:   rpcClient,
+		GrpcConn: grpcConn,
+	}, nil
+}
+
+// IsSynced implements Client.
+func (c *CometBFTClient) IsSynced(ctx context.Context) error {
+	stat, err := c.Client.Status(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get status: %w", err)
+	}
+
+	if stat != nil && stat.SyncInfo.CatchingUp {
+		return fmt.Errorf("still catching up: height(%d) catching-up(%t)", stat.SyncInfo.LatestBlockHeight, stat.SyncInfo.CatchingUp)
+	}
+
+	return nil
+}
+
+// StartupFlags implements Client.
+func (c *CometBFTClient) StartFlags() string {
+	return "--x-crisis-skip-assert-invariants"
+}
+
+// Height implements Client.
+func (c *CometBFTClient) Height(ctx context.Context) (int64, error) {
+	s, err := c.Client.Status(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("tendermint rpc client status: %w", err)
+	}
+
+	return s.SyncInfo.LatestBlockHeight, nil
+}
+
+// Name implements Client.
+func (c *CometBFTClient) Name() string {
+	return "cometbft"
+}
+
+// GrpcClient implements Client.
+func (c *CometBFTClient) GrpcClient() *grpc.ClientConn {
+	return c.GrpcConn
+}
+
+// Block implements Client.
+func (c *CometBFTClient) Block(ctx context.Context, height *int64) (*ctypes.ResultBlock, error) {
+	return c.Client.Block(ctx, height)
+}
+
+// BlockResults implements Client.
+func (c *CometBFTClient) BlockResults(ctx context.Context, height *int64) (*ctypes.ResultBlockResults, error) {
+	return c.Client.BlockResults(ctx, height)
+}
+
+// Status implements Client.
+func (c *CometBFTClient) Status(ctx context.Context) (*ctypes.ResultStatus, error) {
+	return c.Client.Status(ctx)
+}

--- a/chain/cosmos/consensus/consensus.go
+++ b/chain/cosmos/consensus/consensus.go
@@ -7,7 +7,6 @@ import (
 
 	ctypes "github.com/cometbft/cometbft/rpc/core/types"
 	"github.com/strangelove-ventures/interchaintest/v8/dockerutil"
-	"google.golang.org/grpc"
 )
 
 type Client interface {
@@ -20,8 +19,6 @@ type Client interface {
 	BlockResults(ctx context.Context, height *int64) (*ctypes.ResultBlockResults, error)
 	Block(ctx context.Context, height *int64) (*ctypes.ResultBlock, error)
 	Height(ctx context.Context) (int64, error)
-
-	GrpcClient() *grpc.ClientConn
 }
 
 // GetBlankClientByName returns a blank client so non state logic (like startup params) can be used.
@@ -41,8 +38,8 @@ func NewBlankClient(ctx context.Context, img *dockerutil.Image, bin string) Clie
 	return &CometBFTClient{}
 }
 
-func NewClientFactory(remote string, client *http.Client, grpcConn *grpc.ClientConn) Client {
-	cbftClient, err := NewCometBFTClient(remote, client, grpcConn)
+func NewClientFactory(remote string, client *http.Client) Client {
+	cbftClient, err := NewCometBFTClient(remote, client)
 	if err != nil {
 		panic(err)
 	}

--- a/chain/cosmos/consensus/consensus.go
+++ b/chain/cosmos/consensus/consensus.go
@@ -1,0 +1,37 @@
+package consensus
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	ctypes "github.com/cometbft/cometbft/rpc/core/types"
+	"google.golang.org/grpc"
+)
+
+type Client interface {
+	Name() string
+	StartFlags() string
+	IsSynced(ctx context.Context) error
+
+	Status(ctx context.Context) (*ctypes.ResultStatus, error)
+	BlockResults(ctx context.Context, height *int64) (*ctypes.ResultBlockResults, error)
+	Block(ctx context.Context, height *int64) (*ctypes.ResultBlock, error)
+	Height(ctx context.Context) (int64, error)
+
+	GrpcClient() *grpc.ClientConn
+}
+
+func NewClientFactory(remote string, client *http.Client, grpcConn *grpc.ClientConn) Client {
+	cbftClient, err := NewCometBFTClient(remote, client, grpcConn)
+	if err != nil {
+		panic(err)
+	}
+
+	if cbftClient != nil {
+		fmt.Println("Using CometBFT client") // TODO: logger
+		return cbftClient
+	}
+
+	panic("NewClientFactory: No client available")
+}

--- a/chain/cosmos/consensus/consensus.go
+++ b/chain/cosmos/consensus/consensus.go
@@ -37,7 +37,8 @@ func NewBlankClient(ctx context.Context, img *dockerutil.Image, bin string) Clie
 		}
 	}
 
-	panic("NewBlankClient: No client found")
+	fmt.Printf("NewBlankClient: No client found. Defaulting to CometBFT\n")
+	return &CometBFTClient{}
 }
 
 func NewClientFactory(remote string, client *http.Client, grpcConn *grpc.ClientConn) Client {

--- a/chain/cosmos/consensus/gordian.go
+++ b/chain/cosmos/consensus/gordian.go
@@ -1,0 +1,113 @@
+package consensus
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+
+	coretypes "github.com/cometbft/cometbft/rpc/core/types"
+	"github.com/strangelove-ventures/interchaintest/v8/chain/cosmos/cli"
+	"github.com/strangelove-ventures/interchaintest/v8/dockerutil"
+)
+
+var _ Client = (*GordianClient)(nil)
+
+type GordianClient struct {
+	addr   string
+	client *http.Client
+}
+
+func NewGordianClient(addr string, client *http.Client) *GordianClient {
+	addr = strings.Replace(addr, "tcp://", "http://", 1)
+
+	return &GordianClient{
+		addr:   addr,
+		client: client,
+	}
+}
+
+// ClientType implements Client.
+func (g *GordianClient) ClientType() ClientType {
+	return Gordian
+}
+
+// Block implements Client.
+func (g *GordianClient) Block(ctx context.Context, height *int64) (*coretypes.ResultBlock, error) {
+	return &coretypes.ResultBlock{}, nil
+}
+
+// BlockResults implements Client.
+func (g *GordianClient) BlockResults(ctx context.Context, height *int64) (*coretypes.ResultBlockResults, error) {
+	return &coretypes.ResultBlockResults{}, nil
+}
+
+// Height implements Client.
+func (g *GordianClient) Height(ctx context.Context) (int64, error) {
+	type GordianCurrentBlockResponse struct {
+		VotingHeight *uint64 `protobuf:"varint,1,opt,name=voting_height,json=votingHeight,proto3,oneof" json:"voting_height,omitempty"`
+	}
+
+	// TODO: get hostname query to work
+	endpoint := fmt.Sprintf("%s/blocks/watermark", g.addr)
+	req, err := http.NewRequest("GET", endpoint, nil)
+	if err != nil {
+		log.Print(err)
+		os.Exit(1)
+	}
+	q := req.URL.Query()
+
+	// make request as JSON
+	req.Header.Set("Content-Type", "application/json")
+	req.URL.RawQuery = q.Encode()
+
+	// client := &http.Client{}
+	resp, err := g.client.Do(req)
+	if err != nil {
+		log.Print(err)
+		os.Exit(1)
+	}
+	defer resp.Body.Close()
+
+	var watermark GordianCurrentBlockResponse
+	if err := json.NewDecoder(resp.Body).Decode(&watermark); err != nil {
+		log.Print(err)
+		os.Exit(1)
+	}
+
+	return int64(*watermark.VotingHeight), nil
+}
+
+// IsClient implements Client.
+func (g *GordianClient) IsClient(ctx context.Context, img *dockerutil.Image, bin string) bool {
+	res := img.Run(ctx, []string{bin, "gordian"}, dockerutil.ContainerOptions{})
+	return cli.HasCommand(res.Err)
+}
+
+// IsSynced implements Client.
+func (g *GordianClient) IsSynced(ctx context.Context) error {
+	// TODO:
+	h, err := g.Height(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get height: %w", err)
+	}
+
+	if h > 0 {
+		return nil
+	}
+
+	return fmt.Errorf("height is 0")
+}
+
+// StartFlags implements Client.
+func (g *GordianClient) StartFlags(context.Context) string {
+	return ""
+}
+
+// Status implements Client.
+func (g *GordianClient) Status(ctx context.Context) (*coretypes.ResultStatus, error) {
+	return &coretypes.ResultStatus{}, nil
+}

--- a/chain/cosmos/cosmos_chain.go
+++ b/chain/cosmos/cosmos_chain.go
@@ -218,7 +218,7 @@ func (c *CosmosChain) GetNode() *ChainNode {
 }
 
 func (c *CosmosChain) GetNodeGRPC() *grpc.ClientConn {
-	return c.GetNode().ConsensusClient.GrpcClient()
+	return c.GetNode().GRPCClient
 }
 
 // Exec implements ibc.Chain.

--- a/chain/cosmos/cosmos_chain.go
+++ b/chain/cosmos/cosmos_chain.go
@@ -38,6 +38,7 @@ import (
 	"github.com/strangelove-ventures/interchaintest/v8/testutil"
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
+	grpc "google.golang.org/grpc"
 )
 
 // CosmosChain is a local docker testnet for a Cosmos SDK chain.
@@ -214,6 +215,10 @@ func (c *CosmosChain) getFullNode() *ChainNode {
 
 func (c *CosmosChain) GetNode() *ChainNode {
 	return c.Validators[0]
+}
+
+func (c *CosmosChain) GetNodeGRPC() *grpc.ClientConn {
+	return c.GetNode().ConsensusClient.GrpcClient()
 }
 
 // Exec implements ibc.Chain.
@@ -1077,7 +1082,7 @@ func (c *CosmosChain) Height(ctx context.Context) (int64, error) {
 // Acknowledgements implements ibc.Chain, returning all acknowledgments in block at height
 func (c *CosmosChain) Acknowledgements(ctx context.Context, height int64) ([]ibc.PacketAcknowledgement, error) {
 	var acks []*chanTypes.MsgAcknowledgement
-	err := RangeBlockMessages(ctx, c.cfg.EncodingConfig.InterfaceRegistry, c.getFullNode().Client, height, func(msg types.Msg) bool {
+	err := RangeBlockMessages(ctx, c.cfg.EncodingConfig.InterfaceRegistry, c.getFullNode().ConsensusClient, height, func(msg types.Msg) bool {
 		found, ok := msg.(*chanTypes.MsgAcknowledgement)
 		if ok {
 			acks = append(acks, found)
@@ -1110,7 +1115,7 @@ func (c *CosmosChain) Acknowledgements(ctx context.Context, height int64) ([]ibc
 // Timeouts implements ibc.Chain, returning all timeouts in block at height
 func (c *CosmosChain) Timeouts(ctx context.Context, height int64) ([]ibc.PacketTimeout, error) {
 	var timeouts []*chanTypes.MsgTimeout
-	err := RangeBlockMessages(ctx, c.cfg.EncodingConfig.InterfaceRegistry, c.getFullNode().Client, height, func(msg types.Msg) bool {
+	err := RangeBlockMessages(ctx, c.cfg.EncodingConfig.InterfaceRegistry, c.getFullNode().ConsensusClient, height, func(msg types.Msg) bool {
 		found, ok := msg.(*chanTypes.MsgTimeout)
 		if ok {
 			timeouts = append(timeouts, found)

--- a/chain/cosmos/module_auth.go
+++ b/chain/cosmos/module_auth.go
@@ -12,7 +12,7 @@ import (
 
 // AuthQueryAccount performs a query to get the account details of the specified address
 func (c *CosmosChain) AuthQueryAccount(ctx context.Context, addr string) (*cdctypes.Any, error) {
-	res, err := authtypes.NewQueryClient(c.GetNode().GrpcConn).Account(ctx, &authtypes.QueryAccountRequest{
+	res, err := authtypes.NewQueryClient(c.GetNodeGRPC()).Account(ctx, &authtypes.QueryAccountRequest{
 		Address: addr,
 	})
 	return res.Account, err
@@ -20,13 +20,13 @@ func (c *CosmosChain) AuthQueryAccount(ctx context.Context, addr string) (*cdcty
 
 // AuthQueryParams performs a query to get the auth module parameters
 func (c *CosmosChain) AuthQueryParams(ctx context.Context) (*authtypes.Params, error) {
-	res, err := authtypes.NewQueryClient(c.GetNode().GrpcConn).Params(ctx, &authtypes.QueryParamsRequest{})
+	res, err := authtypes.NewQueryClient(c.GetNodeGRPC()).Params(ctx, &authtypes.QueryParamsRequest{})
 	return &res.Params, err
 }
 
 // AuthQueryModuleAccounts performs a query to get the account details of all the chain modules
 func (c *CosmosChain) AuthQueryModuleAccounts(ctx context.Context) ([]authtypes.ModuleAccount, error) {
-	res, err := authtypes.NewQueryClient(c.GetNode().GrpcConn).ModuleAccounts(ctx, &authtypes.QueryModuleAccountsRequest{})
+	res, err := authtypes.NewQueryClient(c.GetNodeGRPC()).ModuleAccounts(ctx, &authtypes.QueryModuleAccountsRequest{})
 
 	maccs := make([]authtypes.ModuleAccount, len(res.Accounts))
 
@@ -44,7 +44,7 @@ func (c *CosmosChain) AuthQueryModuleAccounts(ctx context.Context) ([]authtypes.
 
 // AuthGetModuleAccount performs a query to get the account details of the specified chain module
 func (c *CosmosChain) AuthQueryModuleAccount(ctx context.Context, moduleName string) (authtypes.ModuleAccount, error) {
-	res, err := authtypes.NewQueryClient(c.GetNode().GrpcConn).ModuleAccountByName(ctx, &authtypes.QueryModuleAccountByNameRequest{
+	res, err := authtypes.NewQueryClient(c.GetNodeGRPC()).ModuleAccountByName(ctx, &authtypes.QueryModuleAccountByNameRequest{
 		Name: moduleName,
 	})
 	if err != nil {
@@ -78,13 +78,13 @@ func (c *CosmosChain) GetGovernanceAddress(ctx context.Context) (string, error) 
 }
 
 func (c *CosmosChain) AuthQueryBech32Prefix(ctx context.Context) (string, error) {
-	res, err := authtypes.NewQueryClient(c.GetNode().GrpcConn).Bech32Prefix(ctx, &authtypes.Bech32PrefixRequest{})
+	res, err := authtypes.NewQueryClient(c.GetNodeGRPC()).Bech32Prefix(ctx, &authtypes.Bech32PrefixRequest{})
 	return res.Bech32Prefix, err
 }
 
 // AddressBytesToString converts a byte array address to a string
 func (c *CosmosChain) AuthAddressBytesToString(ctx context.Context, addrBz []byte) (string, error) {
-	res, err := authtypes.NewQueryClient(c.GetNode().GrpcConn).AddressBytesToString(ctx, &authtypes.AddressBytesToStringRequest{
+	res, err := authtypes.NewQueryClient(c.GetNodeGRPC()).AddressBytesToString(ctx, &authtypes.AddressBytesToStringRequest{
 		AddressBytes: addrBz,
 	})
 	return res.AddressString, err
@@ -92,7 +92,7 @@ func (c *CosmosChain) AuthAddressBytesToString(ctx context.Context, addrBz []byt
 
 // AddressStringToBytes converts a string address to a byte array
 func (c *CosmosChain) AuthAddressStringToBytes(ctx context.Context, addr string) ([]byte, error) {
-	res, err := authtypes.NewQueryClient(c.GetNode().GrpcConn).AddressStringToBytes(ctx, &authtypes.AddressStringToBytesRequest{
+	res, err := authtypes.NewQueryClient(c.GetNodeGRPC()).AddressStringToBytes(ctx, &authtypes.AddressStringToBytesRequest{
 		AddressString: addr,
 	})
 	return res.AddressBytes, err
@@ -100,7 +100,7 @@ func (c *CosmosChain) AuthAddressStringToBytes(ctx context.Context, addr string)
 
 // AccountInfo queries the account information of the given address
 func (c *CosmosChain) AuthQueryAccountInfo(ctx context.Context, addr string) (*authtypes.BaseAccount, error) {
-	res, err := authtypes.NewQueryClient(c.GetNode().GrpcConn).AccountInfo(ctx, &authtypes.QueryAccountInfoRequest{
+	res, err := authtypes.NewQueryClient(c.GetNodeGRPC()).AccountInfo(ctx, &authtypes.QueryAccountInfoRequest{
 		Address: addr,
 	})
 	return res.Info, err

--- a/chain/cosmos/module_authz.go
+++ b/chain/cosmos/module_authz.go
@@ -83,7 +83,7 @@ func (tn *ChainNode) AuthzRevoke(ctx context.Context, granter ibc.Wallet, grante
 
 // AuthzQueryGrants queries all grants for a given granter and grantee.
 func (c *CosmosChain) AuthzQueryGrants(ctx context.Context, granter string, grantee string, msgType string, extraFlags ...string) ([]*authz.Grant, error) {
-	res, err := authz.NewQueryClient(c.GetNode().GrpcConn).Grants(ctx, &authz.QueryGrantsRequest{
+	res, err := authz.NewQueryClient(c.GetNodeGRPC()).Grants(ctx, &authz.QueryGrantsRequest{
 		Granter:    granter,
 		Grantee:    grantee,
 		MsgTypeUrl: msgType,
@@ -93,7 +93,7 @@ func (c *CosmosChain) AuthzQueryGrants(ctx context.Context, granter string, gran
 
 // AuthzQueryGrantsByGrantee queries all grants for a given grantee.
 func (c *CosmosChain) AuthzQueryGrantsByGrantee(ctx context.Context, grantee string, extraFlags ...string) ([]*authz.GrantAuthorization, error) {
-	res, err := authz.NewQueryClient(c.GetNode().GrpcConn).GranteeGrants(ctx, &authz.QueryGranteeGrantsRequest{
+	res, err := authz.NewQueryClient(c.GetNodeGRPC()).GranteeGrants(ctx, &authz.QueryGranteeGrantsRequest{
 		Grantee: grantee,
 	})
 	return res.Grants, err
@@ -101,7 +101,7 @@ func (c *CosmosChain) AuthzQueryGrantsByGrantee(ctx context.Context, grantee str
 
 // AuthzQueryGrantsByGranter returns all grants for a granter.
 func (c *CosmosChain) AuthzQueryGrantsByGranter(ctx context.Context, granter string, extraFlags ...string) ([]*authz.GrantAuthorization, error) {
-	res, err := authz.NewQueryClient(c.GetNode().GrpcConn).GranterGrants(ctx, &authz.QueryGranterGrantsRequest{
+	res, err := authz.NewQueryClient(c.GetNodeGRPC()).GranterGrants(ctx, &authz.QueryGranterGrantsRequest{
 		Granter: granter,
 	})
 	return res.Grants, err

--- a/chain/cosmos/module_bank.go
+++ b/chain/cosmos/module_bank.go
@@ -49,51 +49,51 @@ func (c *CosmosChain) GetBalance(ctx context.Context, address string, denom stri
 
 // BankGetBalance is an alias for GetBalance
 func (c *CosmosChain) BankQueryBalance(ctx context.Context, address string, denom string) (sdkmath.Int, error) {
-	res, err := banktypes.NewQueryClient(c.GetNode().GrpcConn).Balance(ctx, &banktypes.QueryBalanceRequest{Address: address, Denom: denom})
+	res, err := banktypes.NewQueryClient(c.GetNodeGRPC()).Balance(ctx, &banktypes.QueryBalanceRequest{Address: address, Denom: denom})
 	return res.Balance.Amount, err
 }
 
 // AllBalances fetches an account address's balance for all denoms it holds
 func (c *CosmosChain) BankQueryAllBalances(ctx context.Context, address string) (types.Coins, error) {
-	res, err := banktypes.NewQueryClient(c.GetNode().GrpcConn).AllBalances(ctx, &banktypes.QueryAllBalancesRequest{Address: address})
+	res, err := banktypes.NewQueryClient(c.GetNodeGRPC()).AllBalances(ctx, &banktypes.QueryAllBalancesRequest{Address: address})
 	return res.GetBalances(), err
 }
 
 // BankDenomMetadata fetches the metadata of a specific coin denomination
 func (c *CosmosChain) BankQueryDenomMetadata(ctx context.Context, denom string) (*banktypes.Metadata, error) {
-	res, err := banktypes.NewQueryClient(c.GetNode().GrpcConn).DenomMetadata(ctx, &banktypes.QueryDenomMetadataRequest{Denom: denom})
+	res, err := banktypes.NewQueryClient(c.GetNodeGRPC()).DenomMetadata(ctx, &banktypes.QueryDenomMetadataRequest{Denom: denom})
 	return &res.Metadata, err
 }
 
 func (c *CosmosChain) BankQueryDenomMetadataByQueryString(ctx context.Context, denom string) (*banktypes.Metadata, error) {
-	res, err := banktypes.NewQueryClient(c.GetNode().GrpcConn).DenomMetadataByQueryString(ctx, &banktypes.QueryDenomMetadataByQueryStringRequest{Denom: denom})
+	res, err := banktypes.NewQueryClient(c.GetNodeGRPC()).DenomMetadataByQueryString(ctx, &banktypes.QueryDenomMetadataByQueryStringRequest{Denom: denom})
 	return &res.Metadata, err
 }
 
 func (c *CosmosChain) BankQueryDenomOwners(ctx context.Context, denom string) ([]*banktypes.DenomOwner, error) {
-	res, err := banktypes.NewQueryClient(c.GetNode().GrpcConn).DenomOwners(ctx, &banktypes.QueryDenomOwnersRequest{Denom: denom})
+	res, err := banktypes.NewQueryClient(c.GetNodeGRPC()).DenomOwners(ctx, &banktypes.QueryDenomOwnersRequest{Denom: denom})
 	return res.DenomOwners, err
 }
 
 func (c *CosmosChain) BankQueryDenomsMetadata(ctx context.Context) ([]banktypes.Metadata, error) {
-	res, err := banktypes.NewQueryClient(c.GetNode().GrpcConn).DenomsMetadata(ctx, &banktypes.QueryDenomsMetadataRequest{})
+	res, err := banktypes.NewQueryClient(c.GetNodeGRPC()).DenomsMetadata(ctx, &banktypes.QueryDenomsMetadataRequest{})
 	return res.Metadatas, err
 }
 
 func (c *CosmosChain) BankQueryParams(ctx context.Context) (*banktypes.Params, error) {
-	res, err := banktypes.NewQueryClient(c.GetNode().GrpcConn).Params(ctx, &banktypes.QueryParamsRequest{})
+	res, err := banktypes.NewQueryClient(c.GetNodeGRPC()).Params(ctx, &banktypes.QueryParamsRequest{})
 	return &res.Params, err
 }
 
 func (c *CosmosChain) BankQuerySendEnabled(ctx context.Context, denoms []string) ([]*banktypes.SendEnabled, error) {
-	res, err := banktypes.NewQueryClient(c.GetNode().GrpcConn).SendEnabled(ctx, &banktypes.QuerySendEnabledRequest{
+	res, err := banktypes.NewQueryClient(c.GetNodeGRPC()).SendEnabled(ctx, &banktypes.QuerySendEnabledRequest{
 		Denoms: denoms,
 	})
 	return res.SendEnabled, err
 }
 
 func (c *CosmosChain) BankQuerySpendableBalance(ctx context.Context, address, denom string) (*types.Coin, error) {
-	res, err := banktypes.NewQueryClient(c.GetNode().GrpcConn).SpendableBalanceByDenom(ctx, &banktypes.QuerySpendableBalanceByDenomRequest{
+	res, err := banktypes.NewQueryClient(c.GetNodeGRPC()).SpendableBalanceByDenom(ctx, &banktypes.QuerySpendableBalanceByDenomRequest{
 		Address: address,
 		Denom:   denom,
 	})
@@ -101,17 +101,17 @@ func (c *CosmosChain) BankQuerySpendableBalance(ctx context.Context, address, de
 }
 
 func (c *CosmosChain) BankQuerySpendableBalances(ctx context.Context, address string) (*types.Coins, error) {
-	res, err := banktypes.NewQueryClient(c.GetNode().GrpcConn).SpendableBalances(ctx, &banktypes.QuerySpendableBalancesRequest{Address: address})
+	res, err := banktypes.NewQueryClient(c.GetNodeGRPC()).SpendableBalances(ctx, &banktypes.QuerySpendableBalancesRequest{Address: address})
 	return &res.Balances, err
 }
 
 func (c *CosmosChain) BankQueryTotalSupply(ctx context.Context) (*types.Coins, error) {
-	res, err := banktypes.NewQueryClient(c.GetNode().GrpcConn).TotalSupply(ctx, &banktypes.QueryTotalSupplyRequest{})
+	res, err := banktypes.NewQueryClient(c.GetNodeGRPC()).TotalSupply(ctx, &banktypes.QueryTotalSupplyRequest{})
 	return &res.Supply, err
 }
 
 func (c *CosmosChain) BankQueryTotalSupplyOf(ctx context.Context, address string) (*types.Coin, error) {
-	res, err := banktypes.NewQueryClient(c.GetNode().GrpcConn).SupplyOf(ctx, &banktypes.QuerySupplyOfRequest{Denom: address})
+	res, err := banktypes.NewQueryClient(c.GetNodeGRPC()).SupplyOf(ctx, &banktypes.QuerySupplyOfRequest{Denom: address})
 
 	return &res.Amount, err
 }

--- a/chain/cosmos/module_distribution.go
+++ b/chain/cosmos/module_distribution.go
@@ -55,7 +55,7 @@ func (tn *ChainNode) DistributionWithdrawValidatorRewards(ctx context.Context, k
 
 // DistributionCommission returns the validator's commission
 func (c *CosmosChain) DistributionQueryCommission(ctx context.Context, valAddr string) (*distrtypes.ValidatorAccumulatedCommission, error) {
-	res, err := distrtypes.NewQueryClient(c.GetNode().GrpcConn).
+	res, err := distrtypes.NewQueryClient(c.GetNodeGRPC()).
 		ValidatorCommission(ctx, &distrtypes.QueryValidatorCommissionRequest{
 			ValidatorAddress: valAddr,
 		})
@@ -64,42 +64,42 @@ func (c *CosmosChain) DistributionQueryCommission(ctx context.Context, valAddr s
 
 // DistributionCommunityPool returns the community pool
 func (c *CosmosChain) DistributionQueryCommunityPool(ctx context.Context) (*sdk.DecCoins, error) {
-	res, err := distrtypes.NewQueryClient(c.GetNode().GrpcConn).
+	res, err := distrtypes.NewQueryClient(c.GetNodeGRPC()).
 		CommunityPool(ctx, &distrtypes.QueryCommunityPoolRequest{})
 	return &res.Pool, err
 }
 
 // DistributionDelegationTotalRewards returns the delegator's total rewards
 func (c *CosmosChain) DistributionQueryDelegationTotalRewards(ctx context.Context, delegatorAddr string) (*distrtypes.QueryDelegationTotalRewardsResponse, error) {
-	res, err := distrtypes.NewQueryClient(c.GetNode().GrpcConn).
+	res, err := distrtypes.NewQueryClient(c.GetNodeGRPC()).
 		DelegationTotalRewards(ctx, &distrtypes.QueryDelegationTotalRewardsRequest{DelegatorAddress: delegatorAddr})
 	return res, err
 }
 
 // DistributionDelegatorValidators returns the delegator's validators
 func (c *CosmosChain) DistributionQueryDelegatorValidators(ctx context.Context, delegatorAddr string) (*distrtypes.QueryDelegatorValidatorsResponse, error) {
-	res, err := distrtypes.NewQueryClient(c.GetNode().GrpcConn).
+	res, err := distrtypes.NewQueryClient(c.GetNodeGRPC()).
 		DelegatorValidators(ctx, &distrtypes.QueryDelegatorValidatorsRequest{DelegatorAddress: delegatorAddr})
 	return res, err
 }
 
 // DistributionDelegatorWithdrawAddress returns the delegator's withdraw address
 func (c *CosmosChain) DistributionQueryDelegatorWithdrawAddress(ctx context.Context, delegatorAddr string) (string, error) {
-	res, err := distrtypes.NewQueryClient(c.GetNode().GrpcConn).
+	res, err := distrtypes.NewQueryClient(c.GetNodeGRPC()).
 		DelegatorWithdrawAddress(ctx, &distrtypes.QueryDelegatorWithdrawAddressRequest{DelegatorAddress: delegatorAddr})
 	return res.WithdrawAddress, err
 }
 
 // DistributionParams returns the distribution params
 func (c *CosmosChain) DistributionQueryParams(ctx context.Context) (*distrtypes.Params, error) {
-	res, err := distrtypes.NewQueryClient(c.GetNode().GrpcConn).
+	res, err := distrtypes.NewQueryClient(c.GetNodeGRPC()).
 		Params(ctx, &distrtypes.QueryParamsRequest{})
 	return &res.Params, err
 }
 
 // DistributionRewards returns the delegator's rewards
 func (c *CosmosChain) DistributionQueryRewards(ctx context.Context, delegatorAddr, valAddr string) (sdk.DecCoins, error) {
-	res, err := distrtypes.NewQueryClient(c.GetNode().GrpcConn).
+	res, err := distrtypes.NewQueryClient(c.GetNodeGRPC()).
 		DelegationRewards(ctx, &distrtypes.QueryDelegationRewardsRequest{
 			DelegatorAddress: delegatorAddr,
 			ValidatorAddress: valAddr,
@@ -109,21 +109,21 @@ func (c *CosmosChain) DistributionQueryRewards(ctx context.Context, delegatorAdd
 
 // DistributionValidatorSlashes returns the validator's slashes
 func (c *CosmosChain) DistributionQueryValidatorSlashes(ctx context.Context, valAddr string) ([]distrtypes.ValidatorSlashEvent, error) {
-	res, err := distrtypes.NewQueryClient(c.GetNode().GrpcConn).
+	res, err := distrtypes.NewQueryClient(c.GetNodeGRPC()).
 		ValidatorSlashes(ctx, &distrtypes.QueryValidatorSlashesRequest{ValidatorAddress: valAddr})
 	return res.Slashes, err
 }
 
 // DistributionValidatorDistributionInfo returns the validator's distribution info
 func (c *CosmosChain) DistributionQueryValidatorDistributionInfo(ctx context.Context, valAddr string) (*distrtypes.QueryValidatorDistributionInfoResponse, error) {
-	res, err := distrtypes.NewQueryClient(c.GetNode().GrpcConn).
+	res, err := distrtypes.NewQueryClient(c.GetNodeGRPC()).
 		ValidatorDistributionInfo(ctx, &distrtypes.QueryValidatorDistributionInfoRequest{ValidatorAddress: valAddr})
 	return res, err
 }
 
 // DistributionValidatorOutstandingRewards returns the validator's outstanding rewards
 func (c *CosmosChain) DistributionQueryValidatorOutstandingRewards(ctx context.Context, valAddr string) (*distrtypes.ValidatorOutstandingRewards, error) {
-	res, err := distrtypes.NewQueryClient(c.GetNode().GrpcConn).
+	res, err := distrtypes.NewQueryClient(c.GetNodeGRPC()).
 		ValidatorOutstandingRewards(ctx, &distrtypes.QueryValidatorOutstandingRewardsRequest{ValidatorAddress: valAddr})
 	return &res.Rewards, err
 }

--- a/chain/cosmos/module_feegrant.go
+++ b/chain/cosmos/module_feegrant.go
@@ -40,7 +40,7 @@ func (tn *ChainNode) FeeGrantRevoke(ctx context.Context, keyName, granterAddr, g
 
 // FeeGrantGetAllowance returns the allowance of a granter and grantee pair.
 func (c *CosmosChain) FeeGrantQueryAllowance(ctx context.Context, granter, grantee string) (*feegrant.Grant, error) {
-	res, err := feegrant.NewQueryClient(c.GetNode().GrpcConn).Allowance(ctx, &feegrant.QueryAllowanceRequest{
+	res, err := feegrant.NewQueryClient(c.GetNodeGRPC()).Allowance(ctx, &feegrant.QueryAllowanceRequest{
 		Granter: granter,
 		Grantee: grantee,
 	})
@@ -49,7 +49,7 @@ func (c *CosmosChain) FeeGrantQueryAllowance(ctx context.Context, granter, grant
 
 // FeeGrantGetAllowances returns all allowances of a grantee.
 func (c *CosmosChain) FeeGrantQueryAllowances(ctx context.Context, grantee string) ([]*feegrant.Grant, error) {
-	res, err := feegrant.NewQueryClient(c.GetNode().GrpcConn).Allowances(ctx, &feegrant.QueryAllowancesRequest{
+	res, err := feegrant.NewQueryClient(c.GetNodeGRPC()).Allowances(ctx, &feegrant.QueryAllowancesRequest{
 		Grantee: grantee,
 	})
 	return res.Allowances, err
@@ -57,7 +57,7 @@ func (c *CosmosChain) FeeGrantQueryAllowances(ctx context.Context, grantee strin
 
 // FeeGrantGetAllowancesByGranter returns all allowances of a granter.
 func (c *CosmosChain) FeeGrantQueryAllowancesByGranter(ctx context.Context, granter string) ([]*feegrant.Grant, error) {
-	res, err := feegrant.NewQueryClient(c.GetNode().GrpcConn).AllowancesByGranter(ctx, &feegrant.QueryAllowancesByGranterRequest{
+	res, err := feegrant.NewQueryClient(c.GetNodeGRPC()).AllowancesByGranter(ctx, &feegrant.QueryAllowancesByGranterRequest{
 		Granter: granter,
 	})
 	return res.Allowances, err

--- a/chain/cosmos/module_gov.go
+++ b/chain/cosmos/module_gov.go
@@ -170,7 +170,7 @@ func (c *CosmosChain) BuildProposal(messages []ProtoMessage, title, summary, met
 
 // GovQueryProposal returns the state and details of a v1beta1 governance proposal.
 func (c *CosmosChain) GovQueryProposal(ctx context.Context, proposalID uint64) (*govv1beta1.Proposal, error) {
-	res, err := govv1beta1.NewQueryClient(c.GetNode().GrpcConn).Proposal(ctx, &govv1beta1.QueryProposalRequest{ProposalId: proposalID})
+	res, err := govv1beta1.NewQueryClient(c.GetNodeGRPC()).Proposal(ctx, &govv1beta1.QueryProposalRequest{ProposalId: proposalID})
 	if err != nil {
 		return nil, err
 	}
@@ -180,7 +180,7 @@ func (c *CosmosChain) GovQueryProposal(ctx context.Context, proposalID uint64) (
 
 // GovQueryProposalV1 returns the state and details of a v1 governance proposal.
 func (c *CosmosChain) GovQueryProposalV1(ctx context.Context, proposalID uint64) (*govv1.Proposal, error) {
-	res, err := govv1.NewQueryClient(c.GetNode().GrpcConn).Proposal(ctx, &govv1.QueryProposalRequest{ProposalId: proposalID})
+	res, err := govv1.NewQueryClient(c.GetNodeGRPC()).Proposal(ctx, &govv1.QueryProposalRequest{ProposalId: proposalID})
 	if err != nil {
 		return nil, err
 	}
@@ -190,7 +190,7 @@ func (c *CosmosChain) GovQueryProposalV1(ctx context.Context, proposalID uint64)
 
 // GovQueryProposalsV1 returns all proposals with a given status.
 func (c *CosmosChain) GovQueryProposalsV1(ctx context.Context, status govv1.ProposalStatus) ([]*govv1.Proposal, error) {
-	res, err := govv1.NewQueryClient(c.GetNode().GrpcConn).Proposals(ctx, &govv1.QueryProposalsRequest{
+	res, err := govv1.NewQueryClient(c.GetNodeGRPC()).Proposals(ctx, &govv1.QueryProposalsRequest{
 		ProposalStatus: status,
 	})
 	if err != nil {
@@ -202,7 +202,7 @@ func (c *CosmosChain) GovQueryProposalsV1(ctx context.Context, status govv1.Prop
 
 // GovQueryVote returns the vote for a proposal from a specific voter.
 func (c *CosmosChain) GovQueryVote(ctx context.Context, proposalID uint64, voter string) (*govv1.Vote, error) {
-	res, err := govv1.NewQueryClient(c.GetNode().GrpcConn).Vote(ctx, &govv1.QueryVoteRequest{
+	res, err := govv1.NewQueryClient(c.GetNodeGRPC()).Vote(ctx, &govv1.QueryVoteRequest{
 		ProposalId: proposalID,
 		Voter:      voter,
 	})
@@ -215,7 +215,7 @@ func (c *CosmosChain) GovQueryVote(ctx context.Context, proposalID uint64, voter
 
 // GovQueryVotes returns all votes for a proposal.
 func (c *CosmosChain) GovQueryVotes(ctx context.Context, proposalID uint64) ([]*govv1.Vote, error) {
-	res, err := govv1.NewQueryClient(c.GetNode().GrpcConn).Votes(ctx, &govv1.QueryVotesRequest{
+	res, err := govv1.NewQueryClient(c.GetNodeGRPC()).Votes(ctx, &govv1.QueryVotesRequest{
 		ProposalId: proposalID,
 	})
 	if err != nil {
@@ -227,7 +227,7 @@ func (c *CosmosChain) GovQueryVotes(ctx context.Context, proposalID uint64) ([]*
 
 // GovQueryParams returns the current governance parameters.
 func (c *CosmosChain) GovQueryParams(ctx context.Context, paramsType string) (*govv1.Params, error) {
-	res, err := govv1.NewQueryClient(c.GetNode().GrpcConn).Params(ctx, &govv1.QueryParamsRequest{
+	res, err := govv1.NewQueryClient(c.GetNodeGRPC()).Params(ctx, &govv1.QueryParamsRequest{
 		ParamsType: paramsType,
 	})
 	if err != nil {

--- a/chain/cosmos/module_slashing.go
+++ b/chain/cosmos/module_slashing.go
@@ -16,7 +16,7 @@ func (tn *ChainNode) SlashingUnJail(ctx context.Context, keyName string) error {
 
 // SlashingGetParams returns slashing params
 func (c *CosmosChain) SlashingQueryParams(ctx context.Context) (*slashingtypes.Params, error) {
-	res, err := slashingtypes.NewQueryClient(c.GetNode().GrpcConn).
+	res, err := slashingtypes.NewQueryClient(c.GetNodeGRPC()).
 		Params(ctx, &slashingtypes.QueryParamsRequest{})
 	if err != nil {
 		return nil, err
@@ -26,7 +26,7 @@ func (c *CosmosChain) SlashingQueryParams(ctx context.Context) (*slashingtypes.P
 
 // SlashingSigningInfo returns signing info for a validator
 func (c *CosmosChain) SlashingQuerySigningInfo(ctx context.Context, consAddress string) (*slashingtypes.ValidatorSigningInfo, error) {
-	res, err := slashingtypes.NewQueryClient(c.GetNode().GrpcConn).
+	res, err := slashingtypes.NewQueryClient(c.GetNodeGRPC()).
 		SigningInfo(ctx, &slashingtypes.QuerySigningInfoRequest{ConsAddress: consAddress})
 	if err != nil {
 		return nil, err
@@ -36,7 +36,7 @@ func (c *CosmosChain) SlashingQuerySigningInfo(ctx context.Context, consAddress 
 
 // SlashingSigningInfos returns all signing infos
 func (c *CosmosChain) SlashingQuerySigningInfos(ctx context.Context) ([]slashingtypes.ValidatorSigningInfo, error) {
-	res, err := slashingtypes.NewQueryClient(c.GetNode().GrpcConn).
+	res, err := slashingtypes.NewQueryClient(c.GetNodeGRPC()).
 		SigningInfos(ctx, &slashingtypes.QuerySigningInfosRequest{})
 	if err != nil {
 		return nil, err

--- a/chain/cosmos/module_staking.go
+++ b/chain/cosmos/module_staking.go
@@ -82,7 +82,7 @@ func (tn *ChainNode) StakingCreateValidatorFile(
 
 // StakingQueryDelegation returns a delegation.
 func (c *CosmosChain) StakingQueryDelegation(ctx context.Context, valAddr string, delegator string) (*stakingtypes.DelegationResponse, error) {
-	res, err := stakingtypes.NewQueryClient(c.GetNode().GrpcConn).
+	res, err := stakingtypes.NewQueryClient(c.GetNodeGRPC()).
 		Delegation(ctx, &stakingtypes.QueryDelegationRequest{DelegatorAddr: delegator, ValidatorAddr: valAddr})
 	if err != nil {
 		return nil, err
@@ -92,7 +92,7 @@ func (c *CosmosChain) StakingQueryDelegation(ctx context.Context, valAddr string
 
 // StakingQueryDelegations returns all delegations for a delegator.
 func (c *CosmosChain) StakingQueryDelegations(ctx context.Context, delegator string) ([]stakingtypes.DelegationResponse, error) {
-	res, err := stakingtypes.NewQueryClient(c.GetNode().GrpcConn).
+	res, err := stakingtypes.NewQueryClient(c.GetNodeGRPC()).
 		DelegatorDelegations(ctx, &stakingtypes.QueryDelegatorDelegationsRequest{DelegatorAddr: delegator, Pagination: nil})
 	if err != nil {
 		return nil, err
@@ -102,7 +102,7 @@ func (c *CosmosChain) StakingQueryDelegations(ctx context.Context, delegator str
 
 // StakingQueryDelegationsTo returns all delegations to a validator.
 func (c *CosmosChain) StakingQueryDelegationsTo(ctx context.Context, validator string) ([]*stakingtypes.DelegationResponse, error) {
-	res, err := stakingtypes.NewQueryClient(c.GetNode().GrpcConn).
+	res, err := stakingtypes.NewQueryClient(c.GetNodeGRPC()).
 		ValidatorDelegations(ctx, &stakingtypes.QueryValidatorDelegationsRequest{ValidatorAddr: validator})
 	if err != nil {
 		return nil, err
@@ -118,7 +118,7 @@ func (c *CosmosChain) StakingQueryDelegationsTo(ctx context.Context, validator s
 
 // StakingQueryDelegatorValidator returns a validator for a delegator.
 func (c *CosmosChain) StakingQueryDelegatorValidator(ctx context.Context, delegator string, validator string) (*stakingtypes.Validator, error) {
-	res, err := stakingtypes.NewQueryClient(c.GetNode().GrpcConn).
+	res, err := stakingtypes.NewQueryClient(c.GetNodeGRPC()).
 		DelegatorValidator(ctx, &stakingtypes.QueryDelegatorValidatorRequest{DelegatorAddr: delegator, ValidatorAddr: validator})
 	if err != nil {
 		return nil, err
@@ -128,7 +128,7 @@ func (c *CosmosChain) StakingQueryDelegatorValidator(ctx context.Context, delega
 
 // StakingQueryDelegatorValidators returns all validators for a delegator.
 func (c *CosmosChain) StakingQueryDelegatorValidators(ctx context.Context, delegator string) ([]stakingtypes.Validator, error) {
-	res, err := stakingtypes.NewQueryClient(c.GetNode().GrpcConn).
+	res, err := stakingtypes.NewQueryClient(c.GetNodeGRPC()).
 		DelegatorValidators(ctx, &stakingtypes.QueryDelegatorValidatorsRequest{DelegatorAddr: delegator})
 	if err != nil {
 		return nil, err
@@ -138,7 +138,7 @@ func (c *CosmosChain) StakingQueryDelegatorValidators(ctx context.Context, deleg
 
 // StakingQueryHistoricalInfo returns the historical info at the given height.
 func (c *CosmosChain) StakingQueryHistoricalInfo(ctx context.Context, height int64) (*stakingtypes.HistoricalInfo, error) {
-	res, err := stakingtypes.NewQueryClient(c.GetNode().GrpcConn).
+	res, err := stakingtypes.NewQueryClient(c.GetNodeGRPC()).
 		HistoricalInfo(ctx, &stakingtypes.QueryHistoricalInfoRequest{Height: height})
 	if err != nil {
 		return nil, err
@@ -148,7 +148,7 @@ func (c *CosmosChain) StakingQueryHistoricalInfo(ctx context.Context, height int
 
 // StakingQueryParams returns the staking parameters.
 func (c *CosmosChain) StakingQueryParams(ctx context.Context) (*stakingtypes.Params, error) {
-	res, err := stakingtypes.NewQueryClient(c.GetNode().GrpcConn).
+	res, err := stakingtypes.NewQueryClient(c.GetNodeGRPC()).
 		Params(ctx, &stakingtypes.QueryParamsRequest{})
 	if err != nil {
 		return nil, err
@@ -158,7 +158,7 @@ func (c *CosmosChain) StakingQueryParams(ctx context.Context) (*stakingtypes.Par
 
 // StakingQueryPool returns the current staking pool values.
 func (c *CosmosChain) StakingQueryPool(ctx context.Context) (*stakingtypes.Pool, error) {
-	res, err := stakingtypes.NewQueryClient(c.GetNode().GrpcConn).
+	res, err := stakingtypes.NewQueryClient(c.GetNodeGRPC()).
 		Pool(ctx, &stakingtypes.QueryPoolRequest{})
 	if err != nil {
 		return nil, err
@@ -168,7 +168,7 @@ func (c *CosmosChain) StakingQueryPool(ctx context.Context) (*stakingtypes.Pool,
 
 // StakingQueryRedelegation returns a redelegation.
 func (c *CosmosChain) StakingQueryRedelegation(ctx context.Context, delegator string, srcValAddr string, dstValAddr string) ([]stakingtypes.RedelegationResponse, error) {
-	res, err := stakingtypes.NewQueryClient(c.GetNode().GrpcConn).
+	res, err := stakingtypes.NewQueryClient(c.GetNodeGRPC()).
 		Redelegations(ctx, &stakingtypes.QueryRedelegationsRequest{DelegatorAddr: delegator, SrcValidatorAddr: srcValAddr, DstValidatorAddr: dstValAddr})
 	if err != nil {
 		return nil, err
@@ -178,7 +178,7 @@ func (c *CosmosChain) StakingQueryRedelegation(ctx context.Context, delegator st
 
 // StakingQueryUnbondingDelegation returns an unbonding delegation.
 func (c *CosmosChain) StakingQueryUnbondingDelegation(ctx context.Context, delegator string, validator string) (*stakingtypes.UnbondingDelegation, error) {
-	res, err := stakingtypes.NewQueryClient(c.GetNode().GrpcConn).
+	res, err := stakingtypes.NewQueryClient(c.GetNodeGRPC()).
 		UnbondingDelegation(ctx, &stakingtypes.QueryUnbondingDelegationRequest{DelegatorAddr: delegator, ValidatorAddr: validator})
 	if err != nil {
 		return nil, err
@@ -188,7 +188,7 @@ func (c *CosmosChain) StakingQueryUnbondingDelegation(ctx context.Context, deleg
 
 // StakingQueryUnbondingDelegations returns all unbonding delegations for a delegator.
 func (c *CosmosChain) StakingQueryUnbondingDelegations(ctx context.Context, delegator string) ([]stakingtypes.UnbondingDelegation, error) {
-	res, err := stakingtypes.NewQueryClient(c.GetNode().GrpcConn).
+	res, err := stakingtypes.NewQueryClient(c.GetNodeGRPC()).
 		DelegatorUnbondingDelegations(ctx, &stakingtypes.QueryDelegatorUnbondingDelegationsRequest{DelegatorAddr: delegator})
 	if err != nil {
 		return nil, err
@@ -198,7 +198,7 @@ func (c *CosmosChain) StakingQueryUnbondingDelegations(ctx context.Context, dele
 
 // StakingQueryUnbondingDelegationsFrom returns all unbonding delegations from a validator.
 func (c *CosmosChain) StakingQueryUnbondingDelegationsFrom(ctx context.Context, validator string) ([]stakingtypes.UnbondingDelegation, error) {
-	res, err := stakingtypes.NewQueryClient(c.GetNode().GrpcConn).
+	res, err := stakingtypes.NewQueryClient(c.GetNodeGRPC()).
 		ValidatorUnbondingDelegations(ctx, &stakingtypes.QueryValidatorUnbondingDelegationsRequest{ValidatorAddr: validator})
 	if err != nil {
 		return nil, err
@@ -208,7 +208,7 @@ func (c *CosmosChain) StakingQueryUnbondingDelegationsFrom(ctx context.Context, 
 
 // StakingQueryValidator returns a validator.
 func (c *CosmosChain) StakingQueryValidator(ctx context.Context, validator string) (*stakingtypes.Validator, error) {
-	res, err := stakingtypes.NewQueryClient(c.GetNode().GrpcConn).
+	res, err := stakingtypes.NewQueryClient(c.GetNodeGRPC()).
 		Validator(ctx, &stakingtypes.QueryValidatorRequest{ValidatorAddr: validator})
 	if err != nil {
 		return nil, err
@@ -218,7 +218,7 @@ func (c *CosmosChain) StakingQueryValidator(ctx context.Context, validator strin
 
 // StakingQueryValidators returns all validators.
 func (c *CosmosChain) StakingQueryValidators(ctx context.Context, status string) ([]stakingtypes.Validator, error) {
-	res, err := stakingtypes.NewQueryClient(c.GetNode().GrpcConn).Validators(ctx, &stakingtypes.QueryValidatorsRequest{
+	res, err := stakingtypes.NewQueryClient(c.GetNodeGRPC()).Validators(ctx, &stakingtypes.QueryValidatorsRequest{
 		Status: status,
 	})
 	if err != nil {

--- a/chain/cosmos/module_upgrade.go
+++ b/chain/cosmos/module_upgrade.go
@@ -39,13 +39,13 @@ func (tn *ChainNode) UpgradeCancel(ctx context.Context, keyName string, extraFla
 
 // UpgradeQueryPlan queries the current upgrade plan.
 func (c *CosmosChain) UpgradeQueryPlan(ctx context.Context) (*upgradetypes.Plan, error) {
-	res, err := upgradetypes.NewQueryClient(c.GetNode().GrpcConn).CurrentPlan(ctx, &upgradetypes.QueryCurrentPlanRequest{})
+	res, err := upgradetypes.NewQueryClient(c.GetNodeGRPC()).CurrentPlan(ctx, &upgradetypes.QueryCurrentPlanRequest{})
 	return res.Plan, err
 }
 
 // UpgradeQueryAppliedPlan queries a previously applied upgrade plan by its name.
 func (c *CosmosChain) UpgradeQueryAppliedPlan(ctx context.Context, name string) (*upgradetypes.QueryAppliedPlanResponse, error) {
-	res, err := upgradetypes.NewQueryClient(c.GetNode().GrpcConn).AppliedPlan(ctx, &upgradetypes.QueryAppliedPlanRequest{
+	res, err := upgradetypes.NewQueryClient(c.GetNodeGRPC()).AppliedPlan(ctx, &upgradetypes.QueryAppliedPlanRequest{
 		Name: name,
 	})
 	return res, err
@@ -54,19 +54,19 @@ func (c *CosmosChain) UpgradeQueryAppliedPlan(ctx context.Context, name string) 
 
 // UpgradeQueryAuthority returns the account with authority to conduct upgrades
 func (c *CosmosChain) UpgradeQueryAuthority(ctx context.Context) (string, error) {
-	res, err := upgradetypes.NewQueryClient(c.GetNode().GrpcConn).Authority(ctx, &upgradetypes.QueryAuthorityRequest{})
+	res, err := upgradetypes.NewQueryClient(c.GetNodeGRPC()).Authority(ctx, &upgradetypes.QueryAuthorityRequest{})
 	return res.Address, err
 }
 
 // UpgradeQueryAllModuleVersions queries the list of module versions from state.
 func (c *CosmosChain) UpgradeQueryAllModuleVersions(ctx context.Context) ([]*upgradetypes.ModuleVersion, error) {
-	res, err := upgradetypes.NewQueryClient(c.GetNode().GrpcConn).ModuleVersions(ctx, &upgradetypes.QueryModuleVersionsRequest{})
+	res, err := upgradetypes.NewQueryClient(c.GetNodeGRPC()).ModuleVersions(ctx, &upgradetypes.QueryModuleVersionsRequest{})
 	return res.ModuleVersions, err
 }
 
 // UpgradeQueryModuleVersion queries a specific module version from state.
 func (c *CosmosChain) UpgradeQueryModuleVersion(ctx context.Context, module string) (*upgradetypes.ModuleVersion, error) {
-	res, err := upgradetypes.NewQueryClient(c.GetNode().GrpcConn).ModuleVersions(ctx, &upgradetypes.QueryModuleVersionsRequest{
+	res, err := upgradetypes.NewQueryClient(c.GetNodeGRPC()).ModuleVersions(ctx, &upgradetypes.QueryModuleVersionsRequest{
 		ModuleName: module,
 	})
 	if err != nil {

--- a/chain/cosmos/poll.go
+++ b/chain/cosmos/poll.go
@@ -58,7 +58,7 @@ func PollForMessage[T any](ctx context.Context, chain *CosmosChain, registry cod
 	}
 	doPoll := func(ctx context.Context, height int64) (T, error) {
 		h := int64(height)
-		block, err := chain.getFullNode().Client.Block(ctx, &h)
+		block, err := chain.getFullNode().ConsensusClient.Block(ctx, &h)
 		if err != nil {
 			return zero, err
 		}

--- a/chain/thorchain/api_query.go
+++ b/chain/thorchain/api_query.go
@@ -195,7 +195,7 @@ func get(url string, target interface{}) error {
 	errResp := ErrorResponse{}
 	err = json.Unmarshal(buf, &errResp)
 	if err == nil && errResp.Error != "" {
-		return fmt.Errorf(errResp.Error)
+		return fmt.Errorf("api error: %s", errResp.Error)
 	}
 
 	// decode response

--- a/examples/cosmos/chain_gordian_test.go
+++ b/examples/cosmos/chain_gordian_test.go
@@ -1,0 +1,109 @@
+package cosmos_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/strangelove-ventures/interchaintest/v8"
+	"github.com/strangelove-ventures/interchaintest/v8/chain/cosmos"
+	"github.com/strangelove-ventures/interchaintest/v8/ibc"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+)
+
+func TestChainGordian(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping in short mode")
+	}
+	t.Parallel()
+
+	cosmos.SetSDKConfig(baseBech32)
+
+	sdk47Genesis := []cosmos.GenesisKV{
+		cosmos.NewGenesisKV("app_state.gov.params.voting_period", "15s"),
+		cosmos.NewGenesisKV("app_state.gov.params.max_deposit_period", "10s"),
+		cosmos.NewGenesisKV("app_state.gov.params.min_deposit.0.denom", "token"),
+		cosmos.NewGenesisKV("app_state.gov.params.min_deposit.0.amount", "1"),
+		cosmos.NewGenesisKV("app_state.bank.denom_metadata", []banktypes.Metadata{denomMetadata}),
+	}
+
+	decimals := int64(6)
+	cf := interchaintest.NewBuiltinChainFactory(zaptest.NewLogger(t), []*interchaintest.ChainSpec{
+		{
+			Name:      "gordianproject",
+			ChainName: "gordianproject",
+			Version:   "local", // spawn -> gordian, modify docker file, build
+			ChainConfig: ibc.ChainConfig{
+				Images: []ibc.DockerImage{
+					{
+						Repository: "gordianproject",
+						Version:    "local",
+						UidGid:     "1025:1025",
+					},
+				},
+				Type:           "cosmos",
+				Name:           "gordian",
+				ChainID:        "gordian-1",
+				GasPrices:      "0.0" + denomMetadata.Base,
+				CoinDecimals:   &decimals,
+				Bin:            "appd",
+				TrustingPeriod: "330h",
+				AdditionalStartArgs: []string{
+					"--g-http-addr", ":26657",
+					"--g-grpc-addr", ":9092", // gRPC 9090 is already used by the SDK.
+				},
+				Denom:         denomMetadata.Base,
+				Bech32Prefix:  baseBech32,
+				CoinType:      "118",
+				ModifyGenesis: cosmos.ModifyGenesis(sdk47Genesis),
+				GasAdjustment: 1.5,
+			},
+			NumValidators: &numValsOne,
+			NumFullNodes:  &numFullNodesZero,
+		},
+	})
+
+	chains, err := cf.Chains(t.Name())
+	require.NoError(t, err)
+
+	chain := chains[0].(*cosmos.CosmosChain)
+
+	ic := interchaintest.NewInterchain().
+		AddChain(chain)
+
+	ctx := context.Background()
+	client, network := interchaintest.DockerSetup(t)
+
+	require.NoError(t, ic.Build(ctx, nil, interchaintest.InterchainBuildOptions{
+		TestName:         t.Name(),
+		Client:           client,
+		NetworkID:        network,
+		SkipPathCreation: true,
+	}))
+	t.Cleanup(func() {
+		_ = ic.Close()
+	})
+
+	// TODO: gordian does not yet accept standard tx commands, it requires a manual broadcast of a generate only. Need to submit the raw bytes properly
+	// users := interchaintest.GetAndFundTestUsers(t, ctx, "default", genesisAmt, chain, chain)
+	// user1 := users[1].FormattedAddress()
+	// fmt.Println("user1", user1, "yuh")
+
+	// b2, err := chain.BankQueryBalance(ctx, user1, chain.Config().Denom)
+	// require.NoError(t, err)
+
+	// fmt.Println("b2", b2)
+
+	// send 1 token
+	// sendAmt := int64(1)
+	// _, err = sendTokens(ctx, chain, users[0], users[1], "", sendAmt)
+	// require.NoError(t, err)
+
+	// // check balances
+	// b2New, err := chain.GetBalance(ctx, user1, chain.Config().Denom)
+	// require.NoError(t, err)
+	// require.Equal(t, b2.Add(sdkmath.NewInt(sendAmt)), b2New)
+
+}

--- a/examples/cosmos/chain_gordian_test.go
+++ b/examples/cosmos/chain_gordian_test.go
@@ -2,6 +2,7 @@ package cosmos_test
 
 import (
 	"context"
+	"os"
 	"testing"
 
 	"github.com/strangelove-ventures/interchaintest/v8"
@@ -13,7 +14,13 @@ import (
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 )
 
+// go test -timeout 3000s -run ^TestChainGordian$ github.com/strangelove-ventures/interchaintest/v8/examples/cosmos -v
 func TestChainGordian(t *testing.T) {
+	// TODO: this test is only local for now. Will add CI in the future
+	if os.Getenv("IS_LOCAL_TESTING_GORDIAN") == "" {
+		t.Skip("skipping test; set IS_LOCAL_TESTING_GORDIAN to run this test")
+	}
+
 	if testing.Short() {
 		t.Skip("skipping in short mode")
 	}

--- a/examples/cosmos/chain_miscellaneous_test.go
+++ b/examples/cosmos/chain_miscellaneous_test.go
@@ -251,7 +251,7 @@ func testRangeBlockMessages(ctx context.Context, t *testing.T, chain *cosmos.Cos
 	require.NoError(t, err)
 
 	var bankMsgs []*banktypes.MsgSend
-	err = cosmos.RangeBlockMessages(ctx, chain.Config().EncodingConfig.InterfaceRegistry, chain.Validators[0].Client, height+1, func(msg sdk.Msg) bool {
+	err = cosmos.RangeBlockMessages(ctx, chain.Config().EncodingConfig.InterfaceRegistry, chain.Validators[0].ConsensusClient, height+1, func(msg sdk.Msg) bool {
 		found, ok := msg.(*banktypes.MsgSend)
 		if ok {
 			bankMsgs = append(bankMsgs, found)


### PR DESCRIPTION
## Summary
To support gordian, we need an easy interface we can plug another consensus client into. On start of an application, ICT figures out which you are using (cometbft or gordian), then uses the proper Consensus Client based on that finding. As a user no extra configuration is required to use gordian, just plug in the docker image.


## Context
This builds off a similar approach used in https://github.com/cosmos/relayer/pull/1490 for the relayer w/ CometBFT (Gordian: https://github.com/cosmos/relayer/pull/1492)

This PR builds off other work here: https://github.com/strangelove-ventures/interchaintest/pull/1205, and https://github.com/strangelove-ventures/interchaintest/pull/1208. 

## TODO
- Get a Gordian simapp image tagged & ghcr'ed so the test can run outside local