### PR TITLE
chore: fix linter warnings

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Install and setup go
-      - name: Set up Go 1.21
+      - name: Set up Go 1.22
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.22'
 
       - name: checkout interchaintest
         uses: actions/checkout@v4
@@ -35,10 +35,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Install and setup go
-      - name: Set up Go 1.21
+      - name: Set up Go 1.22
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.22'
           cache: false
 
       - name: checkout interchaintest
@@ -57,10 +57,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Install and setup go
-      - name: Set up Go 1.21
+      - name: Set up Go 1.22
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.22'
           cache: false
 
       - name: checkout interchaintest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -50,5 +50,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6.1.0
         with:
-          version: v1.57.2
+          version: v1.61.0
           args: --timeout 15m

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Install and setup go
-      - name: Set up Go 1.21
+      - name: Set up Go 1.22
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.22'
 
       - name: checkout interchaintest
         uses: actions/checkout@v4

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,6 +10,7 @@ linters:
   - asciicheck
   - bidichk
   - bodyclose
+  - copyloopvar
   - decorder
   - dupl
   - dupword
@@ -17,7 +18,6 @@ linters:
   - errchkjson
   - errname
   - exhaustive
-  - exportloopref
   - forbidigo
   - gci
   - goconst
@@ -32,8 +32,8 @@ linters:
   - ineffassign
   - loggercheck
   - misspell
-  - nilerr
-  - nilnil
+  # - nilerr disabled because we return nil when there are errors in places that need to keep running e.g. polling/waiting for a condition
+  # - nilnil disabled because we return nil, nil when polling but waiting for a conditional
   - noctx
   - staticcheck
   - stylecheck
@@ -64,6 +64,11 @@ linters-settings:
   gosec:
     excludes:
       - G404 # disables checks on insecure random number source
+      - G115 # disables checks on type conversions between signed and unsigned integers
+      - G306 # disables checks on WriteFile perms. Not an issue since we are writing configs/logs in a local test env
+  gocritic:
+    disabled-checks:
+      - appendAssign # we use append to build cmds from a config and always assign to a new slice to not overwrite cfg
 
 issues:
   max-issues-per-linter: 0

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,19 @@ interchaintest: gen ## Build interchaintest binary into ./bin
 
 .PHONY: test
 test: ## Run unit tests
-	@go test -cover -short -race -timeout=60s ./...
+	@go test -cover -short -race -timeout=30m -failfast -p 2 $(go list ./... | grep -v /cmd | grep -v /examples)
+
+.PHONY: test-conformance
+test-conformance: ## Run e2e conformance tests
+	@go test -race -timeout 30m -failfast -v -p 2 ./cmd/interchaintest
+
+.PHONY: test-ibc-examples
+test-ibc-examples: ## Run e2e ibc example tests
+	@go test -race -timeout 30m -failfast -v -p 2 ./examples/ibc
+
+.PHONY: test-cosmos-examples
+test-cosmos-examples: ## Run e2e cosmos example tests
+	@go test -race -failfast -timeout 30m -v -p 2 ./examples/cosmos
 
 .PHONY: docker-reset
 docker-reset: ## Attempt to delete all running containers. Useful if interchaintest does not exit cleanly.

--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,9 @@ protoVer=0.13.2
 protoImageName=ghcr.io/cosmos/proto-builder:$(protoVer)
 protoImage=$(DOCKER) run --rm -v $(CURDIR):/workspace --workdir /workspace $(protoImageName)
 golangci_lint_cmd=golangci-lint
-golangci_version=v1.57.2
+golangci_version=v1.61.0
 gofumpt_cmd=gofumpt
-gofumpt_version=v0.6.0
+gofumpt_version=v0.7.0
 
 default: help
 

--- a/blockdb/chain_test.go
+++ b/blockdb/chain_test.go
@@ -47,6 +47,8 @@ func TestChain_SaveBlock(t *testing.T) {
 	)
 
 	t.Run("happy path", func(t *testing.T) {
+		t.Parallel()
+
 		db := migratedDB()
 		defer db.Close()
 
@@ -98,20 +100,20 @@ ORDER BY tendermint_event_attr.id`)
 		for i = 0; rows.Next(); i++ {
 			var gotData, gotType, gotKey, gotValue string
 			require.NoError(t, rows.Scan(&gotData, &gotType, &gotKey, &gotValue))
-			require.Equal(t, gotData, `{"test":1}`)
+			require.Equal(t, `{"test":1}`, gotData)
 			switch i {
 			case 0:
-				require.Equal(t, gotType, "e1")
-				require.Equal(t, gotKey, "k1")
-				require.Equal(t, gotValue, "v1")
+				require.Equal(t, "e1", gotType)
+				require.Equal(t, "k1", gotKey)
+				require.Equal(t, "v1", gotValue)
 			case 1:
-				require.Equal(t, gotType, "e2")
-				require.Equal(t, gotKey, "k2")
-				require.Equal(t, gotValue, "v2")
+				require.Equal(t, "e2", gotType)
+				require.Equal(t, "k2", gotKey)
+				require.Equal(t, "v2", gotValue)
 			case 2:
-				require.Equal(t, gotType, "e2")
-				require.Equal(t, gotKey, "k3")
-				require.Equal(t, gotValue, "v3")
+				require.Equal(t, "e2", gotType)
+				require.Equal(t, "k3", gotKey)
+				require.Equal(t, "v3", gotValue)
 			default:
 				t.Fatalf("expected 3 results, got i=%d", i)
 			}
@@ -119,6 +121,8 @@ ORDER BY tendermint_event_attr.id`)
 	})
 
 	t.Run("idempotent", func(t *testing.T) {
+		t.Parallel()
+
 		db := migratedDB()
 		defer db.Close()
 
@@ -152,6 +156,8 @@ ORDER BY tendermint_event_attr.id`)
 	})
 
 	t.Run("zero state", func(t *testing.T) {
+		t.Parallel()
+
 		db := migratedDB()
 		defer db.Close()
 

--- a/blockdb/messages_view_test.go
+++ b/blockdb/messages_view_test.go
@@ -9,17 +9,18 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/strangelove-ventures/interchaintest/v8"
-	"github.com/strangelove-ventures/interchaintest/v8/ibc"
-	"github.com/strangelove-ventures/interchaintest/v8/relayer"
-	"github.com/strangelove-ventures/interchaintest/v8/testreporter"
-	"github.com/strangelove-ventures/interchaintest/v8/testutil"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
 
 	"cosmossdk.io/math"
 
 	"github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/strangelove-ventures/interchaintest/v8"
+	"github.com/strangelove-ventures/interchaintest/v8/ibc"
+	"github.com/strangelove-ventures/interchaintest/v8/relayer"
+	"github.com/strangelove-ventures/interchaintest/v8/testreporter"
+	"github.com/strangelove-ventures/interchaintest/v8/testutil"
 )
 
 func TestMessagesView(t *testing.T) {
@@ -87,7 +88,7 @@ func TestMessagesView(t *testing.T) {
 	var count int
 	row := db.QueryRow(`SELECT COUNT(*) FROM v_cosmos_messages`)
 	require.NoError(t, row.Scan(&count))
-	require.Equal(t, count, 0)
+	require.Equal(t, 0, count)
 
 	// Generate the path.
 	// No transactions happen here.
@@ -105,10 +106,10 @@ FROM v_cosmos_messages
 WHERE type = "/ibc.core.client.v1.MsgCreateClient" AND chain_id = ?;`
 		var clientChainID string
 		require.NoError(t, db.QueryRow(qCreateClient, gaia0ChainID).Scan(&clientChainID))
-		require.Equal(t, clientChainID, gaia1ChainID)
+		require.Equal(t, gaia1ChainID, clientChainID)
 
 		require.NoError(t, db.QueryRow(qCreateClient, gaia1ChainID).Scan(&clientChainID))
-		require.Equal(t, clientChainID, gaia0ChainID)
+		require.Equal(t, gaia0ChainID, clientChainID)
 	})
 	if t.Failed() {
 		return
@@ -208,8 +209,8 @@ WHERE type = "/ibc.core.channel.v1.MsgChannelOpenInit" AND chain_id = ?
 `
 		var portID, counterpartyPortID string
 		require.NoError(t, db.QueryRow(qChannelOpenInit, gaia0ChainID).Scan(&portID, &counterpartyPortID))
-		require.Equal(t, portID, gaia0Port)
-		require.Equal(t, counterpartyPortID, gaia1Port)
+		require.Equal(t, gaia0Port, portID)
+		require.Equal(t, gaia1Port, counterpartyPortID)
 
 		// OpenTry happens on second chain.
 		const qChannelOpenTry = `SELECT
@@ -219,8 +220,8 @@ WHERE type = "/ibc.core.channel.v1.MsgChannelOpenTry" AND chain_id = ?
 `
 		var counterpartyChannelID string
 		require.NoError(t, db.QueryRow(qChannelOpenTry, gaia1ChainID).Scan(&portID, &counterpartyPortID, &counterpartyChannelID))
-		require.Equal(t, portID, gaia1Port)
-		require.Equal(t, counterpartyPortID, gaia0Port)
+		require.Equal(t, gaia1Port, portID)
+		require.Equal(t, gaia0Port, counterpartyPortID)
 		require.Equal(t, counterpartyChannelID, gaia0ChannelID)
 
 		// OpenAck happens on first chain again.
@@ -231,7 +232,7 @@ WHERE type = "/ibc.core.channel.v1.MsgChannelOpenAck" AND chain_id = ?
 `
 		var channelID string
 		require.NoError(t, db.QueryRow(qChannelOpenAck, gaia0ChainID).Scan(&portID, &channelID, &counterpartyChannelID))
-		require.Equal(t, portID, gaia0Port)
+		require.Equal(t, gaia0Port, portID)
 		require.Equal(t, channelID, gaia0ChannelID)
 		require.Equal(t, counterpartyChannelID, gaia1ChannelID)
 
@@ -242,7 +243,7 @@ FROM v_cosmos_messages
 WHERE type = "/ibc.core.channel.v1.MsgChannelOpenConfirm" AND chain_id = ?
 `
 		require.NoError(t, db.QueryRow(qChannelOpenConfirm, gaia1ChainID).Scan(&portID, &channelID))
-		require.Equal(t, portID, gaia1Port)
+		require.Equal(t, gaia1Port, portID)
 		require.Equal(t, channelID, gaia1ChannelID)
 	})
 	if t.Failed() {
@@ -274,7 +275,7 @@ WHERE type = "/ibc.applications.transfer.v1.MsgTransfer" AND chain_id = ?
 `
 		var portID, channelID string
 		require.NoError(t, db.QueryRow(qMsgTransfer, gaia0ChainID).Scan(&portID, &channelID))
-		require.Equal(t, portID, gaia0Port)
+		require.Equal(t, gaia0Port, portID)
 		require.Equal(t, channelID, gaia0ChannelID)
 	})
 	if t.Failed() {
@@ -299,9 +300,9 @@ WHERE type = "/ibc.core.channel.v1.MsgRecvPacket" AND chain_id = ?
 
 		require.NoError(t, db.QueryRow(qMsgRecvPacket, gaia1ChainID).Scan(&portID, &channelID, &counterpartyPortID, &counterpartyChannelID))
 
-		require.Equal(t, portID, gaia0Port)
+		require.Equal(t, gaia0Port, portID)
 		require.Equal(t, channelID, gaia0ChannelID)
-		require.Equal(t, counterpartyPortID, gaia1Port)
+		require.Equal(t, gaia1Port, counterpartyPortID)
 		require.Equal(t, counterpartyChannelID, gaia1ChannelID)
 
 		const qMsgAck = `SELECT
@@ -311,9 +312,9 @@ WHERE type = "/ibc.core.channel.v1.MsgAcknowledgement" AND chain_id = ?
 `
 		require.NoError(t, db.QueryRow(qMsgAck, gaia0ChainID).Scan(&portID, &channelID, &counterpartyPortID, &counterpartyChannelID))
 
-		require.Equal(t, portID, gaia0Port)
+		require.Equal(t, gaia0Port, portID)
 		require.Equal(t, channelID, gaia0ChannelID)
-		require.Equal(t, counterpartyPortID, gaia1Port)
+		require.Equal(t, gaia1Port, counterpartyPortID)
 		require.Equal(t, counterpartyChannelID, gaia1ChannelID)
 	})
 }

--- a/blockdb/query.go
+++ b/blockdb/query.go
@@ -21,7 +21,7 @@ func timeToLocal(timeStr string) (time.Time, error) {
 	if err != nil {
 		return time.Time{}, fmt.Errorf("time.Parse RFC3339: %w", err)
 	}
-	return t.In(time.Local), nil
+	return t.In(time.Local), nil //nolint: gosmopolitan
 }
 
 type SchemaVersionResult struct {

--- a/blockdb/query_test.go
+++ b/blockdb/query_test.go
@@ -37,6 +37,8 @@ func TestQuery_RecentTestCases(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("happy path", func(t *testing.T) {
+		t.Parallel()
+
 		db := migratedDB()
 		defer db.Close()
 
@@ -83,6 +85,8 @@ func TestQuery_RecentTestCases(t *testing.T) {
 	})
 
 	t.Run("limit", func(t *testing.T) {
+		t.Parallel()
+
 		db := migratedDB()
 		defer db.Close()
 
@@ -99,6 +103,8 @@ func TestQuery_RecentTestCases(t *testing.T) {
 	})
 
 	t.Run("no test cases", func(t *testing.T) {
+		t.Parallel()
+
 		db := migratedDB()
 		defer db.Close()
 
@@ -174,6 +180,8 @@ func TestQuery_Transactions(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("happy path", func(t *testing.T) {
+		t.Parallel()
+
 		db := migratedDB()
 		defer db.Close()
 
@@ -201,6 +209,8 @@ func TestQuery_Transactions(t *testing.T) {
 	})
 
 	t.Run("no txs", func(t *testing.T) {
+		t.Parallel()
+
 		db := migratedDB()
 		defer db.Close()
 
@@ -212,6 +222,6 @@ func TestQuery_Transactions(t *testing.T) {
 		results, err := NewQuery(db).Transactions(ctx, chain.id)
 		require.NoError(t, err)
 
-		require.Len(t, results, 0)
+		require.Empty(t, results)
 	})
 }

--- a/blockdb/sql_test.go
+++ b/blockdb/sql_test.go
@@ -63,8 +63,6 @@ func TestDB_Concurrency(t *testing.T) {
 	// and a shared context so all fail if one fails.
 	egWrites, egCtx := errgroup.WithContext(ctx)
 	for i := 0; i < nWriters; i++ {
-		i := i
-
 		// Connecting to the database in the main goroutine
 		// because concurrently connecting to the same database
 		// causes a data race inside sqlite.
@@ -98,8 +96,6 @@ func TestDB_Concurrency(t *testing.T) {
 	// Separate errgroup for the queriers.
 	var egQueries errgroup.Group
 	for i := 0; i < nQueriers; i++ {
-		i := i
-
 		db, err := ConnectDB(ctx, dbPath)
 		require.NoErrorf(t, err, "failed to connect to db for querier %d: %v", i, err)
 		defer db.Close()

--- a/blockdb/sql_test.go
+++ b/blockdb/sql_test.go
@@ -108,7 +108,7 @@ func TestDB_Concurrency(t *testing.T) {
 			for {
 				if ctx.Err() != nil {
 					// Context was canceled; querying is finished.
-					return nil //nolint: nilerr
+					return nil
 				}
 
 				// Deliberately using context.Background() here so that

--- a/blockdb/sql_test.go
+++ b/blockdb/sql_test.go
@@ -112,7 +112,7 @@ func TestDB_Concurrency(t *testing.T) {
 			for {
 				if ctx.Err() != nil {
 					// Context was canceled; querying is finished.
-					return nil
+					return nil //nolint: nilerr
 				}
 
 				// Deliberately using context.Background() here so that

--- a/blockdb/test_case_test.go
+++ b/blockdb/test_case_test.go
@@ -14,6 +14,8 @@ func TestCreateTestCase(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("happy path", func(t *testing.T) {
+		t.Parallel()
+
 		db := migratedDB()
 		defer db.Close()
 
@@ -39,6 +41,8 @@ func TestCreateTestCase(t *testing.T) {
 	})
 
 	t.Run("errors", func(t *testing.T) {
+		t.Parallel()
+
 		db := emptyDB()
 		_, err := CreateTestCase(ctx, db, "fail", "")
 		require.Error(t, err)
@@ -51,6 +55,8 @@ func TestTestCase_AddChain(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("happy path", func(t *testing.T) {
+		t.Parallel()
+
 		db := migratedDB()
 		defer db.Close()
 
@@ -80,6 +86,8 @@ func TestTestCase_AddChain(t *testing.T) {
 	})
 
 	t.Run("errors", func(t *testing.T) {
+		t.Parallel()
+
 		db := migratedDB()
 		defer db.Close()
 

--- a/blockdb/tui/model.go
+++ b/blockdb/tui/model.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/atotto/clipboard"
 	"github.com/rivo/tview"
+
 	"github.com/strangelove-ventures/interchaintest/v8/blockdb"
 )
 

--- a/blockdb/tui/model_test.go
+++ b/blockdb/tui/model_test.go
@@ -4,8 +4,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/strangelove-ventures/interchaintest/v8/blockdb"
 	"github.com/stretchr/testify/require"
+
+	"github.com/strangelove-ventures/interchaintest/v8/blockdb"
 )
 
 func TestModel_RootView(t *testing.T) {

--- a/blockdb/tui/model_test.go
+++ b/blockdb/tui/model_test.go
@@ -12,5 +12,5 @@ func TestModel_RootView(t *testing.T) {
 	m := NewModel(&mockQueryService{}, "test.db", "abc123", time.Now(), make([]blockdb.TestCaseResult, 1))
 	view := m.RootView()
 	require.NotNil(t, view)
-	require.Greater(t, view.GetItemCount(), 0)
+	require.Positive(t, view.GetItemCount())
 }

--- a/blockdb/tui/presenter/cosmos_message_test.go
+++ b/blockdb/tui/presenter/cosmos_message_test.go
@@ -12,6 +12,8 @@ func TestCosmosMessage(t *testing.T) {
 	t.Parallel()
 
 	t.Run("non-variable fields", func(t *testing.T) {
+		t.Parallel()
+
 		res := blockdb.CosmosMessageResult{
 			Height:        55,
 			Index:         13,
@@ -30,6 +32,8 @@ func TestCosmosMessage(t *testing.T) {
 	})
 
 	t.Run("ibc details", func(t *testing.T) {
+		t.Parallel()
+
 		for _, tt := range []struct {
 			Result          blockdb.CosmosMessageResult
 			WantClients     string

--- a/blockdb/tui/presenter/cosmos_message_test.go
+++ b/blockdb/tui/presenter/cosmos_message_test.go
@@ -4,8 +4,9 @@ import (
 	"database/sql"
 	"testing"
 
-	"github.com/strangelove-ventures/interchaintest/v8/blockdb"
 	"github.com/stretchr/testify/require"
+
+	"github.com/strangelove-ventures/interchaintest/v8/blockdb"
 )
 
 func TestCosmosMessage(t *testing.T) {

--- a/blockdb/tui/presenter/test_case_test.go
+++ b/blockdb/tui/presenter/test_case_test.go
@@ -5,8 +5,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/strangelove-ventures/interchaintest/v8/blockdb"
 	"github.com/stretchr/testify/require"
+
+	"github.com/strangelove-ventures/interchaintest/v8/blockdb"
 )
 
 func TestTestCase(t *testing.T) {

--- a/blockdb/tui/presenter/test_case_test.go
+++ b/blockdb/tui/presenter/test_case_test.go
@@ -13,6 +13,8 @@ func TestTestCase(t *testing.T) {
 	t.Parallel()
 
 	t.Run("happy path", func(t *testing.T) {
+		t.Parallel()
+
 		result := blockdb.TestCaseResult{
 			ID:          321,
 			Name:        "My Test",
@@ -36,6 +38,8 @@ func TestTestCase(t *testing.T) {
 	})
 
 	t.Run("zero state", func(t *testing.T) {
+		t.Parallel()
+
 		var pres TestCase
 
 		require.Empty(t, pres.Height())

--- a/blockdb/tui/presenter/tx_test.go
+++ b/blockdb/tui/presenter/tx_test.go
@@ -4,14 +4,17 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/strangelove-ventures/interchaintest/v8/blockdb"
 	"github.com/stretchr/testify/require"
+
+	"github.com/strangelove-ventures/interchaintest/v8/blockdb"
 )
 
 func TestTx(t *testing.T) {
 	t.Parallel()
 
 	t.Run("json", func(t *testing.T) {
+		t.Parallel()
+
 		tx := blockdb.TxResult{
 			Height: 13,
 			Tx:     []byte(`{"json":{"foo":true}}`),
@@ -30,6 +33,8 @@ func TestTx(t *testing.T) {
 	})
 
 	t.Run("non-json", func(t *testing.T) {
+		t.Parallel()
+
 		tx := blockdb.TxResult{
 			Tx: []byte(`some data`),
 		}

--- a/blockdb/tui/update.go
+++ b/blockdb/tui/update.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
+
 	"github.com/strangelove-ventures/interchaintest/v8/blockdb/tui/presenter"
 )
 

--- a/blockdb/tui/update_test.go
+++ b/blockdb/tui/update_test.go
@@ -9,8 +9,9 @@ import (
 
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
-	"github.com/strangelove-ventures/interchaintest/v8/blockdb"
 	"github.com/stretchr/testify/require"
+
+	"github.com/strangelove-ventures/interchaintest/v8/blockdb"
 )
 
 var (

--- a/blockdb/tui/views.go
+++ b/blockdb/tui/views.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
+
 	"github.com/strangelove-ventures/interchaintest/v8/blockdb"
 	"github.com/strangelove-ventures/interchaintest/v8/blockdb/tui/presenter"
 )

--- a/blockdb/views_test.go
+++ b/blockdb/views_test.go
@@ -72,17 +72,17 @@ ORDER BY test_case_id, chain_kid, block_id, tx_id
 	require.Equal(t, tcID, tc.id)
 	require.GreaterOrEqual(t, tcCreatedAt, beforeTestCaseCreate)
 	require.LessOrEqual(t, tcCreatedAt, beforeBlocksCreated)
-	require.Equal(t, tcName, "mytest")
+	require.Equal(t, "mytest", tcName)
 
 	require.Equal(t, chainKeyID, chain.id)
-	require.Equal(t, chainID, "chain1")
-	require.Equal(t, chainType, "cosmos")
+	require.Equal(t, "chain1", chainID)
+	require.Equal(t, "cosmos", chainType)
 
 	require.GreaterOrEqual(t, blockCreatedAt, beforeBlocksCreated)
 	require.LessOrEqual(t, blockCreatedAt, afterBlocksCreated)
-	require.Equal(t, blockHeight, 1)
+	require.Equal(t, 1, blockHeight)
 
-	require.Equal(t, tx, "tx1.0")
+	require.Equal(t, "tx1.0", tx)
 
 	// Save some state gathered from the first row.
 	firstBlockCreatedAt := blockCreatedAt
@@ -104,11 +104,11 @@ ORDER BY test_case_id, chain_kid, block_id, tx_id
 	// New block height.
 	require.GreaterOrEqual(t, blockCreatedAt, firstBlockCreatedAt)
 	require.LessOrEqual(t, blockCreatedAt, afterBlocksCreated)
-	require.Equal(t, blockHeight, 2)
+	require.Equal(t, 2, blockHeight)
 
 	// Next transaction.
 	require.Greater(t, txID, firstTxID)
-	require.Equal(t, tx, "tx2.0")
+	require.Equal(t, "tx2.0", tx)
 
 	secondTxID := txID
 
@@ -126,11 +126,11 @@ ORDER BY test_case_id, chain_kid, block_id, tx_id
 	require.Equal(t, chainKeyID, chain.id)
 
 	// Same block height.
-	require.Equal(t, blockHeight, 2)
+	require.Equal(t, 2, blockHeight)
 
 	// Next transaction.
 	require.Greater(t, txID, secondTxID)
-	require.Equal(t, tx, "tx2.1")
+	require.Equal(t, "tx2.1", tx)
 
 	// No more rows.
 	require.False(t, rows.Next())

--- a/chain/cosmos/broadcaster.go
+++ b/chain/cosmos/broadcaster.go
@@ -8,9 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/strangelove-ventures/interchaintest/v8/dockerutil"
-	"github.com/strangelove-ventures/interchaintest/v8/testutil"
-
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/tx"
@@ -18,6 +15,9 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/tx/signing"
 	authtx "github.com/cosmos/cosmos-sdk/x/auth/tx"
+
+	"github.com/strangelove-ventures/interchaintest/v8/dockerutil"
+	"github.com/strangelove-ventures/interchaintest/v8/testutil"
 )
 
 type ClientContextOpt func(clientContext client.Context) client.Context
@@ -50,6 +50,8 @@ type Broadcaster struct {
 // NewBroadcaster returns a instance of Broadcaster which can be used with broadcast.Tx to
 // broadcast messages sdk messages.
 func NewBroadcaster(t *testing.T, chain *CosmosChain) *Broadcaster {
+	t.Helper()
+
 	return &Broadcaster{
 		t:        t,
 		chain:    chain,

--- a/chain/cosmos/chain_node.go
+++ b/chain/cosmos/chain_node.go
@@ -580,7 +580,11 @@ func (tn *ChainNode) ExecTx(ctx context.Context, keyName string, command ...stri
 func (tn *ChainNode) TxHashToResponse(ctx context.Context, txHash string) (*sdk.TxResponse, error) {
 	stdout, stderr, err := tn.ExecQuery(ctx, "tx", txHash)
 	if err != nil {
-		fmt.Println("TxHashToResponse err: ", err.Error()+" "+string(stderr))
+		tn.log.Info("TxHashToResponse returned an error",
+			zap.String("tx_hash", txHash),
+			zap.Error(err),
+			zap.String("stderr", string(stderr)),
+		)
 	}
 
 	i := &sdk.TxResponse{}
@@ -1164,15 +1168,23 @@ func (tn *ChainNode) CreateNodeContainer(ctx context.Context) error {
 
 	// to prevent port binding conflicts, host port overrides are only exposed on the first validator node.
 	if tn.Validator && tn.Index == 0 && chainCfg.HostPortOverride != nil {
+		var fields []zap.Field
+
+		i := 0
 		for intP, extP := range chainCfg.HostPortOverride {
-			usingPorts[nat.Port(fmt.Sprintf("%d/tcp", intP))] = []nat.PortBinding{
+			port := nat.Port(fmt.Sprintf("%d/tcp", intP))
+
+			usingPorts[port] = []nat.PortBinding{
 				{
 					HostPort: fmt.Sprintf("%d", extP),
 				},
 			}
+
+			fields = append(fields, zap.String(fmt.Sprintf("port_overrides_%d", i), fmt.Sprintf("%s:%d", port, extP)))
+			i++
 		}
 
-		fmt.Printf("Port Overrides: %v. Using: %v\n", chainCfg.HostPortOverride, usingPorts)
+		tn.log.Info("Port overrides", fields...)
 	}
 
 	return tn.containerLifecycle.CreateContainer(ctx, tn.TestName, tn.NetworkID, tn.Image, usingPorts, tn.Bind(), nil, tn.HostName(), cmd, chainCfg.Env, []string{})

--- a/chain/cosmos/chain_node.go
+++ b/chain/cosmos/chain_node.go
@@ -191,7 +191,7 @@ func (tn *ChainNode) NewSidecarProcess(
 		VolumeName: v.Name,
 		ImageRef:   image.Ref(),
 		TestName:   tn.TestName,
-		UidGid:     image.UidGid,
+		UidGid:     image.UIDGID,
 	}); err != nil {
 		return fmt.Errorf("set volume owner: %w", err)
 	}

--- a/chain/cosmos/chain_node.go
+++ b/chain/cosmos/chain_node.go
@@ -21,10 +21,6 @@ import (
 	volumetypes "github.com/docker/docker/api/types/volume"
 	dockerclient "github.com/docker/docker/client"
 	"github.com/docker/go-connections/nat"
-	"github.com/strangelove-ventures/interchaintest/v8/blockdb"
-	"github.com/strangelove-ventures/interchaintest/v8/dockerutil"
-	"github.com/strangelove-ventures/interchaintest/v8/ibc"
-	"github.com/strangelove-ventures/interchaintest/v8/testutil"
 	"go.uber.org/zap"
 	"golang.org/x/mod/semver"
 	"golang.org/x/sync/errgroup"
@@ -49,6 +45,11 @@ import (
 	rpchttp "github.com/cometbft/cometbft/rpc/client/http"
 	coretypes "github.com/cometbft/cometbft/rpc/core/types"
 	libclient "github.com/cometbft/cometbft/rpc/jsonrpc/client"
+
+	"github.com/strangelove-ventures/interchaintest/v8/blockdb"
+	"github.com/strangelove-ventures/interchaintest/v8/dockerutil"
+	"github.com/strangelove-ventures/interchaintest/v8/ibc"
+	"github.com/strangelove-ventures/interchaintest/v8/testutil"
 )
 
 // ChainNode represents a node in the test network that is being created.
@@ -191,7 +192,7 @@ func (tn *ChainNode) NewSidecarProcess(
 		VolumeName: v.Name,
 		ImageRef:   image.Ref(),
 		TestName:   tn.TestName,
-		UidGid:     image.UIDGID,
+		UIDGID:     image.UIDGID,
 	}); err != nil {
 		return fmt.Errorf("set volume owner: %w", err)
 	}
@@ -429,7 +430,7 @@ func (tn *ChainNode) Height(ctx context.Context) (int64, error) {
 
 // FindTxs implements blockdb.BlockSaver.
 func (tn *ChainNode) FindTxs(ctx context.Context, height int64) ([]blockdb.Tx, error) {
-	h := int64(height)
+	h := height
 	var eg errgroup.Group
 	var blockRes *coretypes.ResultBlockResults
 	var block *coretypes.ResultBlock
@@ -469,8 +470,8 @@ func (tn *ChainNode) FindTxs(ctx context.Context, height int64) ([]blockdb.Tx, e
 			attrs := make([]blockdb.EventAttribute, len(e.Attributes))
 			for k, attr := range e.Attributes {
 				attrs[k] = blockdb.EventAttribute{
-					Key:   string(attr.Key),
-					Value: string(attr.Value),
+					Key:   attr.Key,
+					Value: attr.Value,
 				}
 			}
 			newTx.Events[j] = blockdb.Event{
@@ -489,8 +490,8 @@ func (tn *ChainNode) FindTxs(ctx context.Context, height int64) ([]blockdb.Tx, e
 			attrs := make([]blockdb.EventAttribute, len(e.Attributes))
 			for j, attr := range e.Attributes {
 				attrs[j] = blockdb.EventAttribute{
-					Key:   string(attr.Key),
-					Value: string(attr.Value),
+					Key:   attr.Key,
+					Value: attr.Value,
 				}
 			}
 			finalizeBlockTx.Events[i] = blockdb.Event{
@@ -550,7 +551,7 @@ func (tn *ChainNode) ExecTx(ctx context.Context, keyName string, command ...stri
 		return "", err
 	}
 	output := CosmosTx{}
-	err = json.Unmarshal([]byte(stdout), &output)
+	err = json.Unmarshal(stdout, &output)
 	if err != nil {
 		return "", err
 	}
@@ -566,7 +567,7 @@ func (tn *ChainNode) ExecTx(ctx context.Context, keyName string, command ...stri
 		return "", err
 	}
 	output = CosmosTx{}
-	err = json.Unmarshal([]byte(stdout), &output)
+	err = json.Unmarshal(stdout, &output)
 	if err != nil {
 		return "", err
 	}
@@ -931,12 +932,12 @@ func (tn *ChainNode) HasCommand(ctx context.Context, command ...string) bool {
 		return true
 	}
 
-	if strings.Contains(string(err.Error()), "Error: unknown command") {
+	if strings.Contains(err.Error(), "Error: unknown command") {
 		return false
 	}
 
 	// cmd just needed more arguments, but it is a valid command (ex: appd tx bank send)
-	if strings.Contains(string(err.Error()), "Error: accepts") {
+	if strings.Contains(err.Error(), "Error: accepts") {
 		return true
 	}
 
@@ -962,7 +963,7 @@ func (tn *ChainNode) GetBuildInformation(ctx context.Context) *BinaryBuildInform
 	}
 
 	var deps tempBuildDeps
-	if err := json.Unmarshal([]byte(stdout), &deps); err != nil {
+	if err := json.Unmarshal(stdout, &deps); err != nil {
 		return nil
 	}
 
@@ -1024,7 +1025,7 @@ func (tn *ChainNode) QueryClientContractCode(ctx context.Context, codeHash strin
 	if err != nil {
 		return err
 	}
-	err = json.Unmarshal([]byte(stdout), response)
+	err = json.Unmarshal(stdout, response)
 	return err
 }
 

--- a/chain/cosmos/chain_node.go
+++ b/chain/cosmos/chain_node.go
@@ -192,7 +192,7 @@ func (tn *ChainNode) NewSidecarProcess(
 		VolumeName: v.Name,
 		ImageRef:   image.Ref(),
 		TestName:   tn.TestName,
-		UIDGID:     image.UIDGID,
+		UidGid:     image.UIDGID,
 	}); err != nil {
 		return fmt.Errorf("set volume owner: %w", err)
 	}

--- a/chain/cosmos/codec.go
+++ b/chain/cosmos/codec.go
@@ -1,8 +1,6 @@
 package cosmos
 
 import (
-	ibcwasm "github.com/strangelove-ventures/interchaintest/v8/chain/cosmos/08-wasm-types"
-
 	"cosmossdk.io/x/upgrade"
 
 	"github.com/cosmos/ibc-go/modules/capability"
@@ -29,6 +27,8 @@ import (
 	paramsclient "github.com/cosmos/cosmos-sdk/x/params/client"
 	"github.com/cosmos/cosmos-sdk/x/slashing"
 	"github.com/cosmos/cosmos-sdk/x/staking"
+
+	ibcwasm "github.com/strangelove-ventures/interchaintest/v8/chain/cosmos/08-wasm-types"
 )
 
 func DefaultEncoding() testutil.TestEncodingConfig {

--- a/chain/cosmos/cosmos_chain.go
+++ b/chain/cosmos/cosmos_chain.go
@@ -673,7 +673,7 @@ func (c *CosmosChain) NewChainNode(
 		VolumeName: v.Name,
 		ImageRef:   image.Ref(),
 		TestName:   testName,
-		UIDGID:     image.UIDGID,
+		UidGid:     image.UIDGID,
 	}); err != nil {
 		return nil, fmt.Errorf("set volume owner: %w", err)
 	}
@@ -730,7 +730,7 @@ func (c *CosmosChain) NewSidecarProcess(
 		VolumeName: v.Name,
 		ImageRef:   image.Ref(),
 		TestName:   testName,
-		UIDGID:     image.UIDGID,
+		UidGid:     image.UIDGID,
 	}); err != nil {
 		return fmt.Errorf("set volume owner: %w", err)
 	}

--- a/chain/cosmos/cosmos_chain.go
+++ b/chain/cosmos/cosmos_chain.go
@@ -89,7 +89,7 @@ func NewCosmosHeighlinerChainConfig(name string,
 		Images: []ibc.DockerImage{
 			{
 				Repository: fmt.Sprintf("ghcr.io/strangelove-ventures/heighliner/%s", name),
-				UidGid:     dockerutil.GetHeighlinerUserString(),
+				UIDGID:     dockerutil.GetHeighlinerUserString(),
 			},
 		},
 		Bin: binary,
@@ -674,7 +674,7 @@ func (c *CosmosChain) NewChainNode(
 		VolumeName: v.Name,
 		ImageRef:   image.Ref(),
 		TestName:   testName,
-		UidGid:     image.UidGid,
+		UidGid:     image.UIDGID,
 	}); err != nil {
 		return nil, fmt.Errorf("set volume owner: %w", err)
 	}
@@ -731,7 +731,7 @@ func (c *CosmosChain) NewSidecarProcess(
 		VolumeName: v.Name,
 		ImageRef:   image.Ref(),
 		TestName:   testName,
-		UidGid:     image.UidGid,
+		UidGid:     image.UIDGID,
 	}); err != nil {
 		return fmt.Errorf("set volume owner: %w", err)
 	}

--- a/chain/cosmos/cosmos_chain.go
+++ b/chain/cosmos/cosmos_chain.go
@@ -16,12 +16,6 @@ import (
 	dockertypes "github.com/docker/docker/api/types"
 	volumetypes "github.com/docker/docker/api/types/volume"
 	"github.com/docker/docker/client"
-	"github.com/strangelove-ventures/interchaintest/v8/blockdb"
-	wasmtypes "github.com/strangelove-ventures/interchaintest/v8/chain/cosmos/08-wasm-types"
-	"github.com/strangelove-ventures/interchaintest/v8/chain/internal/tendermint"
-	"github.com/strangelove-ventures/interchaintest/v8/dockerutil"
-	"github.com/strangelove-ventures/interchaintest/v8/ibc"
-	"github.com/strangelove-ventures/interchaintest/v8/testutil"
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
 
@@ -37,10 +31,16 @@ import (
 	"github.com/cosmos/cosmos-sdk/crypto/hd"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	"github.com/cosmos/cosmos-sdk/types"
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	paramsutils "github.com/cosmos/cosmos-sdk/x/params/client/utils"
+
+	"github.com/strangelove-ventures/interchaintest/v8/blockdb"
+	wasmtypes "github.com/strangelove-ventures/interchaintest/v8/chain/cosmos/08-wasm-types"
+	"github.com/strangelove-ventures/interchaintest/v8/chain/internal/tendermint"
+	"github.com/strangelove-ventures/interchaintest/v8/dockerutil"
+	"github.com/strangelove-ventures/interchaintest/v8/ibc"
+	"github.com/strangelove-ventures/interchaintest/v8/testutil"
 )
 
 // CosmosChain is a local docker testnet for a Cosmos SDK chain.
@@ -161,7 +161,6 @@ func (c *CosmosChain) AddFullNodes(ctx context.Context, configFileOverrides map[
 
 	var eg errgroup.Group
 	for i := prevCount; i < c.numFullNodes; i++ {
-		i := i
 		eg.Go(func() error {
 			fn := c.FullNodes[i]
 			if err := fn.InitFullNodeFiles(ctx); err != nil {
@@ -387,7 +386,7 @@ func (c *CosmosChain) SendIBCTransfer(
 		dstPort, _       = tendermint.AttributeValue(events, evType, "packet_dst_port")
 		dstChan, _       = tendermint.AttributeValue(events, evType, "packet_dst_channel")
 		timeoutHeight, _ = tendermint.AttributeValue(events, evType, "packet_timeout_height")
-		timeoutTs, _     = tendermint.AttributeValue(events, evType, "packet_timeout_timestamp")
+		timeoutTS, _     = tendermint.AttributeValue(events, evType, "packet_timeout_timestamp")
 		dataHex, _       = tendermint.AttributeValue(events, evType, "packet_data_hex")
 	)
 	tx.Packet.SourcePort = srcPort
@@ -408,9 +407,9 @@ func (c *CosmosChain) SendIBCTransfer(
 	}
 	tx.Packet.Sequence = seqNum
 
-	timeoutNano, err := strconv.ParseUint(timeoutTs, 10, 64)
+	timeoutNano, err := strconv.ParseUint(timeoutTS, 10, 64)
 	if err != nil {
-		return tx, fmt.Errorf("invalid packet timestamp timeout %s: %w", timeoutTs, err)
+		return tx, fmt.Errorf("invalid packet timestamp timeout %s: %w", timeoutTS, err)
 	}
 	tx.Packet.TimeoutTimestamp = ibc.Nanoseconds(timeoutNano)
 
@@ -429,7 +428,7 @@ func (c *CosmosChain) QueryICAAddress(ctx context.Context, connectionID, address
 
 // SendICATx sends an interchain account transaction for a specified address and sends it to the respective
 // interchain account on the counterparty chain.
-func (c *CosmosChain) SendICATx(ctx context.Context, keyName, connectionID string, msgs []sdk.Msg, icaTxMemo string) (string, error) {
+func (c *CosmosChain) SendICATx(ctx context.Context, keyName, connectionID string, msgs []types.Msg, icaTxMemo string) (string, error) {
 	node := c.getFullNode()
 	registry := node.Chain.Config().EncodingConfig.InterfaceRegistry
 	encoding := "proto3"
@@ -674,7 +673,7 @@ func (c *CosmosChain) NewChainNode(
 		VolumeName: v.Name,
 		ImageRef:   image.Ref(),
 		TestName:   testName,
-		UidGid:     image.UIDGID,
+		UIDGID:     image.UIDGID,
 	}); err != nil {
 		return nil, fmt.Errorf("set volume owner: %w", err)
 	}
@@ -731,7 +730,7 @@ func (c *CosmosChain) NewSidecarProcess(
 		VolumeName: v.Name,
 		ImageRef:   image.Ref(),
 		TestName:   testName,
-		UidGid:     image.UIDGID,
+		UIDGID:     image.UIDGID,
 	}); err != nil {
 		return fmt.Errorf("set volume owner: %w", err)
 	}
@@ -759,7 +758,6 @@ func (c *CosmosChain) initializeChainNodes(
 
 	eg, egCtx := errgroup.WithContext(ctx)
 	for i := len(c.Validators); i < c.NumValidators; i++ {
-		i := i
 		eg.Go(func() error {
 			val, err := c.NewChainNode(egCtx, testName, cli, networkID, image, true, i)
 			if err != nil {
@@ -770,7 +768,6 @@ func (c *CosmosChain) initializeChainNodes(
 		})
 	}
 	for i := len(c.FullNodes); i < c.numFullNodes; i++ {
-		i := i
 		eg.Go(func() error {
 			fn, err := c.NewChainNode(egCtx, testName, cli, networkID, image, false, i)
 			if err != nil {
@@ -799,9 +796,6 @@ func (c *CosmosChain) initializeSidecars(
 ) error {
 	eg, egCtx := errgroup.WithContext(ctx)
 	for i, cfg := range c.cfg.SidecarConfigs {
-		i := i
-		cfg := cfg
-
 		if cfg.ValidatorProcess {
 			continue
 		}
@@ -868,8 +862,6 @@ func (c *CosmosChain) Start(testName string, ctx context.Context, additionalGene
 	eg := new(errgroup.Group)
 	// Initialize config and sign gentx for each validator.
 	for i, v := range c.Validators {
-		v := v
-		i := i
 		v.Validator = true
 		eg.Go(func() error {
 			if err := v.InitFullNodeFiles(ctx); err != nil {
@@ -901,7 +893,6 @@ func (c *CosmosChain) Start(testName string, ctx context.Context, additionalGene
 
 	// Initialize config for each full node.
 	for _, n := range c.FullNodes {
-		n := n
 		n.Validator = false
 		eg.Go(func() error {
 			if err := n.InitFullNodeFiles(ctx); err != nil {
@@ -1018,8 +1009,6 @@ func (c *CosmosChain) Start(testName string, ctx context.Context, additionalGene
 	// Start any sidecar processes that should be running before the chain starts
 	eg, egCtx := errgroup.WithContext(ctx)
 	for _, s := range c.Sidecars {
-		s := s
-
 		err = s.containerLifecycle.Running(ctx)
 		if s.preStart && err != nil {
 			eg.Go(func() error {
@@ -1041,7 +1030,6 @@ func (c *CosmosChain) Start(testName string, ctx context.Context, additionalGene
 
 	eg, egCtx = errgroup.WithContext(ctx)
 	for _, n := range chainNodes {
-		n := n
 		eg.Go(func() error {
 			return n.CreateNodeContainer(egCtx)
 		})
@@ -1054,7 +1042,6 @@ func (c *CosmosChain) Start(testName string, ctx context.Context, additionalGene
 
 	eg, egCtx = errgroup.WithContext(ctx)
 	for _, n := range chainNodes {
-		n := n
 		c.log.Info("Starting container", zap.String("container", n.Name()))
 		eg.Go(func() error {
 			if err := n.SetPeers(egCtx, peers); err != nil {
@@ -1091,7 +1078,6 @@ func (c *CosmosChain) Acknowledgements(ctx context.Context, height int64) ([]ibc
 	}
 	ibcAcks := make([]ibc.PacketAcknowledgement, len(acks))
 	for i, ack := range acks {
-		ack := ack
 		ibcAcks[i] = ibc.PacketAcknowledgement{
 			Acknowledgement: ack.Acknowledgement,
 			Packet: ibc.Packet{
@@ -1124,7 +1110,6 @@ func (c *CosmosChain) Timeouts(ctx context.Context, height int64) ([]ibc.PacketT
 	}
 	ibcTimeouts := make([]ibc.PacketTimeout, len(timeouts))
 	for i, ack := range timeouts {
-		ack := ack
 		ibcTimeouts[i] = ibc.PacketTimeout{
 			Packet: ibc.Packet{
 				Sequence:         ack.Packet.Sequence,
@@ -1153,7 +1138,6 @@ func (c *CosmosChain) FindTxs(ctx context.Context, height int64) ([]blockdb.Tx, 
 func (c *CosmosChain) StopAllNodes(ctx context.Context) error {
 	var eg errgroup.Group
 	for _, n := range c.Nodes() {
-		n := n
 		eg.Go(func() error {
 			if err := n.StopContainer(ctx); err != nil {
 				return err
@@ -1168,7 +1152,6 @@ func (c *CosmosChain) StopAllNodes(ctx context.Context) error {
 func (c *CosmosChain) StopAllSidecars(ctx context.Context) error {
 	var eg errgroup.Group
 	for _, s := range c.Sidecars {
-		s := s
 		eg.Go(func() error {
 			if err := s.StopContainer(ctx); err != nil {
 				return err
@@ -1187,7 +1170,6 @@ func (c *CosmosChain) StartAllNodes(ctx context.Context) error {
 	defer c.findTxMu.Unlock()
 	var eg errgroup.Group
 	for _, n := range c.Nodes() {
-		n := n
 		eg.Go(func() error {
 			if err := n.CreateNodeContainer(ctx); err != nil {
 				return err
@@ -1206,8 +1188,6 @@ func (c *CosmosChain) StartAllSidecars(ctx context.Context) error {
 	defer c.findTxMu.Unlock()
 	var eg errgroup.Group
 	for _, s := range c.Sidecars {
-		s := s
-
 		err := s.containerLifecycle.Running(ctx)
 		if err == nil {
 			continue
@@ -1233,8 +1213,6 @@ func (c *CosmosChain) StartAllValSidecars(ctx context.Context) error {
 
 	for _, v := range c.Validators {
 		for _, s := range v.Sidecars {
-			s := s
-
 			err := s.containerLifecycle.Running(ctx)
 			if err == nil {
 				continue
@@ -1256,7 +1234,6 @@ func (c *CosmosChain) VoteOnProposalAllValidators(ctx context.Context, proposalI
 	var eg errgroup.Group
 	for _, n := range c.Nodes() {
 		if n.Validator {
-			n := n
 			eg.Go(func() error {
 				return n.VoteOnProposal(ctx, valKey, proposalID, vote)
 			})

--- a/chain/cosmos/genesis.go
+++ b/chain/cosmos/genesis.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/icza/dyno"
+
 	"github.com/strangelove-ventures/interchaintest/v8/ibc"
 )
 

--- a/chain/cosmos/ics.go
+++ b/chain/cosmos/ics.go
@@ -12,10 +12,6 @@ import (
 	"time"
 
 	"github.com/icza/dyno"
-	"github.com/strangelove-ventures/interchaintest/v8/dockerutil"
-	"github.com/strangelove-ventures/interchaintest/v8/ibc"
-	"github.com/strangelove-ventures/interchaintest/v8/testreporter"
-	"github.com/strangelove-ventures/interchaintest/v8/testutil"
 	"github.com/tidwall/gjson"
 	"go.uber.org/zap"
 	"golang.org/x/mod/semver"
@@ -29,6 +25,11 @@ import (
 	"github.com/cosmos/cosmos-sdk/types"
 	govv1beta1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1beta1"
 	stakingttypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+
+	"github.com/strangelove-ventures/interchaintest/v8/dockerutil"
+	"github.com/strangelove-ventures/interchaintest/v8/ibc"
+	"github.com/strangelove-ventures/interchaintest/v8/testreporter"
+	"github.com/strangelove-ventures/interchaintest/v8/testutil"
 )
 
 const (
@@ -216,7 +217,6 @@ func (c *CosmosChain) StartConsumer(testName string, ctx context.Context, additi
 	eg := new(errgroup.Group)
 	// Initialize validators and fullnodes.
 	for _, v := range c.Nodes() {
-		v := v
 		eg.Go(func() error {
 			if err := v.InitFullNodeFiles(ctx); err != nil {
 				return err
@@ -249,8 +249,6 @@ func (c *CosmosChain) StartConsumer(testName string, ctx context.Context, additi
 
 	// Copy provider priv val keys to these nodes
 	for i, val := range c.Provider.Validators {
-		i := i
-		val := val
 		eg.Go(func() error {
 			copy := c.cfg.InterchainSecurityConfig.ConsumerCopyProviderKey != nil && c.cfg.InterchainSecurityConfig.ConsumerCopyProviderKey(i)
 			if copy {
@@ -330,16 +328,16 @@ func (c *CosmosChain) StartConsumer(testName string, ctx context.Context, additi
 		return fmt.Errorf("failed to unmarshal ccv state json: %w", err)
 	}
 
-	var genesisJson interface{}
-	if err := json.Unmarshal(genbz, &genesisJson); err != nil {
+	var genesisJSON interface{}
+	if err := json.Unmarshal(genbz, &genesisJSON); err != nil {
 		return fmt.Errorf("failed to unmarshal genesis json: %w", err)
 	}
 
-	if err := dyno.Set(genesisJson, ccvStateUnmarshaled, "app_state", "ccvconsumer"); err != nil {
+	if err := dyno.Set(genesisJSON, ccvStateUnmarshaled, "app_state", "ccvconsumer"); err != nil {
 		return fmt.Errorf("failed to populate ccvconsumer genesis state: %w", err)
 	}
 
-	if genbz, err = json.Marshal(genesisJson); err != nil {
+	if genbz, err = json.Marshal(genesisJSON); err != nil {
 		return fmt.Errorf("failed to marshal genesis bytes to json: %w", err)
 	}
 
@@ -381,7 +379,6 @@ func (c *CosmosChain) StartConsumer(testName string, ctx context.Context, additi
 
 	eg, egCtx := errgroup.WithContext(ctx)
 	for _, n := range chainNodes {
-		n := n
 		eg.Go(func() error {
 			return n.CreateNodeContainer(egCtx)
 		})
@@ -394,7 +391,6 @@ func (c *CosmosChain) StartConsumer(testName string, ctx context.Context, additi
 
 	eg, egCtx = errgroup.WithContext(ctx)
 	for _, n := range chainNodes {
-		n := n
 		c.log.Info("Starting container", zap.String("container", n.Name()))
 		eg.Go(func() error {
 			if err := n.SetPeers(egCtx, peers); err != nil {

--- a/chain/cosmos/module_auth.go
+++ b/chain/cosmos/module_auth.go
@@ -2,11 +2,11 @@ package cosmos
 
 import (
 	"context"
-	"fmt"
 
 	cdctypes "github.com/cosmos/cosmos-sdk/codec/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	vestingtypes "github.com/cosmos/cosmos-sdk/x/auth/vesting/types"
+	"go.uber.org/zap"
 )
 
 // AuthQueryAccount performs a query to get the account details of the specified address.
@@ -112,7 +112,7 @@ func (c *CosmosChain) AuthPrintAccountInfo(chain *CosmosChain, res *cdctypes.Any
 		if err := chain.GetCodec().Unmarshal(res.Value, &modAcc); err != nil {
 			return err
 		}
-		fmt.Printf("ModuleAccount: %+v\n", modAcc)
+		c.log.Info("Account info for ModuleAccount", zap.String("account", modAcc.String()))
 		return nil
 
 	case "/cosmos.vesting.v1beta1.VestingAccount":
@@ -120,7 +120,7 @@ func (c *CosmosChain) AuthPrintAccountInfo(chain *CosmosChain, res *cdctypes.Any
 		if err := chain.GetCodec().Unmarshal(res.Value, &vestingAcc); err != nil {
 			return err
 		}
-		fmt.Printf("BaseVestingAccount: %+v\n", vestingAcc)
+		c.log.Info("Account info for BaseVestingAccount", zap.String("account", vestingAcc.String()))
 		return nil
 
 	case "/cosmos.vesting.v1beta1.PeriodicVestingAccount":
@@ -128,7 +128,7 @@ func (c *CosmosChain) AuthPrintAccountInfo(chain *CosmosChain, res *cdctypes.Any
 		if err := chain.GetCodec().Unmarshal(res.Value, &vestingAcc); err != nil {
 			return err
 		}
-		fmt.Printf("PeriodicVestingAccount: %+v\n", vestingAcc)
+		c.log.Info("Account info for PeriodicVestingAccount", zap.String("account", vestingAcc.String()))
 		return nil
 
 	case "/cosmos.vesting.v1beta1.ContinuousVestingAccount":
@@ -136,7 +136,7 @@ func (c *CosmosChain) AuthPrintAccountInfo(chain *CosmosChain, res *cdctypes.Any
 		if err := chain.GetCodec().Unmarshal(res.Value, &vestingAcc); err != nil {
 			return err
 		}
-		fmt.Printf("ContinuousVestingAccount: %+v\n", vestingAcc)
+		c.log.Info("Account info for ContinuousVestingAccount", zap.String("account", vestingAcc.String()))
 		return nil
 
 	case "/cosmos.vesting.v1beta1.DelayedVestingAccount":
@@ -144,7 +144,7 @@ func (c *CosmosChain) AuthPrintAccountInfo(chain *CosmosChain, res *cdctypes.Any
 		if err := chain.GetCodec().Unmarshal(res.Value, &vestingAcc); err != nil {
 			return err
 		}
-		fmt.Printf("DelayedVestingAccount: %+v\n", vestingAcc)
+		c.log.Info("Account info for DelayedVestingAccount", zap.String("account", vestingAcc.String()))
 		return nil
 
 	case "/cosmos.vesting.v1beta1.PermanentLockedAccount":
@@ -152,7 +152,7 @@ func (c *CosmosChain) AuthPrintAccountInfo(chain *CosmosChain, res *cdctypes.Any
 		if err := chain.GetCodec().Unmarshal(res.Value, &vestingAcc); err != nil {
 			return err
 		}
-		fmt.Printf("PermanentLockedAccount: %+v\n", vestingAcc)
+		c.log.Info("Account info for PermanentLockedAccount", zap.String("account", vestingAcc.String()))
 		return nil
 
 	default:
@@ -160,7 +160,7 @@ func (c *CosmosChain) AuthPrintAccountInfo(chain *CosmosChain, res *cdctypes.Any
 		if err := chain.GetCodec().Unmarshal(res.Value, &baseAcc); err != nil {
 			return err
 		}
-		fmt.Printf("BaseAccount: %+v\n", baseAcc)
+		c.log.Info("Account info for BaseAccount", zap.String("account", baseAcc.String()))
 		return nil
 	}
 }

--- a/chain/cosmos/module_auth.go
+++ b/chain/cosmos/module_auth.go
@@ -3,10 +3,11 @@ package cosmos
 import (
 	"context"
 
+	"go.uber.org/zap"
+
 	cdctypes "github.com/cosmos/cosmos-sdk/codec/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	vestingtypes "github.com/cosmos/cosmos-sdk/x/auth/vesting/types"
-	"go.uber.org/zap"
 )
 
 // AuthQueryAccount performs a query to get the account details of the specified address.

--- a/chain/cosmos/module_authz.go
+++ b/chain/cosmos/module_authz.go
@@ -6,10 +6,10 @@ import (
 	"path"
 	"strings"
 
-	"github.com/strangelove-ventures/interchaintest/v8/ibc"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/authz"
+
+	"github.com/strangelove-ventures/interchaintest/v8/ibc"
 )
 
 // AuthzGrant grants a message as a permission to an account.

--- a/chain/cosmos/module_bank.go
+++ b/chain/cosmos/module_bank.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/strangelove-ventures/interchaintest/v8/ibc"
-
 	sdkmath "cosmossdk.io/math"
 
 	"github.com/cosmos/cosmos-sdk/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+
+	"github.com/strangelove-ventures/interchaintest/v8/ibc"
 )
 
 // BankSend sends tokens from one account to another.

--- a/chain/cosmos/module_cosmwasm.go
+++ b/chain/cosmos/module_cosmwasm.go
@@ -10,10 +10,9 @@ import (
 	"path"
 	"path/filepath"
 
-	"github.com/strangelove-ventures/interchaintest/v8/testutil"
-
 	"github.com/cosmos/cosmos-sdk/types"
-	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/strangelove-ventures/interchaintest/v8/testutil"
 )
 
 type InstantiateContractAttribute struct {
@@ -69,7 +68,7 @@ func (tn *ChainNode) StoreContract(ctx context.Context, keyName string, fileName
 	}
 
 	res := CodeInfosResponse{}
-	if err := json.Unmarshal([]byte(stdout), &res); err != nil {
+	if err := json.Unmarshal(stdout, &res); err != nil {
 		return "", err
 	}
 
@@ -102,7 +101,7 @@ func (tn *ChainNode) InstantiateContract(ctx context.Context, keyName string, co
 	}
 
 	contactsRes := QueryContractResponse{}
-	if err := json.Unmarshal([]byte(stdout), &contactsRes); err != nil {
+	if err := json.Unmarshal(stdout, &contactsRes); err != nil {
 		return "", err
 	}
 
@@ -111,18 +110,18 @@ func (tn *ChainNode) InstantiateContract(ctx context.Context, keyName string, co
 }
 
 // ExecuteContract executes a contract transaction with a message using it's address.
-func (tn *ChainNode) ExecuteContract(ctx context.Context, keyName string, contractAddress string, message string, extraExecTxArgs ...string) (res *sdk.TxResponse, err error) {
+func (tn *ChainNode) ExecuteContract(ctx context.Context, keyName string, contractAddress string, message string, extraExecTxArgs ...string) (res *types.TxResponse, err error) {
 	cmd := []string{"wasm", "execute", contractAddress, message}
 	cmd = append(cmd, extraExecTxArgs...)
 
 	txHash, err := tn.ExecTx(ctx, keyName, cmd...)
 	if err != nil {
-		return &sdk.TxResponse{}, err
+		return &types.TxResponse{}, err
 	}
 
 	txResp, err := tn.GetTransaction(tn.CliContext(), txHash)
 	if err != nil {
-		return &sdk.TxResponse{}, fmt.Errorf("failed to get transaction %s: %w", txHash, err)
+		return &types.TxResponse{}, fmt.Errorf("failed to get transaction %s: %w", txHash, err)
 	}
 
 	if txResp.Code != 0 {
@@ -158,7 +157,7 @@ func (tn *ChainNode) QueryContract(ctx context.Context, contractAddress string, 
 	if err != nil {
 		return err
 	}
-	err = json.Unmarshal([]byte(stdout), response)
+	err = json.Unmarshal(stdout, response)
 	return err
 }
 
@@ -221,7 +220,7 @@ func (tn *ChainNode) DumpContractState(ctx context.Context, contractAddress stri
 	}
 
 	res := new(DumpContractStateResponse)
-	if err := json.Unmarshal([]byte(stdout), res); err != nil {
+	if err := json.Unmarshal(stdout, res); err != nil {
 		return nil, err
 	}
 	return res, nil

--- a/chain/cosmos/module_gov.go
+++ b/chain/cosmos/module_gov.go
@@ -9,13 +9,13 @@ import (
 	"path/filepath"
 	"strconv"
 
-	"github.com/strangelove-ventures/interchaintest/v8/dockerutil"
-
 	upgradetypes "cosmossdk.io/x/upgrade/types"
 
 	govv1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
 	govv1beta1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1beta1"
 	paramsutils "github.com/cosmos/cosmos-sdk/x/params/client/utils"
+
+	"github.com/strangelove-ventures/interchaintest/v8/dockerutil"
 )
 
 // VoteOnProposal submits a vote for the specified proposal.
@@ -30,13 +30,13 @@ func (tn *ChainNode) VoteOnProposal(ctx context.Context, keyName string, proposa
 // SubmitProposal submits a gov v1 proposal to the chain.
 func (tn *ChainNode) SubmitProposal(ctx context.Context, keyName string, prop TxProposalv1) (string, error) {
 	file := "proposal.json"
-	propJson, err := json.MarshalIndent(prop, "", " ")
+	propJSON, err := json.MarshalIndent(prop, "", " ")
 	if err != nil {
 		return "", err
 	}
 
 	fw := dockerutil.NewFileWriter(tn.logger(), tn.DockerClient, tn.TestName)
-	if err := fw.WriteFile(ctx, tn.VolumeName, file, propJson); err != nil {
+	if err := fw.WriteFile(ctx, tn.VolumeName, file, propJSON); err != nil {
 		return "", fmt.Errorf("writing contract file to docker volume: %w", err)
 	}
 

--- a/chain/cosmos/module_vesting.go
+++ b/chain/cosmos/module_vesting.go
@@ -6,9 +6,9 @@ import (
 	"fmt"
 	"path"
 
-	"github.com/strangelove-ventures/interchaintest/v8/dockerutil"
-
 	vestingcli "github.com/cosmos/cosmos-sdk/x/auth/vesting/client/cli"
+
+	"github.com/strangelove-ventures/interchaintest/v8/dockerutil"
 )
 
 // VestingCreateAccount creates a new vesting account funded with an allocation of tokens. The account can either be a delayed or continuous vesting account, which is determined by the '--delayed' flag.
@@ -41,7 +41,7 @@ func (tn *ChainNode) VestingCreatePermanentLockedAccount(ctx context.Context, ke
 }
 
 // VestingCreatePeriodicAccount is a sequence of coins and period length in seconds.
-// Periods are sequential, in that the duration of of a period only starts at the end of the previous period.
+// Periods are sequential, in that the duration of a period only starts at the end of the previous period.
 // The duration of the first period starts upon account creation.
 func (tn *ChainNode) VestingCreatePeriodicAccount(ctx context.Context, keyName string, toAddr string, periods vestingcli.VestingData, flags ...string) error {
 	file := "periods.json"

--- a/chain/cosmos/node_test.go
+++ b/chain/cosmos/node_test.go
@@ -4,10 +4,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/strangelove-ventures/interchaintest/v8/chain/cosmos"
 	"github.com/stretchr/testify/require"
 
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+
+	"github.com/strangelove-ventures/interchaintest/v8/chain/cosmos"
 )
 
 func TestCondenseMoniker_MiddleDetail(t *testing.T) {

--- a/chain/cosmos/poll.go
+++ b/chain/cosmos/poll.go
@@ -5,12 +5,12 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/strangelove-ventures/interchaintest/v8/ibc"
-	"github.com/strangelove-ventures/interchaintest/v8/testutil"
-
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	govv1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
 	govv1beta1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1beta1"
+
+	"github.com/strangelove-ventures/interchaintest/v8/ibc"
+	"github.com/strangelove-ventures/interchaintest/v8/testutil"
 )
 
 // PollForProposalStatus attempts to find a proposal with matching ID and status using gov v1.
@@ -57,7 +57,7 @@ func PollForMessage[T any](ctx context.Context, chain *CosmosChain, registry cod
 		fn = func(T) bool { return true }
 	}
 	doPoll := func(ctx context.Context, height int64) (T, error) {
-		h := int64(height)
+		h := height
 		block, err := chain.getFullNode().Client.Block(ctx, &h)
 		if err != nil {
 			return zero, err

--- a/chain/cosmos/query.go
+++ b/chain/cosmos/query.go
@@ -17,7 +17,7 @@ type blockClient interface {
 // RangeBlockMessages iterates through all a block's transactions and each transaction's messages yielding to f.
 // Return true from f to stop iteration.
 func RangeBlockMessages(ctx context.Context, interfaceRegistry codectypes.InterfaceRegistry, client blockClient, height int64, done func(sdk.Msg) bool) error {
-	h := int64(height)
+	h := height
 	block, err := client.Block(ctx, &h)
 	if err != nil {
 		return fmt.Errorf("tendermint rpc get block: %w", err)

--- a/chain/cosmos/sidecar.go
+++ b/chain/cosmos/sidecar.go
@@ -7,9 +7,10 @@ import (
 
 	dockerclient "github.com/docker/docker/client"
 	"github.com/docker/go-connections/nat"
+	"go.uber.org/zap"
+
 	"github.com/strangelove-ventures/interchaintest/v8/dockerutil"
 	"github.com/strangelove-ventures/interchaintest/v8/ibc"
-	"go.uber.org/zap"
 )
 
 type SidecarProcesses []*SidecarProcess

--- a/chain/cosmos/wallet.go
+++ b/chain/cosmos/wallet.go
@@ -1,9 +1,9 @@
 package cosmos
 
 import (
-	"github.com/strangelove-ventures/interchaintest/v8/ibc"
-
 	"github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/strangelove-ventures/interchaintest/v8/ibc"
 )
 
 var (

--- a/chain/cosmos/wasm/wasm.go
+++ b/chain/cosmos/wasm/wasm.go
@@ -2,10 +2,11 @@ package wasm
 
 import (
 	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
-	// simappparams "github.com/cosmos/cosmos-sdk/simapp/params".
-	"github.com/strangelove-ventures/interchaintest/v8/chain/cosmos"
 
 	"github.com/cosmos/cosmos-sdk/types/module/testutil"
+
+	// simappparams "github.com/cosmos/cosmos-sdk/simapp/params".
+	"github.com/strangelove-ventures/interchaintest/v8/chain/cosmos"
 )
 
 func WasmEncoding() *testutil.TestEncodingConfig {

--- a/chain/ethereum/ethererum_chain.go
+++ b/chain/ethereum/ethererum_chain.go
@@ -92,7 +92,7 @@ func (c *EthereumChain) Initialize(ctx context.Context, testName string, cli *do
 		VolumeName: v.Name,
 		ImageRef:   image.Ref(),
 		TestName:   testName,
-		UidGid:     image.UidGid,
+		UidGid:     image.UIDGID,
 	}); err != nil {
 		return fmt.Errorf("set volume owner: %w", err)
 	}

--- a/chain/ethereum/ethererum_chain.go
+++ b/chain/ethereum/ethererum_chain.go
@@ -14,12 +14,13 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/ethclient"
-	"github.com/strangelove-ventures/interchaintest/v8/dockerutil"
-	"github.com/strangelove-ventures/interchaintest/v8/ibc"
-	"github.com/strangelove-ventures/interchaintest/v8/testutil"
 	"go.uber.org/zap"
 
 	sdkmath "cosmossdk.io/math"
+
+	"github.com/strangelove-ventures/interchaintest/v8/dockerutil"
+	"github.com/strangelove-ventures/interchaintest/v8/ibc"
+	"github.com/strangelove-ventures/interchaintest/v8/testutil"
 )
 
 const (
@@ -92,7 +93,7 @@ func (c *EthereumChain) Initialize(ctx context.Context, testName string, cli *do
 		VolumeName: v.Name,
 		ImageRef:   image.Ref(),
 		TestName:   testName,
-		UidGid:     image.UIDGID,
+		UIDGID:     image.UIDGID,
 	}); err != nil {
 		return fmt.Errorf("set volume owner: %w", err)
 	}

--- a/chain/ethereum/ethererum_chain.go
+++ b/chain/ethereum/ethererum_chain.go
@@ -93,7 +93,7 @@ func (c *EthereumChain) Initialize(ctx context.Context, testName string, cli *do
 		VolumeName: v.Name,
 		ImageRef:   image.Ref(),
 		TestName:   testName,
-		UIDGID:     image.UIDGID,
+		UidGid:     image.UIDGID,
 	}); err != nil {
 		return fmt.Errorf("set volume owner: %w", err)
 	}

--- a/chain/ethereum/ethererum_chain.go
+++ b/chain/ethereum/ethererum_chain.go
@@ -139,15 +139,23 @@ func (c *EthereumChain) Start(ctx context.Context, cmd []string, mount []mount.M
 	}
 
 	if c.cfg.HostPortOverride != nil {
+		var fields []zap.Field
+
+		i := 0
 		for intP, extP := range c.cfg.HostPortOverride {
-			usingPorts[nat.Port(fmt.Sprintf("%d/tcp", intP))] = []nat.PortBinding{
+			port := nat.Port(fmt.Sprintf("%d/tcp", intP))
+
+			usingPorts[port] = []nat.PortBinding{
 				{
 					HostPort: fmt.Sprintf("%d", extP),
 				},
 			}
+
+			fields = append(fields, zap.String(fmt.Sprintf("port_overrides_%d", i), fmt.Sprintf("%s:%d", port, extP)))
+			i++
 		}
 
-		fmt.Printf("Port Overrides: %v. Using: %v\n", c.cfg.HostPortOverride, usingPorts)
+		c.log.Info("Port overrides", fields...)
 	}
 
 	err := c.containerLifecycle.CreateContainer(ctx, c.testName, c.networkID, c.cfg.Images[0], usingPorts, c.Bind(), mount, c.HostName(), cmd, nil, []string{})

--- a/chain/ethereum/foundry/anvil_chain.go
+++ b/chain/ethereum/foundry/anvil_chain.go
@@ -52,16 +52,16 @@ func (c *AnvilChain) Start(testName string, ctx context.Context, additionalGenes
 		if err != nil {
 			return err
 		}
-		localJsonFile := filepath.Join(pwd, loadState)
-		dockerJsonFile := path.Join(c.HomeDir(), path.Base(loadState))
+		localJSONFile := filepath.Join(pwd, loadState)
+		dockerJSONFile := path.Join(c.HomeDir(), path.Base(loadState))
 		mounts = []mount.Mount{
 			{
 				Type:   mount.TypeBind,
-				Source: localJsonFile,
-				Target: dockerJsonFile,
+				Source: localJSONFile,
+				Target: dockerJSONFile,
 			},
 		}
-		cmd = append(cmd, "--load-state", dockerJsonFile)
+		cmd = append(cmd, "--load-state", dockerJSONFile)
 	}
 
 	return c.EthereumChain.Start(ctx, cmd, mounts)
@@ -201,7 +201,7 @@ func (c *AnvilChain) BuildWallet(ctx context.Context, keyName string, mnemonic s
 	} else {
 		// Use the genesis account
 		if keyName == "faucet" {
-			mnemonic = "test test test test test test test test test test test junk"
+			mnemonic = "test test test test test test test test test test test junk" //nolint: dupword
 			err := c.RecoverKey(ctx, keyName, mnemonic)
 			if err != nil {
 				return nil, err

--- a/chain/ethereum/foundry/anvil_chain.go
+++ b/chain/ethereum/foundry/anvil_chain.go
@@ -12,9 +12,10 @@ import (
 
 	"github.com/docker/docker/api/types/mount"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"go.uber.org/zap"
+
 	"github.com/strangelove-ventures/interchaintest/v8/chain/ethereum"
 	"github.com/strangelove-ventures/interchaintest/v8/ibc"
-	"go.uber.org/zap"
 )
 
 var _ ibc.Chain = &AnvilChain{}

--- a/chain/ethereum/foundry/default_configs.go
+++ b/chain/ethereum/foundry/default_configs.go
@@ -22,7 +22,7 @@ func DefaultEthereumAnvilChainConfig(
 			{
 				Repository: "ghcr.io/foundry-rs/foundry",
 				Version:    "latest",
-				UidGid:     "1000:1000",
+				UIDGID:     "1000:1000",
 			},
 		},
 		Bin: "anvil",

--- a/chain/ethereum/foundry/forge.go
+++ b/chain/ethereum/foundry/forge.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 
 	"github.com/docker/docker/api/types/mount"
+
 	"github.com/strangelove-ventures/interchaintest/v8/dockerutil"
 )
 

--- a/chain/ethereum/geth/default_configs.go
+++ b/chain/ethereum/geth/default_configs.go
@@ -22,7 +22,7 @@ func DefaultEthereumGethChainConfig(
 			{
 				Repository: "ethereum/client-go",
 				Version:    "v1.14.7",
-				UidGid:     "1025:1025",
+				UIDGID:     "1025:1025",
 			},
 		},
 		Bin: "geth",
@@ -59,7 +59,7 @@ func DefaultBscChainConfig(
 				Repository: "ghcr.io/bnb-chain/bsc",
 				Version:    "1.2.13", // same version as other sim tests
 				// Version:    "1.4.13", // this version does not work in dev mode (1.3.x+)
-				UidGid: "1000:1000",
+				UIDGID: "1000:1000",
 			},
 		},
 		Bin: "geth",

--- a/chain/ethereum/geth/geth_chain.go
+++ b/chain/ethereum/geth/geth_chain.go
@@ -10,12 +10,13 @@ import (
 
 	"github.com/docker/docker/api/types/mount"
 	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/strangelove-ventures/interchaintest/v8/chain/ethereum"
-	"github.com/strangelove-ventures/interchaintest/v8/ibc"
-	"github.com/strangelove-ventures/interchaintest/v8/testutil"
 	"go.uber.org/zap"
 
 	"github.com/cosmos/cosmos-sdk/crypto/hd"
+
+	"github.com/strangelove-ventures/interchaintest/v8/chain/ethereum"
+	"github.com/strangelove-ventures/interchaintest/v8/ibc"
+	"github.com/strangelove-ventures/interchaintest/v8/testutil"
 )
 
 var _ ibc.Chain = &GethChain{}

--- a/chain/ethereum/wallet.go
+++ b/chain/ethereum/wallet.go
@@ -2,6 +2,7 @@ package ethereum
 
 import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
+
 	"github.com/strangelove-ventures/interchaintest/v8/ibc"
 )
 

--- a/chain/internal/tendermint/tendermint_node.go
+++ b/chain/internal/tendermint/tendermint_node.go
@@ -77,7 +77,7 @@ func NewTendermintNode(
 		VolumeName: tn.VolumeName,
 		ImageRef:   tn.Image.Ref(),
 		TestName:   tn.TestName,
-		UIDGID:     tn.Image.UIDGID,
+		UidGid:     tn.Image.UIDGID,
 	}); err != nil {
 		return nil, fmt.Errorf("set tendermint volume owner: %w", err)
 	}

--- a/chain/internal/tendermint/tendermint_node.go
+++ b/chain/internal/tendermint/tendermint_node.go
@@ -13,9 +13,6 @@ import (
 	dockerclient "github.com/docker/docker/client"
 	"github.com/docker/go-connections/nat"
 	"github.com/hashicorp/go-version"
-	"github.com/strangelove-ventures/interchaintest/v8/dockerutil"
-	"github.com/strangelove-ventures/interchaintest/v8/ibc"
-	"github.com/strangelove-ventures/interchaintest/v8/testutil"
 	"go.uber.org/zap"
 
 	tmjson "github.com/cometbft/cometbft/libs/json"
@@ -23,6 +20,10 @@ import (
 	rpcclient "github.com/cometbft/cometbft/rpc/client"
 	rpchttp "github.com/cometbft/cometbft/rpc/client/http"
 	libclient "github.com/cometbft/cometbft/rpc/jsonrpc/client"
+
+	"github.com/strangelove-ventures/interchaintest/v8/dockerutil"
+	"github.com/strangelove-ventures/interchaintest/v8/ibc"
+	"github.com/strangelove-ventures/interchaintest/v8/testutil"
 )
 
 // TendermintNode represents a node in the test network that is being created.
@@ -76,7 +77,7 @@ func NewTendermintNode(
 		VolumeName: tn.VolumeName,
 		ImageRef:   tn.Image.Ref(),
 		TestName:   tn.TestName,
-		UidGid:     tn.Image.UIDGID,
+		UIDGID:     tn.Image.UIDGID,
 	}); err != nil {
 		return nil, fmt.Errorf("set tendermint volume owner: %w", err)
 	}

--- a/chain/internal/tendermint/tendermint_node.go
+++ b/chain/internal/tendermint/tendermint_node.go
@@ -76,7 +76,7 @@ func NewTendermintNode(
 		VolumeName: tn.VolumeName,
 		ImageRef:   tn.Image.Ref(),
 		TestName:   tn.TestName,
-		UidGid:     tn.Image.UidGid,
+		UidGid:     tn.Image.UIDGID,
 	}); err != nil {
 		return nil, fmt.Errorf("set tendermint volume owner: %w", err)
 	}

--- a/chain/internal/tendermint/tendermint_node.go
+++ b/chain/internal/tendermint/tendermint_node.go
@@ -348,15 +348,18 @@ func (tn TendermintNodes) PeerString(ctx context.Context, node *TendermintNode) 
 			// don't peer with ourself
 			continue
 		}
+
 		id, err := n.NodeID(ctx)
 		if err != nil {
 			// TODO: would this be better to panic?
 			// When would NodeId return an error?
 			break
 		}
+
 		hostName := n.HostName()
 		ps := fmt.Sprintf("%s@%s:26656", id, hostName)
-		fmt.Printf("{%s} peering (%s)\n", hostName, ps)
+		n.Log.Info("Peering", zap.String("hostname", hostName), zap.String("peer_string", ps))
+
 		addrs[i] = ps
 	}
 	return strings.Join(addrs, ",")

--- a/chain/penumbra/penumbra_app_node.go
+++ b/chain/penumbra/penumbra_app_node.go
@@ -79,7 +79,7 @@ func NewPenumbraAppNode(
 		VolumeName: pn.VolumeName,
 		ImageRef:   pn.Image.Ref(),
 		TestName:   pn.TestName,
-		UidGid:     image.UidGid,
+		UidGid:     image.UIDGID,
 	}); err != nil {
 		return nil, fmt.Errorf("set penumbra volume owner: %w", err)
 	}
@@ -124,8 +124,8 @@ func (p *PenumbraAppNode) HomeDir() string {
 // CreateKey attempts to initialize a new pcli config file with a newly generated FullViewingKey and CustodyKey.
 func (p *PenumbraAppNode) CreateKey(ctx context.Context, keyName string) error {
 	keyPath := filepath.Join(p.HomeDir(), "keys", keyName)
-	pdUrl := fmt.Sprintf("http://%s:8080", p.HostName())
-	cmd := []string{"pcli", "--home", keyPath, "init", "--grpc-url", pdUrl, "soft-kms", "generate"}
+	pdURL := fmt.Sprintf("http://%s:8080", p.HostName())
+	cmd := []string{"pcli", "--home", keyPath, "init", "--grpc-url", pdURL, "soft-kms", "generate"}
 
 	_, stderr, err := p.Exec(ctx, cmd, nil)
 
@@ -248,13 +248,13 @@ func (p *PenumbraAppNode) GenerateGenesisFile(
 	validators []PenumbraValidatorDefinition,
 	allocations []PenumbraGenesisAppStateAllocation,
 ) error {
-	validatorsJson, err := json.Marshal(validators)
+	validatorsJSON, err := json.Marshal(validators)
 	if err != nil {
 		return fmt.Errorf("error marshalling validators to json: %w", err)
 	}
 
 	fw := dockerutil.NewFileWriter(p.log, p.DockerClient, p.TestName)
-	if err := fw.WriteFile(ctx, p.VolumeName, "validators.json", validatorsJson); err != nil {
+	if err := fw.WriteFile(ctx, p.VolumeName, "validators.json", validatorsJSON); err != nil {
 		return fmt.Errorf("error writing validators to file: %w", err)
 	}
 
@@ -387,7 +387,7 @@ func (p *PenumbraAppNode) Exec(ctx context.Context, cmd []string, env []string) 
 	opts := dockerutil.ContainerOptions{
 		Binds: p.Bind(),
 		Env:   env,
-		User:  p.Image.UidGid,
+		User:  p.Image.UIDGID,
 	}
 
 	res := job.Run(ctx, cmd, opts)

--- a/chain/penumbra/penumbra_app_node.go
+++ b/chain/penumbra/penumbra_app_node.go
@@ -313,7 +313,8 @@ func (p *PenumbraAppNode) GetBalance(ctx context.Context, keyName string) (int64
 		return 0, err
 	}
 
-	fmt.Printf("STDOUT BAL: '%s'\n", string(stdout))
+	p.log.Info("Balance query result", zap.String("key_name", keyName), zap.String("output", string(stdout)))
+
 	return 0, nil
 }
 

--- a/chain/penumbra/penumbra_app_node.go
+++ b/chain/penumbra/penumbra_app_node.go
@@ -11,11 +11,11 @@ import (
 	"github.com/BurntSushi/toml"
 	volumetypes "github.com/docker/docker/api/types/volume"
 	"github.com/docker/docker/client"
-	dockerclient "github.com/docker/docker/client"
 	"github.com/docker/go-connections/nat"
+	"go.uber.org/zap"
+
 	"github.com/strangelove-ventures/interchaintest/v8/dockerutil"
 	"github.com/strangelove-ventures/interchaintest/v8/ibc"
-	"go.uber.org/zap"
 )
 
 // PenumbraAppNode represents an instance of pcli.
@@ -49,7 +49,7 @@ func NewPenumbraAppNode(
 	chain *PenumbraChain,
 	index int,
 	testName string,
-	dockerClient *dockerclient.Client,
+	dockerClient *client.Client,
 	networkID string,
 	image ibc.DockerImage,
 ) (*PenumbraAppNode, error) {
@@ -79,7 +79,7 @@ func NewPenumbraAppNode(
 		VolumeName: pn.VolumeName,
 		ImageRef:   pn.Image.Ref(),
 		TestName:   pn.TestName,
-		UidGid:     image.UIDGID,
+		UIDGID:     image.UIDGID,
 	}); err != nil {
 		return nil, fmt.Errorf("set penumbra volume owner: %w", err)
 	}

--- a/chain/penumbra/penumbra_app_node.go
+++ b/chain/penumbra/penumbra_app_node.go
@@ -79,7 +79,7 @@ func NewPenumbraAppNode(
 		VolumeName: pn.VolumeName,
 		ImageRef:   pn.Image.Ref(),
 		TestName:   pn.TestName,
-		UIDGID:     image.UIDGID,
+		UidGid:     image.UIDGID,
 	}); err != nil {
 		return nil, fmt.Errorf("set penumbra volume owner: %w", err)
 	}

--- a/chain/penumbra/penumbra_chain.go
+++ b/chain/penumbra/penumbra_chain.go
@@ -13,10 +13,6 @@ import (
 	"github.com/BurntSushi/toml"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
-	"github.com/strangelove-ventures/interchaintest/v8/chain/internal/tendermint"
-	"github.com/strangelove-ventures/interchaintest/v8/dockerutil"
-	"github.com/strangelove-ventures/interchaintest/v8/ibc"
-	"github.com/strangelove-ventures/interchaintest/v8/testutil"
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
 
@@ -27,6 +23,11 @@ import (
 	cryptocodec "github.com/cosmos/cosmos-sdk/crypto/codec"
 	"github.com/cosmos/cosmos-sdk/crypto/hd"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
+
+	"github.com/strangelove-ventures/interchaintest/v8/chain/internal/tendermint"
+	"github.com/strangelove-ventures/interchaintest/v8/dockerutil"
+	"github.com/strangelove-ventures/interchaintest/v8/ibc"
+	"github.com/strangelove-ventures/interchaintest/v8/testutil"
 )
 
 type PenumbraChain struct {
@@ -369,9 +370,6 @@ func (c *PenumbraChain) Start(_ string, ctx context.Context, additionalGenesisWa
 
 	eg, egCtx := errgroup.WithContext(ctx)
 	for i, v := range validators {
-		v := v
-		i := i
-
 		keyName := fmt.Sprintf("%s-%d", valKey, i)
 		eg.Go(func() error {
 			if err := v.TendermintNode.InitValidatorFiles(egCtx); err != nil {
@@ -461,7 +459,6 @@ func (c *PenumbraChain) Start(_ string, ctx context.Context, additionalGenesisWa
 	}
 
 	for _, n := range fullnodes {
-		n := n
 		eg.Go(func() error { return n.TendermintNode.InitFullNodeFiles(egCtx) })
 	}
 
@@ -477,8 +474,6 @@ func (c *PenumbraChain) Start(_ string, ctx context.Context, additionalGenesisWa
 	// penumbra generate-testnet right now overwrites new validator keys
 	eg, egCtx = errgroup.WithContext(ctx)
 	for i, val := range c.PenumbraNodes[:c.numValidators] {
-		i := i
-		val := val
 		// Use an errgroup to save some time doing many concurrent copies inside containers.
 		eg.Go(func() error {
 			firstValPrivKeyRelPath := fmt.Sprintf(".penumbra/testnet_data/node%d/cometbft/config/priv_validator_key.json", i)
@@ -529,8 +524,6 @@ func (c *PenumbraChain) start(ctx context.Context) error {
 
 	eg, egCtx := errgroup.WithContext(ctx)
 	for _, n := range c.PenumbraNodes {
-		n := n
-
 		sep, err := n.TendermintNode.GetConfigSeparator()
 		if err != nil {
 			return err
@@ -555,8 +548,6 @@ func (c *PenumbraChain) start(ctx context.Context) error {
 
 	eg, egCtx = errgroup.WithContext(ctx)
 	for _, n := range c.PenumbraNodes {
-		n := n
-
 		c.log.Info("Starting tendermint container", zap.String("container", n.TendermintNode.Name()))
 		eg.Go(func() error {
 			peers := tmNodes.PeerString(egCtx, n.TendermintNode)
@@ -581,9 +572,6 @@ func (c *PenumbraChain) start(ctx context.Context) error {
 
 	eg, egCtx = errgroup.WithContext(ctx)
 	for i, val := range c.PenumbraNodes[:c.numValidators] {
-		val := val
-		i := i
-
 		keyName := fmt.Sprintf("%s-%d", valKey, i)
 
 		eg.Go(func() error {

--- a/chain/penumbra/penumbra_client_node.go
+++ b/chain/penumbra/penumbra_client_node.go
@@ -299,9 +299,15 @@ func (p *PenumbraClientNode) SendIBCTransfer(
 	}
 
 	if os.Getenv("ICTEST_DEBUG") != "" {
-		fmt.Printf("Timeout timestamp: %+v \n", timeoutTimestamp)
-		fmt.Printf("Timeout: %+v \n", timeoutHeight)
-		fmt.Printf("Withdrawal: %+v \n", withdrawal)
+		p.log.Info("Ics20 withdrawal info",
+			zap.String("denom", withdrawal.Denom.Denom),
+			zap.String("amount", amount.Amount.String()),
+			zap.String("destination_chain_address", withdrawal.DestinationChainAddress),
+			zap.String("return_address", withdrawal.ReturnAddress.String()),
+			zap.String("channel_id", channelID),
+			zap.String("timeout_height", withdrawal.TimeoutHeight.String()),
+			zap.Uint64("timeout_timestamp", timeoutTimestamp),
+		)
 	}
 
 	// Generate a transaction plan sending ics_20 transfer

--- a/chain/penumbra/penumbra_client_node.go
+++ b/chain/penumbra/penumbra_client_node.go
@@ -110,7 +110,7 @@ func NewClientNode(
 		VolumeName: p.VolumeName,
 		ImageRef:   image.Ref(),
 		TestName:   testName,
-		UIDGID:     image.UIDGID,
+		UidGid:     image.UIDGID,
 	}); err != nil {
 		return nil, fmt.Errorf("set pclientd volume owner: %w", err)
 	}

--- a/chain/penumbra/penumbra_client_node_test.go
+++ b/chain/penumbra/penumbra_client_node_test.go
@@ -4,10 +4,11 @@ import (
 	"math/big"
 	"testing"
 
-	"github.com/strangelove-ventures/interchaintest/v8/ibc"
 	"github.com/stretchr/testify/require"
 
 	"cosmossdk.io/math"
+
+	"github.com/strangelove-ventures/interchaintest/v8/ibc"
 )
 
 // TestBigIntDecoding tests the decoding of big integers.

--- a/chain/penumbra/penumbra_node.go
+++ b/chain/penumbra/penumbra_node.go
@@ -6,9 +6,10 @@ import (
 	"sync"
 
 	dockerclient "github.com/docker/docker/client"
+	"go.uber.org/zap"
+
 	"github.com/strangelove-ventures/interchaintest/v8/chain/internal/tendermint"
 	"github.com/strangelove-ventures/interchaintest/v8/ibc"
-	"go.uber.org/zap"
 )
 
 // PenumbraNode reporesents a node in the Penumbra network which consists of one instance of Tendermint,

--- a/chain/polkadot/keys.go
+++ b/chain/polkadot/keys.go
@@ -23,7 +23,7 @@ func DeriveEd25519FromName(name string) (*p2pCrypto.Ed25519PrivateKey, error) {
 	chainCode := make([]byte, 32)
 	derivePath := []byte{byte(len(name) << 2)}
 	derivePath = append(derivePath, []byte(namecase.New().NameCase(name))...)
-	_ = copy(chainCode, []byte(derivePath))
+	_ = copy(chainCode, derivePath)
 
 	hasher, err := blake2b.New256(nil)
 	if err != nil {
@@ -68,7 +68,7 @@ func DeriveSr25519FromName(path []string) (*schnorrkel.MiniSecretKey, error) {
 		var chainCode [32]byte
 		derivePath := []byte{byte(len(pathItem) << 2)}
 		derivePath = append(derivePath, []byte(pathItem)...)
-		_ = copy(chainCode[:], []byte(derivePath))
+		_ = copy(chainCode[:], derivePath)
 		miniSecret, _, err = miniSecret.HardDeriveMiniSecretKey([]byte{}, chainCode)
 		if err != nil {
 			return nil, fmt.Errorf("error hard deriving mini secret key")
@@ -82,7 +82,7 @@ func DeriveSecp256k1FromName(name string) (*secp256k1.PrivateKey, error) {
 	chainCode := make([]byte, 32)
 	derivePath := []byte{byte(len(name) << 2)}
 	derivePath = append(derivePath, []byte(namecase.New().NameCase(name))...)
-	_ = copy(chainCode, []byte(derivePath))
+	_ = copy(chainCode, derivePath)
 
 	hasher, err := blake2b.New256(nil)
 	if err != nil {

--- a/chain/polkadot/keys_test.go
+++ b/chain/polkadot/keys_test.go
@@ -8,8 +8,9 @@ import (
 	p2pCrypto "github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/misko9/go-substrate-rpc-client/v4/signature"
-	"github.com/strangelove-ventures/interchaintest/v8/chain/polkadot"
 	"github.com/stretchr/testify/require"
+
+	"github.com/strangelove-ventures/interchaintest/v8/chain/polkadot"
 )
 
 func TestNodeKeyPeerID(t *testing.T) {
@@ -22,8 +23,8 @@ func TestNodeKeyPeerID(t *testing.T) {
 
 	id, err := peer.IDFromPrivateKey(privKey)
 	require.NoError(t, err, "error getting peer id from private key")
-	peerId := id.String()
-	require.Equal(t, "12D3KooWCqDbuUHRNWPAuHpVnzZGCkkMwgEx7Xd6xgszqtVpH56c", peerId)
+	peerID := id.String()
+	require.Equal(t, "12D3KooWCqDbuUHRNWPAuHpVnzZGCkkMwgEx7Xd6xgszqtVpH56c", peerID)
 }
 
 func Test_DeriveEd25519FromName(t *testing.T) {

--- a/chain/polkadot/parachain_node.go
+++ b/chain/polkadot/parachain_node.go
@@ -14,13 +14,14 @@ import (
 	p2pcrypto "github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/libp2p/go-libp2p/core/peer"
 	gsrpc "github.com/misko9/go-substrate-rpc-client/v4"
-	"github.com/strangelove-ventures/interchaintest/v8/dockerutil"
-	"github.com/strangelove-ventures/interchaintest/v8/ibc"
 	"go.uber.org/zap"
 
 	"cosmossdk.io/math"
 
 	sdktypes "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/strangelove-ventures/interchaintest/v8/dockerutil"
+	"github.com/strangelove-ventures/interchaintest/v8/ibc"
 )
 
 // Increase parachain wallet amount due to their additional precision.
@@ -47,7 +48,7 @@ type ParachainNode struct {
 
 	api         *gsrpc.SubstrateAPI
 	hostWsPort  string
-	hostRpcPort string
+	hostRPCPort string
 }
 
 type ParachainNodes []*ParachainNode
@@ -108,11 +109,11 @@ func (pn *ParachainNode) PeerID() (string, error) {
 
 // MultiAddress returns the p2p multiaddr of the node.
 func (pn *ParachainNode) MultiAddress() (string, error) {
-	peerId, err := pn.PeerID()
+	peerID, err := pn.PeerID()
 	if err != nil {
 		return "", err
 	}
-	return fmt.Sprintf("/dns4/%s/tcp/%s/p2p/%s", pn.HostName(), strings.Split(nodePort, "/")[0], peerId), nil
+	return fmt.Sprintf("/dns4/%s/tcp/%s/p2p/%s", pn.HostName(), strings.Split(nodePort, "/")[0], peerID), nil
 }
 
 type GetParachainIDResponse struct {
@@ -278,11 +279,11 @@ func (pn *ParachainNode) StartContainer(ctx context.Context) error {
 	}
 
 	// Set the host ports once since they will not change after the container has started.
-	pn.hostWsPort, pn.hostRpcPort = hostPorts[0], hostPorts[1]
+	pn.hostWsPort, pn.hostRPCPort = hostPorts[0], hostPorts[1]
 
-	explorerUrl := fmt.Sprintf("\033[4;34mhttps://polkadot.js.org/apps?rpc=ws://%s#/explorer\033[0m",
+	explorerURL := fmt.Sprintf("\033[4;34mhttps://polkadot.js.org/apps?rpc=ws://%s#/explorer\033[0m",
 		strings.Replace(pn.hostWsPort, "localhost", "127.0.0.1", 1))
-	pn.log.Info(explorerUrl, zap.String("container", pn.Name()))
+	pn.log.Info(explorerURL, zap.String("container", pn.Name()))
 	var api *gsrpc.SubstrateAPI
 	if err = retry.Do(func() error {
 		var err error

--- a/chain/polkadot/parachain_node.go
+++ b/chain/polkadot/parachain_node.go
@@ -180,7 +180,7 @@ func (pn *ParachainNode) ParachainID(ctx context.Context) (int, error) {
 		return -1, res.Err
 	}
 	out := GetParachainIDResponse{}
-	if err := json.Unmarshal([]byte(res.Stdout), &out); err != nil {
+	if err := json.Unmarshal(res.Stdout, &out); err != nil {
 		return -1, err
 	}
 	return out.ParachainID, nil
@@ -302,7 +302,7 @@ func (pn *ParachainNode) Exec(ctx context.Context, cmd []string, env []string) d
 	opts := dockerutil.ContainerOptions{
 		Binds: pn.Bind(),
 		Env:   env,
-		User:  pn.Image.UidGid,
+		User:  pn.Image.UIDGID,
 	}
 	return job.Run(ctx, cmd, opts)
 }

--- a/chain/polkadot/polkadot_chain.go
+++ b/chain/polkadot/polkadot_chain.go
@@ -179,7 +179,7 @@ func (c *PolkadotChain) NewRelayChainNode(
 		VolumeName: v.Name,
 		ImageRef:   image.Ref(),
 		TestName:   testName,
-		UidGid:     image.UidGid,
+		UidGid:     image.UIDGID,
 	}); err != nil {
 		return nil, fmt.Errorf("set volume owner: %w", err)
 	}
@@ -234,7 +234,7 @@ func (c *PolkadotChain) NewParachainNode(
 		VolumeName: v.Name,
 		ImageRef:   parachainConfig.Image.Ref(),
 		TestName:   testName,
-		UidGid:     parachainConfig.Image.UidGid,
+		UidGid:     parachainConfig.Image.UIDGID,
 	}); err != nil {
 		return nil, fmt.Errorf("set volume owner: %w", err)
 	}

--- a/chain/polkadot/polkadot_chain.go
+++ b/chain/polkadot/polkadot_chain.go
@@ -178,7 +178,7 @@ func (c *PolkadotChain) NewRelayChainNode(
 		VolumeName: v.Name,
 		ImageRef:   image.Ref(),
 		TestName:   testName,
-		UIDGID:     image.UIDGID,
+		UidGid:     image.UIDGID,
 	}); err != nil {
 		return nil, fmt.Errorf("set volume owner: %w", err)
 	}
@@ -233,7 +233,7 @@ func (c *PolkadotChain) NewParachainNode(
 		VolumeName: v.Name,
 		ImageRef:   parachainConfig.Image.Ref(),
 		TestName:   testName,
-		UIDGID:     parachainConfig.Image.UIDGID,
+		UidGid:     parachainConfig.Image.UIDGID,
 	}); err != nil {
 		return nil, fmt.Errorf("set volume owner: %w", err)
 	}

--- a/chain/polkadot/polkadot_chain.go
+++ b/chain/polkadot/polkadot_chain.go
@@ -3,7 +3,6 @@ package polkadot
 import (
 	"context"
 	"crypto/rand"
-	crand "crypto/rand"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -14,14 +13,10 @@ import (
 	"github.com/docker/docker/api/types"
 	volumetypes "github.com/docker/docker/api/types/volume"
 	"github.com/docker/docker/client"
-	dockerclient "github.com/docker/docker/client"
 	"github.com/icza/dyno"
 	p2pcrypto "github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/misko9/go-substrate-rpc-client/v4/signature"
 	gstypes "github.com/misko9/go-substrate-rpc-client/v4/types"
-	"github.com/strangelove-ventures/interchaintest/v8/blockdb"
-	"github.com/strangelove-ventures/interchaintest/v8/dockerutil"
-	"github.com/strangelove-ventures/interchaintest/v8/ibc"
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
 
@@ -30,6 +25,10 @@ import (
 	"github.com/cosmos/go-bip39"
 
 	sdktypes "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/strangelove-ventures/interchaintest/v8/blockdb"
+	"github.com/strangelove-ventures/interchaintest/v8/dockerutil"
+	"github.com/strangelove-ventures/interchaintest/v8/ibc"
 )
 
 // Increase polkadot wallet amount due to their additional precision.
@@ -79,7 +78,7 @@ type ParachainConfig struct {
 // IndexedName is a slice of the substrate dev key names used for key derivation.
 var (
 	IndexedName = []string{"alice", "bob", "charlie", "dave", "ferdie"}
-	IndexedUri  = []string{"//Alice", "//Bob", "//Charlie", "//Dave", "//Ferdie"}
+	IndexedURI  = []string{"//Alice", "//Bob", "//Charlie", "//Dave", "//Ferdie"}
 )
 
 // NewPolkadotChain returns an uninitialized PolkadotChain, which implements the ibc.Chain interface.
@@ -104,7 +103,7 @@ func (c *PolkadotChain) NewRelayChainNode(
 	ctx context.Context,
 	i int,
 	chain *PolkadotChain,
-	dockerClient *dockerclient.Client,
+	dockerClient *client.Client,
 	networkID string,
 	testName string,
 	image ibc.DockerImage,
@@ -114,7 +113,7 @@ func (c *PolkadotChain) NewRelayChainNode(
 		return nil, err
 	}
 
-	nodeKey, _, err := p2pcrypto.GenerateEd25519Key(crand.Reader)
+	nodeKey, _, err := p2pcrypto.GenerateEd25519Key(rand.Reader)
 	if err != nil {
 		return nil, fmt.Errorf("error generating node key: %w", err)
 	}
@@ -127,15 +126,15 @@ func (c *PolkadotChain) NewRelayChainNode(
 	}
 
 	accountKeyName := IndexedName[i]
-	accountKeyUri := IndexedUri[i]
+	accountKeyURI := IndexedURI[i]
 	stashKeyName := accountKeyName + "stash"
-	stashKeyUri := accountKeyUri + "//stash"
+	stashKeyURI := accountKeyURI + "//stash"
 
-	if err := c.RecoverKey(ctx, accountKeyName, accountKeyUri); err != nil {
+	if err := c.RecoverKey(ctx, accountKeyName, accountKeyURI); err != nil {
 		return nil, err
 	}
 
-	if err := c.RecoverKey(ctx, stashKeyName, stashKeyUri); err != nil {
+	if err := c.RecoverKey(ctx, stashKeyName, stashKeyURI); err != nil {
 		return nil, err
 	}
 
@@ -179,7 +178,7 @@ func (c *PolkadotChain) NewRelayChainNode(
 		VolumeName: v.Name,
 		ImageRef:   image.Ref(),
 		TestName:   testName,
-		UidGid:     image.UIDGID,
+		UIDGID:     image.UIDGID,
 	}); err != nil {
 		return nil, fmt.Errorf("set volume owner: %w", err)
 	}
@@ -190,12 +189,12 @@ func (c *PolkadotChain) NewRelayChainNode(
 func (c *PolkadotChain) NewParachainNode(
 	ctx context.Context,
 	i int,
-	dockerClient *dockerclient.Client,
+	dockerClient *client.Client,
 	networkID string,
 	testName string,
 	parachainConfig ParachainConfig,
 ) (*ParachainNode, error) {
-	nodeKey, _, err := p2pcrypto.GenerateEd25519Key(crand.Reader)
+	nodeKey, _, err := p2pcrypto.GenerateEd25519Key(rand.Reader)
 	if err != nil {
 		return nil, fmt.Errorf("error generating node key: %w", err)
 	}
@@ -234,7 +233,7 @@ func (c *PolkadotChain) NewParachainNode(
 		VolumeName: v.Name,
 		ImageRef:   parachainConfig.Image.Ref(),
 		TestName:   testName,
-		UidGid:     parachainConfig.Image.UIDGID,
+		UIDGID:     parachainConfig.Image.UIDGID,
 	}); err != nil {
 		return nil, fmt.Errorf("set volume owner: %w", err)
 	}
@@ -431,7 +430,6 @@ func (c *PolkadotChain) Start(testName string, ctx context.Context, additionalGe
 			return fmt.Errorf("error generating parachain genesis file: %w", err)
 		}
 		for _, n := range parachainNodes {
-			n := n
 			eg.Go(func() error {
 				c.logger().Info("Copying parachain chain spec", zap.String("container", n.Name()))
 				fw := dockerutil.NewFileWriter(n.logger(), n.DockerClient, n.TestName)
@@ -486,8 +484,6 @@ func (c *PolkadotChain) Start(testName string, ctx context.Context, additionalGe
 	}
 
 	for i, n := range c.RelayChainNodes {
-		n := n
-		i := i
 		eg.Go(func() error {
 			if i != 0 {
 				c.logger().Info("Copying raw chain spec", zap.String("container", n.Name()))
@@ -507,9 +503,7 @@ func (c *PolkadotChain) Start(testName string, ctx context.Context, additionalGe
 		return err
 	}
 	for _, nodes := range c.ParachainNodes {
-		nodes := nodes
 		for _, n := range nodes {
-			n := n
 			eg.Go(func() error {
 				c.logger().Info("Copying raw chain spec", zap.String("container", n.Name()))
 				if err := fw.WriteFile(ctx, n.VolumeName, n.RawRelayChainSpecFilePathRelative(), rawChainSpecBytes); err != nil {
@@ -547,15 +541,13 @@ func (c *PolkadotChain) GetRPCAddress() string {
 
 	if len(c.ParachainNodes) > 0 && len(c.ParachainNodes[0]) > 0 {
 		parachainHostName = c.ParachainNodes[0][0].HostName()
-		// return fmt.Sprintf("%s:%s", c.ParachainNodes[0][0].HostName(), strings.Split(rpcPort, "/")[0])
 	} else {
 		parachainHostName = c.RelayChainNodes[0].HostName()
 	}
 	relaychainHostName := c.RelayChainNodes[0].HostName()
-	parachainUrl := fmt.Sprintf("http://%s:%s", parachainHostName, port)
-	relaychainUrl := fmt.Sprintf("http://%s:%s", relaychainHostName, port)
-	return fmt.Sprintf("%s,%s", parachainUrl, relaychainUrl)
-	// return fmt.Sprintf("%s:%s", c.RelayChainNodes[0].HostName(), strings.Split(rpcPort, "/")[0])
+	parachainURL := fmt.Sprintf("http://%s:%s", parachainHostName, port)
+	relaychainURL := fmt.Sprintf("http://%s:%s", relaychainHostName, port)
+	return fmt.Sprintf("%s,%s", parachainURL, relaychainURL)
 }
 
 // GetGRPCAddress retrieves the grpc address that can be reached by other containers in the docker network.
@@ -577,9 +569,9 @@ func (c *PolkadotChain) GetHostPeerAddress() string {
 // Implements Chain interface.
 func (c *PolkadotChain) GetHostRPCAddress() string {
 	if len(c.ParachainNodes) > 0 && len(c.ParachainNodes[0]) > 0 {
-		return c.ParachainNodes[0][0].hostRpcPort
+		return c.ParachainNodes[0][0].hostRPCPort
 	}
-	return c.RelayChainNodes[0].hostRpcPort
+	return c.RelayChainNodes[0].hostRPCPort
 }
 
 // GetHostGRPCAddress returns the grpc address that can be reached by processes on the host machine.
@@ -641,7 +633,7 @@ func NewMnemonic() (string, error) {
 func (c *PolkadotChain) CreateKey(ctx context.Context, keyName string) error {
 	_, err := c.keyring.Get(keyName)
 	if err == nil {
-		return fmt.Errorf("Key already exists: %s", keyName)
+		return fmt.Errorf("key already exists: %s", keyName)
 	}
 
 	mnemonic, err := NewMnemonic()
@@ -671,7 +663,7 @@ func (c *PolkadotChain) CreateKey(ctx context.Context, keyName string) error {
 func (c *PolkadotChain) RecoverKey(ctx context.Context, keyName, mnemonic string) error {
 	_, err := c.keyring.Get(keyName)
 	if err == nil {
-		return fmt.Errorf("Key already exists: %s", keyName)
+		return fmt.Errorf("key already exists: %s", keyName)
 	}
 
 	kp, err := signature.KeyringPairFromSecret(mnemonic, Ss58Format)

--- a/chain/polkadot/polkadot_chain_test.go
+++ b/chain/polkadot/polkadot_chain_test.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"testing"
 
-	"github.com/strangelove-ventures/interchaintest/v8"
-	"github.com/strangelove-ventures/interchaintest/v8/ibc"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
+
+	"github.com/strangelove-ventures/interchaintest/v8"
+	"github.com/strangelove-ventures/interchaintest/v8/ibc"
 )
 
 func TestWalletMethods(t *testing.T) {

--- a/chain/polkadot/polkadot_chain_test.go
+++ b/chain/polkadot/polkadot_chain_test.go
@@ -25,12 +25,12 @@ func TestWalletMethods(t *testing.T) {
 					{
 						Repository: "seunlanlege/centauri-polkadot",
 						Version:    "v0.9.27",
-						UidGid:     "1025:1025",
+						UIDGID:     "1025:1025",
 					},
 					{
 						Repository: "seunlanlege/centauri-parachain",
 						Version:    "v0.9.27",
-						UidGid:     "1025:1025",
+						UIDGID:     "1025:1025",
 					},
 				},
 				Bin:            "polkadot",

--- a/chain/polkadot/polkadot_chain_test.go
+++ b/chain/polkadot/polkadot_chain_test.go
@@ -2,10 +2,9 @@ package polkadot_test
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
-	interchaintest "github.com/strangelove-ventures/interchaintest/v8"
+	"github.com/strangelove-ventures/interchaintest/v8"
 	"github.com/strangelove-ventures/interchaintest/v8/ibc"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
@@ -59,10 +58,6 @@ func TestWalletMethods(t *testing.T) {
 
 	address, err := chain.GetAddress(ctx, relayKeyName)
 	require.NoError(t, err, "Error getting relay address")
-	fmt.Println("Relay wallet mnemonic: ", relayWallet.Mnemonic())
-	fmt.Println("Relay wallet keyname: ", relayWallet.KeyName())
-	fmt.Println("Relay wallet address: ", relayWallet.FormattedAddress())
-	fmt.Println("Address: ", address)
 	require.Equal(t, relayWallet.FormattedAddress(), string(address), "Relay addresses not equal")
 
 	// BuildWallet test
@@ -72,10 +67,6 @@ func TestWalletMethods(t *testing.T) {
 
 	address, err = chain.GetAddress(ctx, userKeyName)
 	require.NoError(t, err, "Error getting user address")
-	fmt.Println("Wallet mnemonic: ", userWallet.Mnemonic())
-	fmt.Println("Wallet keyname: ", userWallet.KeyName())
-	fmt.Println("Wallet address: ", userWallet.FormattedAddress())
-	fmt.Println("Address: ", address)
 	require.Equal(t, userWallet.FormattedAddress(), string(address), "User addresses not equal")
 
 	// RecoverKey test

--- a/chain/polkadot/relay_chain_node.go
+++ b/chain/polkadot/relay_chain_node.go
@@ -270,7 +270,7 @@ func (p *RelayChainNode) Exec(ctx context.Context, cmd []string, env []string) d
 	opts := dockerutil.ContainerOptions{
 		Binds: p.Bind(),
 		Env:   env,
-		User:  p.Image.UidGid,
+		User:  p.Image.UIDGID,
 	}
 	return job.Run(ctx, cmd, opts)
 }

--- a/chain/polkadot/relay_chain_node.go
+++ b/chain/polkadot/relay_chain_node.go
@@ -15,11 +15,12 @@ import (
 	p2pCrypto "github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/libp2p/go-libp2p/core/peer"
 	gsrpc "github.com/misko9/go-substrate-rpc-client/v4"
-	"github.com/strangelove-ventures/interchaintest/v8/dockerutil"
-	"github.com/strangelove-ventures/interchaintest/v8/ibc"
 	"go.uber.org/zap"
 
 	"cosmossdk.io/math"
+
+	"github.com/strangelove-ventures/interchaintest/v8/dockerutil"
+	"github.com/strangelove-ventures/interchaintest/v8/ibc"
 )
 
 // RelayChainNode defines the properties required for running a polkadot relay chain node.
@@ -43,7 +44,7 @@ type RelayChainNode struct {
 
 	api         *gsrpc.SubstrateAPI
 	hostWsPort  string
-	hostRpcPort string
+	hostRPCPort string
 }
 
 type RelayChainNodes []*RelayChainNode
@@ -123,17 +124,17 @@ func (p *RelayChainNode) EcdsaAddress() (string, error) {
 
 // MultiAddress returns the p2p multiaddr of the node.
 func (p *RelayChainNode) MultiAddress() (string, error) {
-	peerId, err := p.PeerID()
+	peerID, err := p.PeerID()
 	if err != nil {
 		return "", err
 	}
-	return fmt.Sprintf("/dns4/%s/tcp/%s/p2p/%s", p.HostName(), strings.Split(nodePort, "/")[0], peerId), nil
+	return fmt.Sprintf("/dns4/%s/tcp/%s/p2p/%s", p.HostName(), strings.Split(nodePort, "/")[0], peerID), nil
 }
 
-func (c *RelayChainNode) logger() *zap.Logger {
-	return c.log.With(
-		zap.String("chain_id", c.Chain.Config().ChainID),
-		zap.String("test", c.TestName),
+func (p *RelayChainNode) logger() *zap.Logger {
+	return p.log.With(
+		zap.String("chain_id", p.Chain.Config().ChainID),
+		zap.String("test", p.TestName),
 	)
 }
 
@@ -243,12 +244,12 @@ func (p *RelayChainNode) StartContainer(ctx context.Context) error {
 	}
 
 	// Set the host ports once since they will not change after the container has started.
-	p.hostWsPort, p.hostRpcPort = hostPorts[0], hostPorts[1]
+	p.hostWsPort, p.hostRPCPort = hostPorts[0], hostPorts[1]
 
 	p.logger().Info("Waiting for RPC endpoint to be available", zap.String("container", p.Name()))
-	explorerUrl := fmt.Sprintf("\033[4;34mhttps://polkadot.js.org/apps?rpc=ws://%s#/explorer\033[0m",
+	explorerURL := fmt.Sprintf("\033[4;34mhttps://polkadot.js.org/apps?rpc=ws://%s#/explorer\033[0m",
 		strings.Replace(p.hostWsPort, "localhost", "127.0.0.1", 1))
-	p.log.Info(explorerUrl, zap.String("container", p.Name()))
+	p.log.Info(explorerURL, zap.String("container", p.Name()))
 	var api *gsrpc.SubstrateAPI
 	if err = retry.Do(func() error {
 		var err error

--- a/chain/polkadot/ss58.go
+++ b/chain/polkadot/ss58.go
@@ -40,28 +40,29 @@ func DecodeAddressSS58(address string) ([]byte, error) {
 		return nil, err
 	}
 	var checksumLength int
-	if IntInSlice(len(ss58AddrDecoded), []int{3, 4, 6, 10}) {
+	switch {
+	case IntInSlice(len(ss58AddrDecoded), []int{3, 4, 6, 10}):
 		checksumLength = 1
-	} else if IntInSlice(len(ss58AddrDecoded), []int{5, 7, 11, 35}) {
+	case IntInSlice(len(ss58AddrDecoded), []int{5, 7, 11, 35}):
 		checksumLength = 2
-	} else if IntInSlice(len(ss58AddrDecoded), []int{8, 12}) {
+	case IntInSlice(len(ss58AddrDecoded), []int{8, 12}):
 		checksumLength = 3
-	} else if IntInSlice(len(ss58AddrDecoded), []int{9, 13}) {
+	case IntInSlice(len(ss58AddrDecoded), []int{9, 13}):
 		checksumLength = 4
-	} else if IntInSlice(len(ss58AddrDecoded), []int{14}) {
+	case IntInSlice(len(ss58AddrDecoded), []int{14}):
 		checksumLength = 5
-	} else if IntInSlice(len(ss58AddrDecoded), []int{15}) {
+	case IntInSlice(len(ss58AddrDecoded), []int{15}):
 		checksumLength = 6
-	} else if IntInSlice(len(ss58AddrDecoded), []int{16}) {
+	case IntInSlice(len(ss58AddrDecoded), []int{16}):
 		checksumLength = 7
-	} else if IntInSlice(len(ss58AddrDecoded), []int{17}) {
+	case IntInSlice(len(ss58AddrDecoded), []int{17}):
 		checksumLength = 8
-	} else {
-		return nil, fmt.Errorf("Cannot get checksum length")
+	default:
+		return nil, fmt.Errorf("cannot get checksum length")
 	}
 	bss := ss58AddrDecoded[0 : len(ss58AddrDecoded)-checksumLength]
 	checksum, _ := blake2b.New(64, []byte{})
-	w := append(checksumPrefix, bss...) //nolint: gocritic
+	w := append(checksumPrefix, bss...)
 	_, err = checksum.Write(w)
 	if err != nil {
 		return nil, err
@@ -69,7 +70,7 @@ func DecodeAddressSS58(address string) ([]byte, error) {
 
 	h := checksum.Sum(nil)
 	if BytesToHex(h[0:checksumLength]) != BytesToHex(ss58AddrDecoded[len(ss58AddrDecoded)-checksumLength:]) {
-		return nil, fmt.Errorf("Checksum incorrect")
+		return nil, fmt.Errorf("checksum incorrect")
 	}
 	return ss58AddrDecoded[1 : len(ss58AddrDecoded)-checksumLength], nil
 }

--- a/chain/polkadot/ss58.go
+++ b/chain/polkadot/ss58.go
@@ -61,7 +61,7 @@ func DecodeAddressSS58(address string) ([]byte, error) {
 	}
 	bss := ss58AddrDecoded[0 : len(ss58AddrDecoded)-checksumLength]
 	checksum, _ := blake2b.New(64, []byte{})
-	w := append(checksumPrefix, bss...)
+	w := append(checksumPrefix, bss...) //nolint: gocritic
 	_, err = checksum.Write(w)
 	if err != nil {
 		return nil, err

--- a/chain/polkadot/tx.go
+++ b/chain/polkadot/tx.go
@@ -2,6 +2,7 @@ package polkadot
 
 import (
 	"encoding/hex"
+	"fmt"
 	"math/big"
 	"strconv"
 
@@ -78,7 +79,14 @@ func SendIbcFundsTx(
 	}
 
 	raw := gstypes.NewU8(1)
-	size := gstypes.NewU8(uint8(len(amount.Address) * 4))
+
+	s := len(amount.Address) * 4
+
+	if s < 0 {
+		return hash, fmt.Errorf("cannot safely convert int value %d to uint8 due to negative value", s)
+	}
+
+	size := gstypes.NewU8(uint8(s))
 	to := gstypes.NewStorageDataRaw([]byte(amount.Address))
 	channel := gstypes.NewU64(0) // Parse channel number from string
 	timeout := gstypes.NewU8(1)

--- a/chain/polkadot/tx.go
+++ b/chain/polkadot/tx.go
@@ -2,7 +2,6 @@ package polkadot
 
 import (
 	"encoding/hex"
-	"fmt"
 	"math/big"
 	"strconv"
 
@@ -81,13 +80,7 @@ func SendIbcFundsTx(
 
 	raw := gstypes.NewU8(1)
 
-	s := len(amount.Address) * 4
-
-	if s < 0 {
-		return hash, fmt.Errorf("cannot safely convert int value %d to uint8 due to negative value", s)
-	}
-
-	size := gstypes.NewU8(uint8(s))
+	size := gstypes.NewU8(uint8(len(amount.Address) * 4))
 	to := gstypes.NewStorageDataRaw([]byte(amount.Address))
 	channel := gstypes.NewU64(0) // Parse channel number from string
 	timeout := gstypes.NewU8(1)

--- a/chain/polkadot/tx.go
+++ b/chain/polkadot/tx.go
@@ -9,6 +9,7 @@ import (
 	gsrpc "github.com/misko9/go-substrate-rpc-client/v4"
 	"github.com/misko9/go-substrate-rpc-client/v4/signature"
 	gstypes "github.com/misko9/go-substrate-rpc-client/v4/types"
+
 	"github.com/strangelove-ventures/interchaintest/v8/ibc"
 )
 
@@ -92,11 +93,11 @@ func SendIbcFundsTx(
 	timeout := gstypes.NewU8(1)
 	timestamp := gstypes.NewOptionU64(gstypes.NewU64(0))
 	height := gstypes.NewOptionU64(gstypes.NewU64(3000)) // Must set timestamp or height
-	assetId := gstypes.NewU128(*big.NewInt(assetNum))
+	assetID := gstypes.NewU128(*big.NewInt(assetNum))
 	amount2 := gstypes.NewU128(*amount.Amount.BigInt())
 	memo := gstypes.NewU8(0)
 
-	call, err := gstypes.NewCall(meta, "Ibc.transfer", raw, size, to, channel, timeout, timestamp, height, assetId, amount2, memo)
+	call, err := gstypes.NewCall(meta, "Ibc.transfer", raw, size, to, channel, timeout, timestamp, height, assetID, amount2, memo)
 	if err != nil {
 		return hash, err
 	}
@@ -131,10 +132,10 @@ func MintFundsTx(
 		return hash, err
 	}
 
-	assetId := gstypes.NewU128(*big.NewInt(assetNum))
+	assetID := gstypes.NewU128(*big.NewInt(assetNum))
 	amount2 := gstypes.NewUCompact(amount.Amount.BigInt())
 
-	call, err := gstypes.NewCall(meta, "Assets.mint", assetId, receiver, amount2)
+	call, err := gstypes.NewCall(meta, "Assets.mint", assetID, receiver, amount2)
 	if err != nil {
 		return hash, err
 	}

--- a/chain/thorchain/api_query.go
+++ b/chain/thorchain/api_query.go
@@ -4,7 +4,9 @@ package thorchain
 // Copied from thorchain's simulation test, may be replaced in the future for queries via chain binary
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -12,12 +14,12 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/strangelove-ventures/interchaintest/v8/chain/thorchain/common"
-
 	sdkmath "cosmossdk.io/math"
+
+	"github.com/strangelove-ventures/interchaintest/v8/chain/thorchain/common"
 )
 
-func (c *Thorchain) ApiGetBalances(addr string) (common.Coins, error) {
+func (c *Thorchain) APIGetBalances(ctx context.Context, addr string) (common.Coins, error) {
 	url := fmt.Sprintf("%s/cosmos/bank/v1beta1/balances/%s", c.GetAPIAddress(), addr)
 	var balances struct {
 		Balances []struct {
@@ -25,7 +27,7 @@ func (c *Thorchain) ApiGetBalances(addr string) (common.Coins, error) {
 			Amount string `json:"amount"`
 		} `json:"balances"`
 	}
-	err := get(url, &balances)
+	err := get(ctx, url, &balances)
 	if err != nil {
 		return nil, err
 	}
@@ -49,17 +51,17 @@ func (c *Thorchain) ApiGetBalances(addr string) (common.Coins, error) {
 	return coins, nil
 }
 
-func (c *Thorchain) ApiGetInboundAddress(chain string) (address string, router *string, err error) {
+func (c *Thorchain) APIGetInboundAddress(ctx context.Context, chain string) (address string, router *string, err error) {
 	url := fmt.Sprintf("%s/thorchain/inbound_addresses", c.GetAPIAddress())
 	var inboundAddresses []InboundAddress
-	err = get(url, &inboundAddresses)
+	err = get(ctx, url, &inboundAddresses)
 	if err != nil {
 		return "", nil, err
 	}
 
 	// find address for chain
 	for _, inboundAddress := range inboundAddresses {
-		if *inboundAddress.Chain == string(chain) {
+		if *inboundAddress.Chain == chain {
 			if inboundAddress.Router != nil {
 				router = new(string)
 				*router = *inboundAddress.Router
@@ -71,10 +73,10 @@ func (c *Thorchain) ApiGetInboundAddress(chain string) (address string, router *
 	return "", nil, fmt.Errorf("no inbound address found for chain %s", chain)
 }
 
-func (c *Thorchain) ApiGetRouterAddress(chain string) (string, error) {
+func (c *Thorchain) APIGetRouterAddress(ctx context.Context, chain string) (string, error) {
 	url := fmt.Sprintf("%s/thorchain/inbound_addresses", c.GetAPIAddress())
 	var inboundAddresses []InboundAddress
-	err := get(url, &inboundAddresses)
+	err := get(ctx, url, &inboundAddresses)
 	if err != nil {
 		return "", err
 	}
@@ -89,35 +91,35 @@ func (c *Thorchain) ApiGetRouterAddress(chain string) (string, error) {
 	return "", fmt.Errorf("no inbound address found for chain %s", chain)
 }
 
-func (c *Thorchain) ApiGetLiquidityProviders(asset common.Asset) ([]LiquidityProvider, error) {
+func (c *Thorchain) APIGetLiquidityProviders(ctx context.Context, asset common.Asset) ([]LiquidityProvider, error) {
 	url := fmt.Sprintf("%s/thorchain/pool/%s/liquidity_providers", c.GetAPIAddress(), asset.String())
 	var liquidityProviders []LiquidityProvider
-	err := get(url, &liquidityProviders)
+	err := get(ctx, url, &liquidityProviders)
 	return liquidityProviders, err
 }
 
-func (c *Thorchain) ApiGetSavers(asset common.Asset) ([]Saver, error) {
+func (c *Thorchain) APIGetSavers(ctx context.Context, asset common.Asset) ([]Saver, error) {
 	url := fmt.Sprintf("%s/thorchain/pool/%s/savers", c.GetAPIAddress(), asset.GetLayer1Asset().String())
 	var savers []Saver
-	err := get(url, &savers)
+	err := get(ctx, url, &savers)
 	return savers, err
 }
 
-func (c *Thorchain) ApiGetPools() ([]Pool, error) {
+func (c *Thorchain) APIGetPools(ctx context.Context) ([]Pool, error) {
 	url := fmt.Sprintf("%s/thorchain/pools", c.GetAPIAddress())
 	var pools []Pool
-	err := get(url, &pools)
+	err := get(ctx, url, &pools)
 	return pools, err
 }
 
-func (c *Thorchain) ApiGetPool(asset common.Asset) (Pool, error) {
+func (c *Thorchain) APIGetPool(ctx context.Context, asset common.Asset) (Pool, error) {
 	url := fmt.Sprintf("%s/thorchain/pool/%s", c.GetAPIAddress(), asset.String())
 	var pool Pool
-	err := get(url, &pool)
+	err := get(ctx, url, &pool)
 	return pool, err
 }
 
-func (c *Thorchain) ApiGetSwapQuote(from, to common.Asset, amount sdkmath.Uint) (QuoteSwapResponse, error) {
+func (c *Thorchain) APIGetSwapQuote(ctx context.Context, from, to common.Asset, amount sdkmath.Uint) (QuoteSwapResponse, error) {
 	baseURL := fmt.Sprintf("%s/thorchain/quote/swap", c.GetAPIAddress())
 	parsedURL, err := url.Parse(baseURL)
 	if err != nil {
@@ -131,11 +133,11 @@ func (c *Thorchain) ApiGetSwapQuote(from, to common.Asset, amount sdkmath.Uint) 
 	url := parsedURL.String()
 
 	var quote QuoteSwapResponse
-	err = get(url, &quote)
+	err = get(ctx, url, &quote)
 	return quote, err
 }
 
-func (c *Thorchain) ApiGetSaverDepositQuote(asset common.Asset, amount sdkmath.Uint) (QuoteSaverDepositResponse, error) {
+func (c *Thorchain) APIGetSaverDepositQuote(ctx context.Context, asset common.Asset, amount sdkmath.Uint) (QuoteSaverDepositResponse, error) {
 	baseURL := fmt.Sprintf("%s/thorchain/quote/saver/deposit", c.GetAPIAddress())
 	parsedURL, err := url.Parse(baseURL)
 	if err != nil {
@@ -148,28 +150,28 @@ func (c *Thorchain) ApiGetSaverDepositQuote(asset common.Asset, amount sdkmath.U
 	url := parsedURL.String()
 
 	var quote QuoteSaverDepositResponse
-	err = get(url, &quote)
+	err = get(ctx, url, &quote)
 	return quote, err
 }
 
-func (c *Thorchain) ApiGetTxStages(txid string) (TxStagesResponse, error) {
+func (c *Thorchain) APIGetTxStages(ctx context.Context, txid string) (TxStagesResponse, error) {
 	url := fmt.Sprintf("%s/thorchain/tx/stages/%s", c.GetAPIAddress(), txid)
 	var stages TxStagesResponse
-	err := get(url, &stages)
+	err := get(ctx, url, &stages)
 	return stages, err
 }
 
-func (c *Thorchain) ApiGetTxDetails(txid string) (TxDetailsResponse, error) {
+func (c *Thorchain) APIGetTxDetails(ctx context.Context, txid string) (TxDetailsResponse, error) {
 	url := fmt.Sprintf("%s/thorchain/tx/details/%s", c.GetAPIAddress(), txid)
 	var details TxDetailsResponse
-	err := get(url, &details)
+	err := get(ctx, url, &details)
 	return details, err
 }
 
-func (c *Thorchain) ApiGetMimirs() (map[string]int64, error) {
+func (c *Thorchain) APIGetMimirs(ctx context.Context) (map[string]int64, error) {
 	url := fmt.Sprintf("%s/thorchain/mimir", c.GetAPIAddress())
 	var mimirs map[string]int64
-	err := get(url, &mimirs)
+	err := get(ctx, url, &mimirs)
 	return mimirs, err
 }
 
@@ -177,8 +179,13 @@ func (c *Thorchain) ApiGetMimirs() (map[string]int64, error) {
 // Internal
 ////////////////////////////////////////////////////////////////////////////////////////
 
-func get(url string, target interface{}) error {
-	resp, err := http.Get(url)
+func get(ctx context.Context, url string, target interface{}) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return err
+	}
+
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return err
 	}
@@ -195,7 +202,7 @@ func get(url string, target interface{}) error {
 	errResp := ErrorResponse{}
 	err = json.Unmarshal(buf, &errResp)
 	if err == nil && errResp.Error != "" {
-		return fmt.Errorf(errResp.Error)
+		return errors.New(errResp.Error)
 	}
 
 	// decode response
@@ -203,8 +210,8 @@ func get(url string, target interface{}) error {
 }
 
 // ConvertAssetAmount converts the given coin to the target asset and returns the amount.
-func (c *Thorchain) ConvertAssetAmount(coin Coin, asset string) (sdkmath.Uint, error) {
-	pools, err := c.ApiGetPools()
+func (c *Thorchain) ConvertAssetAmount(ctx context.Context, coin Coin, asset string) (sdkmath.Uint, error) {
+	pools, err := c.APIGetPools(ctx)
 	if err != nil {
 		return sdkmath.ZeroUint(), err
 	}

--- a/chain/thorchain/broadcaster.go
+++ b/chain/thorchain/broadcaster.go
@@ -8,9 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/strangelove-ventures/interchaintest/v8/dockerutil"
-	"github.com/strangelove-ventures/interchaintest/v8/testutil"
-
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/tx"
@@ -18,6 +15,9 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/tx/signing"
 	authtx "github.com/cosmos/cosmos-sdk/x/auth/tx"
+
+	"github.com/strangelove-ventures/interchaintest/v8/dockerutil"
+	"github.com/strangelove-ventures/interchaintest/v8/testutil"
 )
 
 type ClientContextOpt func(clientContext client.Context) client.Context
@@ -50,6 +50,8 @@ type Broadcaster struct {
 // NewBroadcaster returns a instance of Broadcaster which can be used with broadcast.Tx to
 // broadcast messages sdk messages.
 func NewBroadcaster(t *testing.T, chain *Thorchain) *Broadcaster {
+	t.Helper()
+
 	return &Broadcaster{
 		t:        t,
 		chain:    chain,

--- a/chain/thorchain/common/chain.go
+++ b/chain/thorchain/common/chain.go
@@ -81,6 +81,8 @@ func (c Chain) GetGasAsset() Asset {
 		return AVAXAsset
 	case GAIAChain:
 		return ATOMAsset
+	case EmptyChain:
+		return EmptyAsset
 	default:
 		return EmptyAsset
 	}

--- a/chain/thorchain/genesis.go
+++ b/chain/thorchain/genesis.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/icza/dyno"
+
 	"github.com/strangelove-ventures/interchaintest/v8/ibc"
 )
 

--- a/chain/thorchain/module_bank.go
+++ b/chain/thorchain/module_bank.go
@@ -3,12 +3,12 @@ package thorchain
 import (
 	"context"
 
-	"github.com/strangelove-ventures/interchaintest/v8/ibc"
-
 	sdkmath "cosmossdk.io/math"
 
 	"github.com/cosmos/cosmos-sdk/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+
+	"github.com/strangelove-ventures/interchaintest/v8/ibc"
 )
 
 // Deprecated: use BankSend instead.

--- a/chain/thorchain/module_thorchain.go
+++ b/chain/thorchain/module_thorchain.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/strangelove-ventures/interchaintest/v8/ibc"
-
 	"cosmossdk.io/math"
+
+	"github.com/strangelove-ventures/interchaintest/v8/ibc"
 )
 
 // BankSend sends tokens from one account to another.

--- a/chain/thorchain/poll.go
+++ b/chain/thorchain/poll.go
@@ -5,10 +5,10 @@ import (
 	"errors"
 	"fmt"
 
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+
 	"github.com/strangelove-ventures/interchaintest/v8/ibc"
 	"github.com/strangelove-ventures/interchaintest/v8/testutil"
-
-	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 )
 
 // PollForMessage searches every transaction for a message. Must pass a coded registry capable of decoding the cosmos transaction.
@@ -19,7 +19,7 @@ func PollForMessage[T any](ctx context.Context, chain *Thorchain, registry codec
 		fn = func(T) bool { return true }
 	}
 	doPoll := func(ctx context.Context, height int64) (T, error) {
-		h := int64(height)
+		h := height
 		block, err := chain.getFullNode().Client.Block(ctx, &h)
 		if err != nil {
 			return zero, err

--- a/chain/thorchain/query.go
+++ b/chain/thorchain/query.go
@@ -17,7 +17,7 @@ type blockClient interface {
 // RangeBlockMessages iterates through all a block's transactions and each transaction's messages yielding to f.
 // Return true from f to stop iteration.
 func RangeBlockMessages(ctx context.Context, interfaceRegistry codectypes.InterfaceRegistry, client blockClient, height int64, done func(sdk.Msg) bool) error {
-	h := int64(height)
+	h := height
 	block, err := client.Block(ctx, &h)
 	if err != nil {
 		return fmt.Errorf("tendermint rpc get block: %w", err)

--- a/chain/thorchain/sidecar.go
+++ b/chain/thorchain/sidecar.go
@@ -7,9 +7,10 @@ import (
 
 	dockerclient "github.com/docker/docker/client"
 	"github.com/docker/go-connections/nat"
+	"go.uber.org/zap"
+
 	"github.com/strangelove-ventures/interchaintest/v8/dockerutil"
 	"github.com/strangelove-ventures/interchaintest/v8/ibc"
-	"go.uber.org/zap"
 )
 
 type SidecarProcesses []*SidecarProcess

--- a/chain/thorchain/thorchain.go
+++ b/chain/thorchain/thorchain.go
@@ -80,7 +80,7 @@ func NewThorchainHeighlinerChainConfig(
 		Images: []ibc.DockerImage{
 			{
 				Repository: "ghcr.io/strangelove-ventures/heighliner/thorchain",
-				UidGid:     dockerutil.GetHeighlinerUserString(),
+				UIDGID:     dockerutil.GetHeighlinerUserString(),
 			},
 		},
 		Bin: binary,
@@ -506,7 +506,7 @@ func (c *Thorchain) NewChainNode(
 		VolumeName: v.Name,
 		ImageRef:   image.Ref(),
 		TestName:   testName,
-		UidGid:     image.UidGid,
+		UidGid:     image.UIDGID,
 	}); err != nil {
 		return nil, fmt.Errorf("set volume owner: %w", err)
 	}
@@ -569,7 +569,7 @@ func (c *Thorchain) NewSidecarProcess(
 		VolumeName: v.Name,
 		ImageRef:   image.Ref(),
 		TestName:   testName,
-		UidGid:     image.UidGid,
+		UidGid:     image.UIDGID,
 	}); err != nil {
 		return fmt.Errorf("set volume owner: %w", err)
 	}

--- a/chain/thorchain/thorchain.go
+++ b/chain/thorchain/thorchain.go
@@ -506,7 +506,7 @@ func (c *Thorchain) NewChainNode(
 		VolumeName: v.Name,
 		ImageRef:   image.Ref(),
 		TestName:   testName,
-		UIDGID:     image.UIDGID,
+		UidGid:     image.UIDGID,
 	}); err != nil {
 		return nil, fmt.Errorf("set volume owner: %w", err)
 	}
@@ -569,7 +569,7 @@ func (c *Thorchain) NewSidecarProcess(
 		VolumeName: v.Name,
 		ImageRef:   image.Ref(),
 		TestName:   testName,
-		UIDGID:     image.UIDGID,
+		UidGid:     image.UIDGID,
 	}); err != nil {
 		return fmt.Errorf("set volume owner: %w", err)
 	}

--- a/chain/thorchain/thornode.go
+++ b/chain/thorchain/thornode.go
@@ -21,10 +21,6 @@ import (
 	dockerclient "github.com/docker/docker/client"
 	"github.com/docker/go-connections/nat"
 	"github.com/icza/dyno"
-	"github.com/strangelove-ventures/interchaintest/v8/blockdb"
-	"github.com/strangelove-ventures/interchaintest/v8/dockerutil"
-	"github.com/strangelove-ventures/interchaintest/v8/ibc"
-	"github.com/strangelove-ventures/interchaintest/v8/testutil"
 	"go.uber.org/zap"
 	"golang.org/x/mod/semver"
 	"golang.org/x/sync/errgroup"
@@ -32,6 +28,7 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 
 	sdkmath "cosmossdk.io/math"
+
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -44,6 +41,11 @@ import (
 	rpchttp "github.com/cometbft/cometbft/rpc/client/http"
 	coretypes "github.com/cometbft/cometbft/rpc/core/types"
 	libclient "github.com/cometbft/cometbft/rpc/jsonrpc/client"
+
+	"github.com/strangelove-ventures/interchaintest/v8/blockdb"
+	"github.com/strangelove-ventures/interchaintest/v8/dockerutil"
+	"github.com/strangelove-ventures/interchaintest/v8/ibc"
+	"github.com/strangelove-ventures/interchaintest/v8/testutil"
 )
 
 type ChainNode struct {
@@ -187,7 +189,7 @@ func (tn *ChainNode) NewSidecarProcess(
 		VolumeName: v.Name,
 		ImageRef:   image.Ref(),
 		TestName:   tn.TestName,
-		UidGid:     image.UIDGID,
+		UIDGID:     image.UIDGID,
 	}); err != nil {
 		return fmt.Errorf("set volume owner: %w", err)
 	}
@@ -406,7 +408,7 @@ func (tn *ChainNode) Height(ctx context.Context) (int64, error) {
 
 // FindTxs implements blockdb.BlockSaver.
 func (tn *ChainNode) FindTxs(ctx context.Context, height int64) ([]blockdb.Tx, error) {
-	h := int64(height)
+	h := height
 	var eg errgroup.Group
 	var blockRes *coretypes.ResultBlockResults
 	var block *coretypes.ResultBlock
@@ -446,8 +448,8 @@ func (tn *ChainNode) FindTxs(ctx context.Context, height int64) ([]blockdb.Tx, e
 			attrs := make([]blockdb.EventAttribute, len(e.Attributes))
 			for k, attr := range e.Attributes {
 				attrs[k] = blockdb.EventAttribute{
-					Key:   string(attr.Key),
-					Value: string(attr.Value),
+					Key:   attr.Key,
+					Value: attr.Value,
 				}
 			}
 			newTx.Events[j] = blockdb.Event{
@@ -466,8 +468,8 @@ func (tn *ChainNode) FindTxs(ctx context.Context, height int64) ([]blockdb.Tx, e
 			attrs := make([]blockdb.EventAttribute, len(e.Attributes))
 			for j, attr := range e.Attributes {
 				attrs[j] = blockdb.EventAttribute{
-					Key:   string(attr.Key),
-					Value: string(attr.Value),
+					Key:   attr.Key,
+					Value: attr.Value,
 				}
 			}
 			finalizeBlockTx.Events[i] = blockdb.Event{
@@ -526,7 +528,7 @@ func (tn *ChainNode) ExecTx(ctx context.Context, keyName string, command ...stri
 		return "", err
 	}
 	output := CosmosTx{}
-	err = json.Unmarshal([]byte(stdout), &output)
+	err = json.Unmarshal(stdout, &output)
 	if err != nil {
 		return "", err
 	}
@@ -542,7 +544,7 @@ func (tn *ChainNode) ExecTx(ctx context.Context, keyName string, command ...stri
 		return "", err
 	}
 	output = CosmosTx{}
-	err = json.Unmarshal([]byte(stdout), &output)
+	err = json.Unmarshal(stdout, &output)
 	if err != nil {
 		return "", err
 	}
@@ -612,6 +614,7 @@ func (tn *ChainNode) ExecBin(ctx context.Context, backendfile bool, command ...s
 	keyringCommand := []string{
 		"sh",
 		"-c",
+		//nolint: dupword
 		fmt.Sprintf(`cat <<EOF | %s --keyring-backend %s
 password
 password
@@ -716,6 +719,7 @@ func (tn *ChainNode) CreateKey(ctx context.Context, name string) error {
 	command := []string{
 		"sh",
 		"-c",
+		//nolint: dupword
 		fmt.Sprintf(`cat <<EOF | %s keys add %s --keyring-backend %s --coin-type %s --home %s --output json
 password
 password
@@ -745,6 +749,7 @@ func (tn *ChainNode) RecoverKey(ctx context.Context, keyName, mnemonic string) e
 	command := []string{
 		"sh",
 		"-c",
+		//nolint: dupword
 		fmt.Sprintf(`cat <<EOF | %s keys add %s --recover --keyring-backend %s --coin-type %s --home %s --output json
 %s
 password
@@ -945,7 +950,7 @@ func (tn *ChainNode) GetNodeAccount(ctx context.Context) error {
 	tn.NodeAccount = &NodeAccount{
 		NodeAddress:         bech32NodeAddr,
 		Version:             version,
-		IpAddress:           "192.168.0.10", // TODO: may need to populate real ip after chain start
+		IPAddress:           "192.168.0.10", // TODO: may need to populate real ip after chain start
 		Status:              "Active",
 		Bond:                "100000000", // 1 rune
 		ActiveBlockHeight:   "0",
@@ -1182,12 +1187,12 @@ func (tn *ChainNode) HasCommand(ctx context.Context, command ...string) bool {
 		return true
 	}
 
-	if strings.Contains(string(err.Error()), "Error: unknown command") {
+	if strings.Contains(err.Error(), "Error: unknown command") {
 		return false
 	}
 
 	// cmd just needed more arguments, but it is a valid command (ex: appd tx bank send)
-	if strings.Contains(string(err.Error()), "Error: accepts") {
+	if strings.Contains(err.Error(), "Error: accepts") {
 		return true
 	}
 
@@ -1213,7 +1218,7 @@ func (tn *ChainNode) GetBuildInformation(ctx context.Context) *BinaryBuildInform
 	}
 
 	var deps tempBuildDeps
-	if err := json.Unmarshal([]byte(stdout), &deps); err != nil {
+	if err := json.Unmarshal(stdout, &deps); err != nil {
 		return nil
 	}
 

--- a/chain/thorchain/thornode.go
+++ b/chain/thorchain/thornode.go
@@ -187,7 +187,7 @@ func (tn *ChainNode) NewSidecarProcess(
 		VolumeName: v.Name,
 		ImageRef:   image.Ref(),
 		TestName:   tn.TestName,
-		UidGid:     image.UidGid,
+		UidGid:     image.UIDGID,
 	}); err != nil {
 		return fmt.Errorf("set volume owner: %w", err)
 	}

--- a/chain/thorchain/thornode.go
+++ b/chain/thorchain/thornode.go
@@ -189,7 +189,7 @@ func (tn *ChainNode) NewSidecarProcess(
 		VolumeName: v.Name,
 		ImageRef:   image.Ref(),
 		TestName:   tn.TestName,
-		UIDGID:     image.UIDGID,
+		UidGid:     image.UIDGID,
 	}); err != nil {
 		return fmt.Errorf("set volume owner: %w", err)
 	}

--- a/chain/thorchain/types.go
+++ b/chain/thorchain/types.go
@@ -12,7 +12,7 @@ type NodeAccountPubKeySet struct {
 type NodeAccount struct {
 	NodeAddress         string               `json:"node_address"`
 	Version             string               `json:"version"`
-	IpAddress           string               `json:"ip_address"`
+	IPAddress           string               `json:"ip_address"`
 	Status              string               `json:"status"`
 	Bond                string               `json:"bond"`
 	BondUInt            uint64               `json:"-"`
@@ -121,7 +121,7 @@ type LiquidityProvider struct {
 	Units              string  `json:"units"`
 	PendingRune        string  `json:"pending_rune"`
 	PendingAsset       string  `json:"pending_asset"`
-	PendingTxId        *string `json:"pending_tx_id,omitempty"`
+	PendingTxID        *string `json:"pending_tx_id,omitempty"`
 	RuneDepositValue   string  `json:"rune_deposit_value"`
 	AssetDepositValue  string  `json:"asset_deposit_value"`
 	RuneRedeemValue    *string `json:"rune_redeem_value,omitempty"`
@@ -380,7 +380,7 @@ type Coin struct {
 
 // Tx struct for Tx.
 type Tx struct {
-	Id          *string `json:"id,omitempty"`
+	ID          *string `json:"id,omitempty"`
 	Chain       *string `json:"chain,omitempty"`
 	FromAddress *string `json:"from_address,omitempty"`
 	ToAddress   *string `json:"to_address,omitempty"`
@@ -427,7 +427,7 @@ type TxOutItem struct {
 
 // TxDetailsResponse struct for TxDetailsResponse.
 type TxDetailsResponse struct {
-	TxId    *string      `json:"tx_id,omitempty"`
+	TxID    *string      `json:"tx_id,omitempty"`
 	Tx      ObservedTx   `json:"tx"`
 	Txs     []ObservedTx `json:"txs"`
 	Actions []TxOutItem  `json:"actions"`

--- a/chain/thorchain/wallet.go
+++ b/chain/thorchain/wallet.go
@@ -1,9 +1,9 @@
 package thorchain
 
 import (
-	"github.com/strangelove-ventures/interchaintest/v8/ibc"
-
 	"github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/strangelove-ventures/interchaintest/v8/ibc"
 )
 
 var (

--- a/chain/utxo/cli.go
+++ b/chain/utxo/cli.go
@@ -16,7 +16,7 @@ func (c *UtxoChain) GetWalletVersion(ctx context.Context, keyName string) (int, 
 	var err error
 
 	if keyName == "" {
-		cmd := append(c.BaseCli, "getwalletinfo") //nolint: gocritic
+		cmd := append(c.BaseCli, "getwalletinfo")
 		stdout, _, err = c.Exec(ctx, cmd, nil)
 		if err != nil {
 			return 0, err
@@ -26,7 +26,7 @@ func (c *UtxoChain) GetWalletVersion(ctx context.Context, keyName string) (int, 
 			return 0, err
 		}
 
-		cmd := append(c.BaseCli, fmt.Sprintf("-rpcwallet=%s", keyName), "getwalletinfo") //nolint: gocritic
+		cmd := append(c.BaseCli, fmt.Sprintf("-rpcwallet=%s", keyName), "getwalletinfo")
 		stdout, _, err = c.Exec(ctx, cmd, nil)
 		if err != nil {
 			return 0, err
@@ -64,7 +64,7 @@ func (c *UtxoChain) LoadWallet(ctx context.Context, keyName string) error {
 		wallet.mu.Lock()
 		defer wallet.mu.Unlock()
 		if wallet.loadCount == 0 {
-			cmd := append(c.BaseCli, "loadwallet", keyName) //nolint: gocritic
+			cmd := append(c.BaseCli, "loadwallet", keyName)
 			_, _, err = c.Exec(ctx, cmd, nil)
 			if err != nil {
 				return err
@@ -88,7 +88,7 @@ func (c *UtxoChain) UnloadWallet(ctx context.Context, keyName string) error {
 		wallet.mu.Lock()
 		defer wallet.mu.Unlock()
 		if wallet.loadCount == 1 {
-			cmd := append(c.BaseCli, "unloadwallet", keyName) //nolint: gocritic
+			cmd := append(c.BaseCli, "unloadwallet", keyName)
 			_, _, err = c.Exec(ctx, cmd, nil)
 			if err != nil {
 				return err
@@ -103,7 +103,7 @@ func (c *UtxoChain) UnloadWallet(ctx context.Context, keyName string) error {
 
 func (c *UtxoChain) CreateWallet(ctx context.Context, keyName string) error {
 	if c.WalletVersion == 0 || c.WalletVersion >= noDefaultKeyWalletVersion {
-		cmd := append(c.BaseCli, "createwallet", keyName) //nolint: gocritic
+		cmd := append(c.BaseCli, "createwallet", keyName)
 		_, _, err := c.Exec(ctx, cmd, nil)
 		if err != nil {
 			return err
@@ -130,9 +130,9 @@ func (c *UtxoChain) GetNewAddress(ctx context.Context, keyName string, mweb bool
 
 	var cmd []string
 	if c.WalletVersion >= noDefaultKeyWalletVersion {
-		cmd = append(c.BaseCli, fmt.Sprintf("-rpcwallet=%s", keyName), "getnewaddress") //nolint: gocritic
+		cmd = append(c.BaseCli, fmt.Sprintf("-rpcwallet=%s", keyName), "getnewaddress")
 	} else {
-		cmd = append(c.BaseCli, "getnewaddress") //nolint: gocritic
+		cmd = append(c.BaseCli, "getnewaddress")
 	}
 
 	if mweb {
@@ -389,11 +389,12 @@ func (c *UtxoChain) SignRawTransaction(ctx context.Context, keyName string, rawT
 
 func (c *UtxoChain) SendRawTransaction(ctx context.Context, signedRawTxHex string) (string, error) {
 	var cmd []string
-	if c.WalletVersion >= namedFixWalletVersion {
+	switch {
+	case c.WalletVersion >= namedFixWalletVersion:
 		cmd = append(c.BaseCli, "sendrawtransaction", signedRawTxHex)
-	} else if c.WalletVersion > noDefaultKeyWalletVersion {
+	case c.WalletVersion > noDefaultKeyWalletVersion:
 		cmd = append(c.BaseCli, "sendrawtransaction", signedRawTxHex, "0")
-	} else {
+	default:
 		cmd = append(c.BaseCli, "sendrawtransaction", signedRawTxHex)
 	}
 	stdout, _, err := c.Exec(ctx, cmd, nil)

--- a/chain/utxo/cli.go
+++ b/chain/utxo/cli.go
@@ -16,7 +16,7 @@ func (c *UtxoChain) GetWalletVersion(ctx context.Context, keyName string) (int, 
 	var err error
 
 	if keyName == "" {
-		cmd := append(c.BaseCli, "getwalletinfo")
+		cmd := append(c.BaseCli, "getwalletinfo") //nolint: gocritic
 		stdout, _, err = c.Exec(ctx, cmd, nil)
 		if err != nil {
 			return 0, err
@@ -26,7 +26,7 @@ func (c *UtxoChain) GetWalletVersion(ctx context.Context, keyName string) (int, 
 			return 0, err
 		}
 
-		cmd := append(c.BaseCli, fmt.Sprintf("-rpcwallet=%s", keyName), "getwalletinfo")
+		cmd := append(c.BaseCli, fmt.Sprintf("-rpcwallet=%s", keyName), "getwalletinfo") //nolint: gocritic
 		stdout, _, err = c.Exec(ctx, cmd, nil)
 		if err != nil {
 			return 0, err
@@ -64,7 +64,7 @@ func (c *UtxoChain) LoadWallet(ctx context.Context, keyName string) error {
 		wallet.mu.Lock()
 		defer wallet.mu.Unlock()
 		if wallet.loadCount == 0 {
-			cmd := append(c.BaseCli, "loadwallet", keyName)
+			cmd := append(c.BaseCli, "loadwallet", keyName) //nolint: gocritic
 			_, _, err = c.Exec(ctx, cmd, nil)
 			if err != nil {
 				return err
@@ -88,7 +88,7 @@ func (c *UtxoChain) UnloadWallet(ctx context.Context, keyName string) error {
 		wallet.mu.Lock()
 		defer wallet.mu.Unlock()
 		if wallet.loadCount == 1 {
-			cmd := append(c.BaseCli, "unloadwallet", keyName)
+			cmd := append(c.BaseCli, "unloadwallet", keyName) //nolint: gocritic
 			_, _, err = c.Exec(ctx, cmd, nil)
 			if err != nil {
 				return err
@@ -103,7 +103,7 @@ func (c *UtxoChain) UnloadWallet(ctx context.Context, keyName string) error {
 
 func (c *UtxoChain) CreateWallet(ctx context.Context, keyName string) error {
 	if c.WalletVersion == 0 || c.WalletVersion >= noDefaultKeyWalletVersion {
-		cmd := append(c.BaseCli, "createwallet", keyName)
+		cmd := append(c.BaseCli, "createwallet", keyName) //nolint: gocritic
 		_, _, err := c.Exec(ctx, cmd, nil)
 		if err != nil {
 			return err
@@ -130,9 +130,9 @@ func (c *UtxoChain) GetNewAddress(ctx context.Context, keyName string, mweb bool
 
 	var cmd []string
 	if c.WalletVersion >= noDefaultKeyWalletVersion {
-		cmd = append(c.BaseCli, fmt.Sprintf("-rpcwallet=%s", keyName), "getnewaddress")
+		cmd = append(c.BaseCli, fmt.Sprintf("-rpcwallet=%s", keyName), "getnewaddress") //nolint: gocritic
 	} else {
-		cmd = append(c.BaseCli, "getnewaddress")
+		cmd = append(c.BaseCli, "getnewaddress") //nolint: gocritic
 	}
 
 	if mweb {
@@ -256,11 +256,11 @@ func (c *UtxoChain) CreateRawTransaction(ctx context.Context, keyName string, li
 	if err != nil {
 		return "", err
 	}
-	fees = fees * c.cfg.GasAdjustment
+	fees *= c.cfg.GasAdjustment
 	for _, utxo := range listUtxo {
 		if wallet.address == utxo.Address || strings.Contains(utxo.Address, wallet.address) {
 			sendInputs = append(sendInputs, SendInput{
-				TxId: utxo.TxId,
+				TxID: utxo.TxID,
 				Vout: utxo.Vout,
 			})
 			utxoTotal += utxo.Amount
@@ -377,11 +377,11 @@ func (c *UtxoChain) SignRawTransaction(ctx context.Context, keyName string, rawT
 	}
 
 	if !signRawTxOutput.Complete {
-		c.logger().Error(fmt.Sprintf("Signing transaction did not complete, (%d) errors", len(signRawTxOutput.Errors)))
+		c.logger().Error(fmt.Sprintf("signing transaction did not complete, (%d) errors", len(signRawTxOutput.Errors)))
 		for i, sErr := range signRawTxOutput.Errors {
 			c.logger().Error(fmt.Sprintf("Signing error %d: %s", i, sErr.Error))
 		}
-		return "", fmt.Errorf("Sign transaction error on %s", c.cfg.Name)
+		return "", fmt.Errorf("sign transaction error on %s", c.cfg.Name)
 	}
 
 	return signRawTxOutput.Hex, nil

--- a/chain/utxo/default_configs.go
+++ b/chain/utxo/default_configs.go
@@ -26,7 +26,7 @@ func DefaultBitcoinChainConfig(
 			{
 				Repository: "bitcoin/bitcoin",
 				Version:    "26.2",
-				UidGid:     "1025:1025",
+				UIDGID:     "1025:1025",
 			},
 		},
 		Bin: "bitcoind,bitcoin-cli",
@@ -59,7 +59,7 @@ func DefaultBitcoinCashChainConfig(
 			{
 				Repository: "zquestz/bitcoin-cash-node",
 				Version:    "27.1.0",
-				UidGid:     "1025:1025",
+				UIDGID:     "1025:1025",
 			},
 		},
 		Bin: "bitcoind,bitcoin-cli",
@@ -92,7 +92,7 @@ func DefaultLitecoinChainConfig(
 			{
 				Repository: "uphold/litecoin-core",
 				Version:    "0.21",
-				UidGid:     "1025:1025",
+				UIDGID:     "1025:1025",
 			},
 		},
 		Bin: "litecoind,litecoin-cli",
@@ -127,7 +127,7 @@ func DefaultDogecoinChainConfig(
 				Version:    "dogecoin-daemon-1.14.7",
 				// Repository: "coinmetrics/dogecoin",
 				// Version:    "1.14.7",
-				UidGid: "1000:1000",
+				UIDGID: "1000:1000",
 			},
 		},
 		Bin: "dogecoind,dogecoin-cli",

--- a/chain/utxo/types.go
+++ b/chain/utxo/types.go
@@ -14,7 +14,7 @@ type TransactionReceipt struct {
 type ListUtxo []Utxo
 
 type Utxo struct {
-	TxId          string  `json:"txid,omitempty"`
+	TxID          string  `json:"txid,omitempty"`
 	Vout          int     `json:"vout,omitempty"`
 	Address       string  `json:"address,omitempty"`
 	Label         string  `json:"label,omitempty"`
@@ -30,7 +30,7 @@ type Utxo struct {
 type SendInputs []SendInput
 
 type SendInput struct {
-	TxId string `json:"txid"` // hex
+	TxID string `json:"txid"` // hex
 	Vout int    `json:"vout"`
 }
 

--- a/chain/utxo/unimplemented.go
+++ b/chain/utxo/unimplemented.go
@@ -59,5 +59,5 @@ func (c *UtxoChain) Timeouts(ctx context.Context, height int64) ([]ibc.PacketTim
 
 func (c *UtxoChain) BuildRelayerWallet(ctx context.Context, keyName string) (ibc.Wallet, error) {
 	PanicFunctionName()
-	return nil, nil
+	return &UtxoWallet{}, nil
 }

--- a/chain/utxo/utxo_chain.go
+++ b/chain/utxo/utxo_chain.go
@@ -189,15 +189,23 @@ func (c *UtxoChain) Start(testName string, ctx context.Context, additionalGenesi
 	}
 
 	if c.cfg.HostPortOverride != nil {
+		var fields []zap.Field
+
+		i := 0
 		for intP, extP := range c.cfg.HostPortOverride {
-			usingPorts[nat.Port(fmt.Sprintf("%d/tcp", intP))] = []nat.PortBinding{
+			port := nat.Port(fmt.Sprintf("%d/tcp", intP))
+
+			usingPorts[port] = []nat.PortBinding{
 				{
 					HostPort: fmt.Sprintf("%d", extP),
 				},
 			}
+
+			fields = append(fields, zap.String(fmt.Sprintf("port_overrides_%d", i), fmt.Sprintf("%s:%d", port, extP)))
+			i++
 		}
 
-		fmt.Printf("Port Overrides: %v. Using: %v\n", c.cfg.HostPortOverride, usingPorts)
+		c.log.Info("Port overrides", fields...)
 	}
 
 	env := []string{}

--- a/chain/utxo/utxo_chain.go
+++ b/chain/utxo/utxo_chain.go
@@ -14,12 +14,13 @@ import (
 	"github.com/docker/docker/api/types/volume"
 	dockerclient "github.com/docker/docker/client"
 	"github.com/docker/go-connections/nat"
-	"github.com/strangelove-ventures/interchaintest/v8/dockerutil"
-	"github.com/strangelove-ventures/interchaintest/v8/ibc"
-	"github.com/strangelove-ventures/interchaintest/v8/testutil"
 	"go.uber.org/zap"
 
 	sdkmath "cosmossdk.io/math"
+
+	"github.com/strangelove-ventures/interchaintest/v8/dockerutil"
+	"github.com/strangelove-ventures/interchaintest/v8/ibc"
+	"github.com/strangelove-ventures/interchaintest/v8/testutil"
 )
 
 var _ ibc.Chain = &UtxoChain{}
@@ -129,7 +130,7 @@ func (c *UtxoChain) Initialize(ctx context.Context, testName string, cli *docker
 		VolumeName: v.Name,
 		ImageRef:   image.Ref(),
 		TestName:   testName,
-		UidGid:     image.UIDGID,
+		UIDGID:     image.UIDGID,
 	}); err != nil {
 		return fmt.Errorf("set volume owner: %w", err)
 	}

--- a/chain/utxo/utxo_chain.go
+++ b/chain/utxo/utxo_chain.go
@@ -130,7 +130,7 @@ func (c *UtxoChain) Initialize(ctx context.Context, testName string, cli *docker
 		VolumeName: v.Name,
 		ImageRef:   image.Ref(),
 		TestName:   testName,
-		UIDGID:     image.UIDGID,
+		UidGid:     image.UIDGID,
 	}); err != nil {
 		return fmt.Errorf("set volume owner: %w", err)
 	}

--- a/chain/utxo/wallet.go
+++ b/chain/utxo/wallet.go
@@ -53,16 +53,16 @@ func (c *UtxoChain) getWalletForNewAddress(keyName string) (*NodeWallet, error) 
 	wallet, found := c.KeyNameToWalletMap[keyName]
 	if c.WalletVersion >= noDefaultKeyWalletVersion {
 		if !found {
-			return nil, fmt.Errorf("Wallet keyname (%s) not found, has it been created?", keyName)
+			return nil, fmt.Errorf("wallet keyname (%s) not found, has it been created?", keyName)
 		}
 		if wallet.address != "" {
-			return nil, fmt.Errorf("Wallet keyname (%s) already has an address", keyName)
+			return nil, fmt.Errorf("wallet keyname (%s) already has an address", keyName)
 		}
 	}
 
 	if c.WalletVersion < noDefaultKeyWalletVersion {
 		if found {
-			return nil, fmt.Errorf("Wallet keyname (%s) already has an address", keyName)
+			return nil, fmt.Errorf("wallet keyname (%s) already has an address", keyName)
 		} else {
 			wallet = &NodeWallet{
 				keyName: keyName,
@@ -77,10 +77,10 @@ func (c *UtxoChain) getWalletForNewAddress(keyName string) (*NodeWallet, error) 
 func (c *UtxoChain) getWalletForSetAccount(keyName string, addr string) (*NodeWallet, error) {
 	wallet, found := c.KeyNameToWalletMap[keyName]
 	if !found {
-		return nil, fmt.Errorf("Wallet keyname (%s) not found, get new address not called", keyName)
+		return nil, fmt.Errorf("wallet keyname (%s) not found, get new address not called", keyName)
 	}
 	if wallet.address != addr {
-		return nil, fmt.Errorf("Wallet keyname (%s) is associated with address (%s), not (%s)", keyName, wallet.address, addr)
+		return nil, fmt.Errorf("wallet keyname (%s) is associated with address (%s), not (%s)", keyName, wallet.address, addr)
 	}
 	return wallet, nil
 }
@@ -94,7 +94,7 @@ func (c *UtxoChain) getWalletForUse(keyName string) (*NodeWallet, error) {
 	// For chain without wallet support, GetNewAddress() and SetAccount() must be called.
 	// For chains with wallet support, CreateWallet() and GetNewAddress() must be called.
 	if !wallet.ready {
-		return nil, fmt.Errorf("Wallet keyname (%s) is not ready for use, check creation steps", keyName)
+		return nil, fmt.Errorf("wallet keyname (%s) is not ready for use, check creation steps", keyName)
 	}
 	return wallet, nil
 }
@@ -102,7 +102,7 @@ func (c *UtxoChain) getWalletForUse(keyName string) (*NodeWallet, error) {
 func (c *UtxoChain) getWallet(keyName string) (*NodeWallet, error) {
 	wallet, found := c.KeyNameToWalletMap[keyName]
 	if !found {
-		return nil, fmt.Errorf("Wallet keyname (%s) not found", keyName)
+		return nil, fmt.Errorf("wallet keyname (%s) not found", keyName)
 	}
 	return wallet, nil
 }

--- a/chainfactory.go
+++ b/chainfactory.go
@@ -6,6 +6,11 @@ import (
 	"strings"
 	"sync"
 
+	"go.uber.org/zap"
+	"gopkg.in/yaml.v3"
+
+	_ "embed"
+
 	"github.com/strangelove-ventures/interchaintest/v8/chain/cosmos"
 	"github.com/strangelove-ventures/interchaintest/v8/chain/ethereum/foundry"
 	"github.com/strangelove-ventures/interchaintest/v8/chain/ethereum/geth"
@@ -14,10 +19,6 @@ import (
 	"github.com/strangelove-ventures/interchaintest/v8/chain/thorchain"
 	"github.com/strangelove-ventures/interchaintest/v8/chain/utxo"
 	"github.com/strangelove-ventures/interchaintest/v8/ibc"
-	"go.uber.org/zap"
-	"gopkg.in/yaml.v3"
-
-	_ "embed"
 )
 
 // ChainFactory describes how to get chains for tests.
@@ -134,11 +135,11 @@ func buildChain(log *zap.Logger, testName string, cfg ibc.ChainConfig, numValida
 	}
 
 	switch cfg.Type {
-	case "cosmos":
+	case ibc.Cosmos:
 		return cosmos.NewCosmosChain(testName, cfg, nv, nf, log), nil
-	case "penumbra":
+	case ibc.Penumbra:
 		return penumbra.NewPenumbraChain(log, testName, cfg, nv, nf), nil
-	case "polkadot":
+	case ibc.Polkadot:
 		// TODO Clean this up. RelayChain config should only reference cfg.Images[0] and parachains should iterate through the remaining
 		// Maybe just pass everything in like NewCosmosChain and NewPenumbraChain, let NewPolkadotChain figure it out
 		// Or parachains and ICS consumer chains maybe should be their own chain
@@ -158,7 +159,7 @@ func buildChain(log *zap.Logger, testName string, cfg ibc.ChainConfig, numValida
 		default:
 			return nil, fmt.Errorf("unexpected error, unknown polkadot parachain: %s", cfg.Name)
 		}
-	case "ethereum":
+	case ibc.Ethereum:
 		switch cfg.Bin {
 		case "anvil":
 			return foundry.NewAnvilChain(testName, cfg, log), nil
@@ -167,9 +168,9 @@ func buildChain(log *zap.Logger, testName string, cfg ibc.ChainConfig, numValida
 		default:
 			return nil, fmt.Errorf("unknown binary: %s for ethereum chain type, must be anvil or geth", cfg.Bin)
 		}
-	case "thorchain":
+	case ibc.Thorchain:
 		return thorchain.NewThorchain(testName, cfg, nv, nf, log), nil
-	case "utxo":
+	case ibc.UTXO:
 		return utxo.NewUtxoChain(testName, cfg, log), nil
 	default:
 		return nil, fmt.Errorf("unexpected error, unknown chain type: %s for chain: %s", cfg.Type, cfg.Name)

--- a/chainset.go
+++ b/chainset.go
@@ -9,12 +9,13 @@ import (
 	"time"
 
 	"github.com/docker/docker/client"
-	"github.com/strangelove-ventures/interchaintest/v8/blockdb"
-	"github.com/strangelove-ventures/interchaintest/v8/chain/cosmos"
-	"github.com/strangelove-ventures/interchaintest/v8/ibc"
 	"go.uber.org/multierr"
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
+
+	"github.com/strangelove-ventures/interchaintest/v8/blockdb"
+	"github.com/strangelove-ventures/interchaintest/v8/chain/cosmos"
+	"github.com/strangelove-ventures/interchaintest/v8/ibc"
 )
 
 // chainSet is an unordered collection of ibc.Chain,
@@ -53,7 +54,6 @@ func (cs *chainSet) Initialize(ctx context.Context, testName string, cli *client
 	var eg errgroup.Group
 
 	for c := range cs.chains {
-		c := c
 		cs.log.Info("Initializing chain", zap.String("chain_id", c.Config().ChainID))
 		eg.Go(func() error {
 			if err := c.Initialize(ctx, testName, cli, networkID); err != nil {
@@ -82,7 +82,6 @@ func (cs *chainSet) CreateCommonAccount(ctx context.Context, keyName string) (fa
 	eg, egCtx := errgroup.WithContext(ctx)
 
 	for c := range cs.chains {
-		c := c
 		eg.Go(func() error {
 			wallet, err := c.BuildWallet(egCtx, keyName, "")
 			if err != nil {
@@ -109,7 +108,6 @@ func (cs *chainSet) Start(ctx context.Context, testName string, additionalGenesi
 	eg, egCtx := errgroup.WithContext(ctx)
 
 	for c := range cs.chains {
-		c := c
 		if cosmosChain, ok := c.(*cosmos.CosmosChain); ok && cosmosChain.Provider != nil {
 			// wait for provider chains to be started up first
 			continue
@@ -142,7 +140,6 @@ func (cs *chainSet) Start(ctx context.Context, testName string, additionalGenesi
 
 	// Now startup any consumer chains
 	for c := range cs.chains {
-		c := c
 		if cosmosChain, ok := c.(*cosmos.CosmosChain); ok && cosmosChain.Provider != nil {
 			eg.Go(func() error {
 				// this is a consumer chain
@@ -193,7 +190,6 @@ func (cs chainSet) TrackBlocks(ctx context.Context, testName, dbPath, gitSha str
 	cs.collectors = make([]*blockdb.Collector, len(cs.chains))
 	i := 0
 	for c := range cs.chains {
-		c := c
 		id := c.Config().ChainID
 		finder, ok := c.(blockdb.TxFinder)
 		if !ok {

--- a/chainspec.go
+++ b/chainspec.go
@@ -232,11 +232,9 @@ func (s *ChainSpec) applyConfigOverrides(cfg ibc.ChainConfig) (*ibc.ChainConfig,
 			default:
 				return nil, fmt.Errorf("unexpected parachain: %s", s.Name)
 			}
-		} else {
+		} else if len(s.ChainConfig.Images) < 2 || s.ChainConfig.Images[1].Version == "" {
 			// Ensure there are at least two images and check the 2nd version is populated
-			if len(s.ChainConfig.Images) < 2 || s.ChainConfig.Images[1].Version == "" {
-				return nil, fmt.Errorf("ChainCongfig.Images must be >1 and ChainConfig.Images[1].Version must not be empty")
-			}
+			return nil, fmt.Errorf("ChainCongfig.Images must be >1 and ChainConfig.Images[1].Version must not be empty")
 		}
 	}
 

--- a/chainspec_test.go
+++ b/chainspec_test.go
@@ -5,10 +5,11 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	interchaintest "github.com/strangelove-ventures/interchaintest/v8"
-	"github.com/strangelove-ventures/interchaintest/v8/ibc"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
+
+	interchaintest "github.com/strangelove-ventures/interchaintest/v8"
+	"github.com/strangelove-ventures/interchaintest/v8/ibc"
 )
 
 func TestChainSpec_Config(t *testing.T) {

--- a/chainspec_test.go
+++ b/chainspec_test.go
@@ -57,7 +57,7 @@ func TestChainSpec_Config(t *testing.T) {
 				// Skip Name, as that is intended to be inherited from ChainName.
 				ChainID: "mychain-123",
 				Images: []ibc.DockerImage{
-					{Repository: "docker.example.com", Version: "latest", UidGid: "1:1"},
+					{Repository: "docker.example.com", Version: "latest", UIDGID: "1:1"},
 				},
 				Bin:            "/bin/true",
 				Bech32Prefix:   "foo",

--- a/cmd/interchaintest/flags.go
+++ b/cmd/interchaintest/flags.go
@@ -6,9 +6,10 @@ import (
 	"os"
 	"time"
 
-	interchaintest "github.com/strangelove-ventures/interchaintest/v8"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+
+	interchaintest "github.com/strangelove-ventures/interchaintest/v8"
 )
 
 // The value of the extra flags this test supports.

--- a/cmd/interchaintest/interchaintest_test.go
+++ b/cmd/interchaintest/interchaintest_test.go
@@ -12,14 +12,15 @@ import (
 	"time"
 
 	"github.com/rivo/tview"
-	interchaintest "github.com/strangelove-ventures/interchaintest/v8"
+	"go.uber.org/zap"
+
+	"github.com/strangelove-ventures/interchaintest/v8"
 	"github.com/strangelove-ventures/interchaintest/v8/blockdb"
 	blockdbtui "github.com/strangelove-ventures/interchaintest/v8/blockdb/tui"
 	"github.com/strangelove-ventures/interchaintest/v8/conformance"
 	"github.com/strangelove-ventures/interchaintest/v8/ibc"
 	"github.com/strangelove-ventures/interchaintest/v8/relayer"
 	"github.com/strangelove-ventures/interchaintest/v8/testreporter"
-	"go.uber.org/zap"
 )
 
 func init() {
@@ -250,8 +251,7 @@ func addFlags() {
 
 func parseFlags() {
 	flag.Parse()
-	switch subcommand() {
-	case "debug":
+	if subcommand() == "debug" {
 		// Ignore errors because configured with flag.ExitOnError.
 		_ = debugFlagSet.Parse(os.Args[2:])
 	}

--- a/cmd/interchaintest/matrix_test.go
+++ b/cmd/interchaintest/matrix_test.go
@@ -4,11 +4,12 @@ import (
 	"encoding/json"
 	"testing"
 
-	interchaintest "github.com/strangelove-ventures/interchaintest/v8"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
 
 	_ "embed"
+
+	interchaintest "github.com/strangelove-ventures/interchaintest/v8"
 )
 
 // Embed the matrix files as strings since they aren't intended to be changed.

--- a/conformance/flush.go
+++ b/conformance/flush.go
@@ -5,16 +5,17 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/strangelove-ventures/interchaintest/v8"
-	"github.com/strangelove-ventures/interchaintest/v8/ibc"
-	"github.com/strangelove-ventures/interchaintest/v8/relayer"
-	"github.com/strangelove-ventures/interchaintest/v8/testreporter"
-	"github.com/strangelove-ventures/interchaintest/v8/testutil"
 	"github.com/stretchr/testify/require"
 
 	"cosmossdk.io/math"
 
 	"github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/strangelove-ventures/interchaintest/v8"
+	"github.com/strangelove-ventures/interchaintest/v8/ibc"
+	"github.com/strangelove-ventures/interchaintest/v8/relayer"
+	"github.com/strangelove-ventures/interchaintest/v8/testreporter"
+	"github.com/strangelove-ventures/interchaintest/v8/testutil"
 )
 
 func TestRelayerFlushing(t *testing.T, ctx context.Context, cf interchaintest.ChainFactory, rf interchaintest.RelayerFactory, rep *testreporter.Reporter) {

--- a/conformance/relayersetup.go
+++ b/conformance/relayersetup.go
@@ -5,15 +5,16 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/strangelove-ventures/interchaintest/v8"
-	"github.com/strangelove-ventures/interchaintest/v8/ibc"
-	"github.com/strangelove-ventures/interchaintest/v8/testreporter"
-	"github.com/strangelove-ventures/interchaintest/v8/testutil"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 
 	conntypes "github.com/cosmos/ibc-go/v8/modules/core/03-connection/types"
 	"github.com/cosmos/ibc-go/v8/modules/core/exported"
+
+	"github.com/strangelove-ventures/interchaintest/v8"
+	"github.com/strangelove-ventures/interchaintest/v8/ibc"
+	"github.com/strangelove-ventures/interchaintest/v8/testreporter"
+	"github.com/strangelove-ventures/interchaintest/v8/testutil"
 )
 
 // TestRelayerSetup contains a series of subtests that configure a relayer step-by-step.
@@ -103,7 +104,7 @@ func TestRelayerSetup(t *testing.T, ctx context.Context, cf interchaintest.Chain
 		req.True(len(conns0) == 1 || len(conns0) == 2)
 		if len(conns0) == 2 {
 			// Chain might have a localhost connection. Connection IDs are sorted, so this would be at position [1].
-			req.Equal(conns0[1].ID, exported.LocalhostConnectionID)
+			req.Equal(exported.LocalhostConnectionID, conns0[1].ID)
 		}
 		conn0 := conns0[0]
 		req.NotEmpty(conn0.ID)
@@ -116,7 +117,7 @@ func TestRelayerSetup(t *testing.T, ctx context.Context, cf interchaintest.Chain
 		req.True(len(conns1) == 1 || len(conns1) == 2)
 		if len(conns1) == 2 {
 			// Chain might have a localhost connection. Connection IDs are sorted, so this would be at position [1].
-			req.Equal(conns1[1].ID, exported.LocalhostConnectionID)
+			req.Equal(exported.LocalhostConnectionID, conns1[1].ID)
 		}
 		conn1 := conns1[0]
 		req.NotEmpty(conn1.ID)
@@ -172,14 +173,14 @@ func TestRelayerSetup(t *testing.T, ctx context.Context, cf interchaintest.Chain
 		// Not asserting against ConnectionHops or ChannelID.
 		req.Subset([]string{"STATE_OPEN", "Open"}, []string{ch0.State})
 		req.Subset([]string{"ORDER_UNORDERED", "Unordered"}, []string{ch0.Ordering})
-		req.Equal(ch0.Counterparty, ibc.ChannelCounterparty{PortID: "transfer", ChannelID: ch1.ChannelID})
-		req.Equal(ch0.Version, "ics20-1")
-		req.Equal(ch0.PortID, "transfer")
+		req.Equal(ibc.ChannelCounterparty{PortID: "transfer", ChannelID: ch1.ChannelID}, ch0.Counterparty)
+		req.Equal("ics20-1", ch0.Version)
+		req.Equal("transfer", ch0.PortID)
 
 		req.Subset([]string{"STATE_OPEN", "Open"}, []string{ch1.State})
 		req.Subset([]string{"ORDER_UNORDERED", "Unordered"}, []string{ch1.Ordering})
-		req.Equal(ch1.Counterparty, ibc.ChannelCounterparty{PortID: "transfer", ChannelID: ch0.ChannelID})
-		req.Equal(ch1.Version, "ics20-1")
-		req.Equal(ch1.PortID, "transfer")
+		req.Equal(ibc.ChannelCounterparty{PortID: "transfer", ChannelID: ch0.ChannelID}, ch1.Counterparty)
+		req.Equal("ics20-1", ch1.Version)
+		req.Equal("transfer", ch1.PortID)
 	})
 }

--- a/contract/cosmwasm/rust_optimizer.go
+++ b/contract/cosmwasm/rust_optimizer.go
@@ -77,7 +77,7 @@ func (c *Contract) Compile() *Contract {
 // WaitForCompile will wait until compilation is complete, this can be called after chain setup
 // Successful compilation will return the binary location in a channel.
 func (c *Contract) WaitForCompile() (string, error) {
-	contractBinary := ""
+	var contractBinary string
 	select {
 	case err := <-c.errChan:
 		return "", err

--- a/dockerutil/container_lifecycle.go
+++ b/dockerutil/container_lifecycle.go
@@ -20,7 +20,7 @@ import (
 	"go.uber.org/zap"
 )
 
-// Example Go/Cosmos-SDK panic format is `panic: bad Duration: time: invalid duration "bad"\n`
+// Example Go/Cosmos-SDK panic format is `panic: bad Duration: time: invalid duration "bad"\n`.
 var panicRe = regexp.MustCompile(`panic:.*\n`)
 
 type ContainerLifecycle struct {

--- a/dockerutil/container_lifecycle.go
+++ b/dockerutil/container_lifecycle.go
@@ -16,8 +16,9 @@ import (
 	dockerclient "github.com/docker/docker/client"
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/go-connections/nat"
-	"github.com/strangelove-ventures/interchaintest/v8/ibc"
 	"go.uber.org/zap"
+
+	"github.com/strangelove-ventures/interchaintest/v8/ibc"
 )
 
 // Example Go/Cosmos-SDK panic format is `panic: bad Duration: time: invalid duration "bad"\n`.

--- a/dockerutil/container_lifecycle.go
+++ b/dockerutil/container_lifecycle.go
@@ -158,7 +158,7 @@ func (c *ContainerLifecycle) CheckForFailedStart(ctx context.Context, wait time.
 
 	if err := ParseSDKPanicFromText(logs.String()); err != nil {
 		// Must use Println and not the logger as there are ascii escape codes in the logs.
-		fmt.Printf("\nContainer name: %s.\nerror: %s.\nlogs\n%s\n", c.containerName, err.Error(), logs.String())
+		fmt.Printf("\nContainer name: %s.\nerror: %s.\nlogs\n%s\n", c.containerName, err.Error(), logs.String()) //nolint: forbidigo
 		return fmt.Errorf("container %s failed to start: %w", c.containerName, err)
 	}
 

--- a/dockerutil/file.go
+++ b/dockerutil/file.go
@@ -41,8 +41,8 @@ func CopyFile(src, dst string) (int64, error) {
 	return nBytes, err
 }
 
-func CopyCoverageFromContainer(ctx context.Context, t *testing.T, client *client.Client, containerId string, internalGoCoverDir string, extHostGoCoverDir string) {
-	r, _, err := client.CopyFromContainer(ctx, containerId, internalGoCoverDir)
+func CopyCoverageFromContainer(ctx context.Context, t *testing.T, client *client.Client, containerID string, internalGoCoverDir string, extHostGoCoverDir string) {
+	r, _, err := client.CopyFromContainer(ctx, containerID, internalGoCoverDir)
 	require.NoError(t, err)
 	defer r.Close()
 
@@ -58,7 +58,7 @@ func CopyCoverageFromContainer(ctx context.Context, t *testing.T, client *client
 		require.NoError(t, err)
 
 		var fileBuff bytes.Buffer
-		_, err = io.Copy(&fileBuff, tr)
+		_, err = io.Copy(&fileBuff, tr) //nolint: gosec
 		require.NoError(t, err)
 
 		name := hdr.Name
@@ -74,7 +74,7 @@ func CopyCoverageFromContainer(ctx context.Context, t *testing.T, client *client
 		}
 
 		filePath := filepath.Join(extHostGoCoverDir, extractedFileName)
-		err = os.WriteFile(filePath, fileBuff.Bytes(), os.ModePerm)
+		err = os.WriteFile(filePath, fileBuff.Bytes(), os.ModePerm) //nolint: gosec
 		require.NoError(t, err)
 	}
 }

--- a/dockerutil/file.go
+++ b/dockerutil/file.go
@@ -42,6 +42,8 @@ func CopyFile(src, dst string) (int64, error) {
 }
 
 func CopyCoverageFromContainer(ctx context.Context, t *testing.T, client *client.Client, containerID string, internalGoCoverDir string, extHostGoCoverDir string) {
+	t.Helper()
+
 	r, _, err := client.CopyFromContainer(ctx, containerID, internalGoCoverDir)
 	require.NoError(t, err)
 	defer r.Close()
@@ -74,7 +76,7 @@ func CopyCoverageFromContainer(ctx context.Context, t *testing.T, client *client
 		}
 
 		filePath := filepath.Join(extHostGoCoverDir, extractedFileName)
-		err = os.WriteFile(filePath, fileBuff.Bytes(), os.ModePerm) //nolint: gosec
+		err = os.WriteFile(filePath, fileBuff.Bytes(), os.ModePerm)
 		require.NoError(t, err)
 	}
 }

--- a/dockerutil/fileretriever_test.go
+++ b/dockerutil/fileretriever_test.go
@@ -5,10 +5,11 @@ import (
 	"testing"
 
 	volumetypes "github.com/docker/docker/api/types/volume"
-	interchaintest "github.com/strangelove-ventures/interchaintest/v8"
-	"github.com/strangelove-ventures/interchaintest/v8/dockerutil"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
+
+	"github.com/strangelove-ventures/interchaintest/v8"
+	"github.com/strangelove-ventures/interchaintest/v8/dockerutil"
 )
 
 func TestFileRetriever(t *testing.T) {
@@ -58,12 +59,12 @@ func TestFileRetriever(t *testing.T) {
 	t.Run("top-level file", func(t *testing.T) {
 		b, err := fr.SingleFileContent(ctx, v.Name, "hello.txt")
 		require.NoError(t, err)
-		require.Equal(t, string(b), "hello world")
+		require.Equal(t, "hello world", string(b))
 	})
 
 	t.Run("nested file", func(t *testing.T) {
 		b, err := fr.SingleFileContent(ctx, v.Name, "foo/bar/baz.txt")
 		require.NoError(t, err)
-		require.Equal(t, string(b), "test")
+		require.Equal(t, "test", string(b))
 	})
 }

--- a/dockerutil/filewriter_test.go
+++ b/dockerutil/filewriter_test.go
@@ -5,10 +5,11 @@ import (
 	"testing"
 
 	volumetypes "github.com/docker/docker/api/types/volume"
-	interchaintest "github.com/strangelove-ventures/interchaintest/v8"
-	"github.com/strangelove-ventures/interchaintest/v8/dockerutil"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
+
+	"github.com/strangelove-ventures/interchaintest/v8"
+	"github.com/strangelove-ventures/interchaintest/v8/dockerutil"
 )
 
 func TestFileWriter(t *testing.T) {
@@ -48,7 +49,7 @@ func TestFileWriter(t *testing.T) {
 		)
 		require.NoError(t, res.Err)
 
-		require.Equal(t, string(res.Stdout), "hello world")
+		require.Equal(t, "hello world", string(res.Stdout))
 	})
 
 	t.Run("create nested file", func(t *testing.T) {
@@ -63,6 +64,6 @@ func TestFileWriter(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		require.Equal(t, string(res.Stdout), ":D")
+		require.Equal(t, ":D", string(res.Stdout))
 	})
 }

--- a/dockerutil/image_test.go
+++ b/dockerutil/image_test.go
@@ -69,7 +69,7 @@ func TestImage_Run(t *testing.T) {
 echo -n hi from stderr >> /dev/stderr
 `
 		tmpDir := t.TempDir()
-		err := os.WriteFile(filepath.Join(tmpDir, "test.sh"), []byte(scriptBody), 0o777) //nolint: gosec
+		err := os.WriteFile(filepath.Join(tmpDir, "test.sh"), []byte(scriptBody), 0o777)
 		require.NoError(t, err)
 
 		opts := ContainerOptions{

--- a/dockerutil/image_test.go
+++ b/dockerutil/image_test.go
@@ -69,7 +69,7 @@ func TestImage_Run(t *testing.T) {
 echo -n hi from stderr >> /dev/stderr
 `
 		tmpDir := t.TempDir()
-		err := os.WriteFile(filepath.Join(tmpDir, "test.sh"), []byte(scriptBody), 0o777)
+		err := os.WriteFile(filepath.Join(tmpDir, "test.sh"), []byte(scriptBody), 0o777) //nolint: gosec
 		require.NoError(t, err)
 
 		opts := ContainerOptions{

--- a/dockerutil/keyring.go
+++ b/dockerutil/keyring.go
@@ -51,7 +51,7 @@ func NewLocalKeyringFromDockerContainer(ctx context.Context, dc *client.Client, 
 		}
 
 		filePath := filepath.Join(localDirectory, "keyring-test", extractedFileName)
-		if err := os.WriteFile(filePath, fileBuff.Bytes(), os.ModePerm); err != nil { //nolint: gosec
+		if err := os.WriteFile(filePath, fileBuff.Bytes(), os.ModePerm); err != nil {
 			return nil, err
 		}
 	}

--- a/dockerutil/keyring.go
+++ b/dockerutil/keyring.go
@@ -19,8 +19,8 @@ import (
 
 // NewLocalKeyringFromDockerContainer copies the contents of the given container directory into a specified local directory.
 // This allows test hosts to sign transactions on behalf of test users.
-func NewLocalKeyringFromDockerContainer(ctx context.Context, dc *client.Client, localDirectory, containerKeyringDir, containerId string) (keyring.Keyring, error) {
-	reader, _, err := dc.CopyFromContainer(ctx, containerId, containerKeyringDir)
+func NewLocalKeyringFromDockerContainer(ctx context.Context, dc *client.Client, localDirectory, containerKeyringDir, containerID string) (keyring.Keyring, error) {
+	reader, _, err := dc.CopyFromContainer(ctx, containerID, containerKeyringDir)
 	if err != nil {
 		return nil, err
 	}
@@ -39,7 +39,7 @@ func NewLocalKeyringFromDockerContainer(ctx context.Context, dc *client.Client, 
 		}
 
 		var fileBuff bytes.Buffer
-		if _, err := io.Copy(&fileBuff, tr); err != nil {
+		if _, err := io.Copy(&fileBuff, tr); err != nil { //nolint: gosec
 			return nil, err
 		}
 
@@ -51,7 +51,7 @@ func NewLocalKeyringFromDockerContainer(ctx context.Context, dc *client.Client, 
 		}
 
 		filePath := filepath.Join(localDirectory, "keyring-test", extractedFileName)
-		if err := os.WriteFile(filePath, fileBuff.Bytes(), os.ModePerm); err != nil {
+		if err := os.WriteFile(filePath, fileBuff.Bytes(), os.ModePerm); err != nil { //nolint: gosec
 			return nil, err
 		}
 	}

--- a/dockerutil/setup_test.go
+++ b/dockerutil/setup_test.go
@@ -7,9 +7,10 @@ import (
 
 	volumetypes "github.com/docker/docker/api/types/volume"
 	"github.com/docker/docker/errdefs"
+	"github.com/stretchr/testify/require"
+
 	"github.com/strangelove-ventures/interchaintest/v8/dockerutil"
 	"github.com/strangelove-ventures/interchaintest/v8/mocktesting"
-	"github.com/stretchr/testify/require"
 )
 
 func TestDockerSetup_KeepVolumes(t *testing.T) {
@@ -36,7 +37,6 @@ func TestDockerSetup_KeepVolumes(t *testing.T) {
 		{keep: false, passed: true, volumeKept: false},
 		{keep: true, passed: true, volumeKept: false},
 	} {
-		tc := tc
 		state := "failed"
 		if tc.passed {
 			state = "passed"

--- a/dockerutil/volumeowner.go
+++ b/dockerutil/volumeowner.go
@@ -20,12 +20,12 @@ type VolumeOwnerOptions struct {
 	VolumeName string
 	ImageRef   string
 	TestName   string
-	UIDGID     string
+	UidGid     string //nolint: stylecheck
 }
 
 // SetVolumeOwner configures the owner of a volume to match the default user in the supplied image reference.
 func SetVolumeOwner(ctx context.Context, opts VolumeOwnerOptions) error {
-	owner := opts.UIDGID
+	owner := opts.UidGid
 	if owner == "" {
 		owner = GetRootUserString()
 	}

--- a/dockerutil/volumeowner.go
+++ b/dockerutil/volumeowner.go
@@ -20,12 +20,12 @@ type VolumeOwnerOptions struct {
 	VolumeName string
 	ImageRef   string
 	TestName   string
-	UidGid     string
+	UIDGID     string
 }
 
 // SetVolumeOwner configures the owner of a volume to match the default user in the supplied image reference.
 func SetVolumeOwner(ctx context.Context, opts VolumeOwnerOptions) error {
-	owner := opts.UidGid
+	owner := opts.UIDGID
 	if owner == "" {
 		owner = GetRootUserString()
 	}

--- a/examples/cosmos/bad_genesis_params_test.go
+++ b/examples/cosmos/bad_genesis_params_test.go
@@ -11,11 +11,9 @@ import (
 	"go.uber.org/zap/zaptest"
 )
 
-var (
-	badGenesis = []cosmos.GenesisKV{
-		cosmos.NewGenesisKV("app_state.gov.params.voting_period", "bad"),
-	}
-)
+var badGenesis = []cosmos.GenesisKV{
+	cosmos.NewGenesisKV("app_state.gov.params.voting_period", "bad"),
+}
 
 func TestBadInputParams(t *testing.T) {
 	cf := interchaintest.NewBuiltinChainFactory(zaptest.NewLogger(t), []*interchaintest.ChainSpec{

--- a/examples/cosmos/code_coverage_test.go
+++ b/examples/cosmos/code_coverage_test.go
@@ -34,7 +34,7 @@ func TestCodeCoverage(t *testing.T) {
 			{
 				Repository: "ghcr.io/liftedinit/manifest-ledger",
 				Version:    "v0.0.1-alpha.10",
-				UidGid:     "1025:1025",
+				UIDGID:     "1025:1025",
 			},
 		},
 		Bin:            "manifestd",

--- a/examples/cosmos/ethermint_test.go
+++ b/examples/cosmos/ethermint_test.go
@@ -97,7 +97,7 @@ func TestEthermintChain(t *testing.T) {
 			ChainConfig: ibc.ChainConfig{
 				Type:           "cosmos",
 				ChainID:        "dymension_100-1",
-				Images:         []ibc.DockerImage{{Repository: "ghcr.io/strangelove-ventures/heighliner/dymension", Version: "854ef84", UidGid: "1025:1025"}},
+				Images:         []ibc.DockerImage{{Repository: "ghcr.io/strangelove-ventures/heighliner/dymension", Version: "854ef84", UIDGID: "1025:1025"}},
 				Bin:            "dymd",
 				Bech32Prefix:   wallet,
 				Denom:          denom,

--- a/examples/cosmos/sdk_boundary_test.go
+++ b/examples/cosmos/sdk_boundary_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	interchaintest "github.com/strangelove-ventures/interchaintest/v8"
+	"github.com/strangelove-ventures/interchaintest/v8"
 	"github.com/strangelove-ventures/interchaintest/v8/chain/cosmos"
 	"github.com/strangelove-ventures/interchaintest/v8/conformance"
 	"github.com/strangelove-ventures/interchaintest/v8/ibc"
@@ -79,7 +79,7 @@ func TestSDKBoundaries(t *testing.T) {
 				relayer.CustomDockerImage(
 					rly.DefaultContainerImage,
 					tt.relayerVersion,
-					rly.RlyDefaultUidGid,
+					rly.RlyDefaultUIDGID,
 				),
 			)
 

--- a/examples/ethereum/foundry_test.go
+++ b/examples/ethereum/foundry_test.go
@@ -18,7 +18,6 @@ import (
 )
 
 func TestFoundry(t *testing.T) {
-
 	if testing.Short() {
 		t.Skip()
 	}
@@ -124,5 +123,4 @@ func TestFoundry(t *testing.T) {
 
 	// Sleep for an additional testing
 	time.Sleep(10 * time.Second)
-
 }

--- a/examples/ethereum/geth_test.go
+++ b/examples/ethereum/geth_test.go
@@ -2,7 +2,6 @@ package ethereum_test
 
 import (
 	"context"
-
 	"fmt"
 	"strings"
 	"testing"
@@ -19,7 +18,6 @@ import (
 )
 
 func TestGeth(t *testing.T) {
-
 	if testing.Short() {
 		t.Skip()
 	}

--- a/examples/hyperspace/hyperspace_test.go
+++ b/examples/hyperspace/hyperspace_test.go
@@ -114,12 +114,12 @@ func TestHyperspace(t *testing.T) {
 					{
 						Repository: "polkadot-node",
 						Version:    "local", // Set your locally built version
-						UidGid:     "1000:1000",
+						UIDGID:     "1000:1000",
 					},
 					{
 						Repository: "parachain-node",
 						Version:    "latest", // Set your locally built version
-						UidGid:     "1000:1000",
+						UIDGID:     "1000:1000",
 					},
 				},
 				Bin:            "polkadot",
@@ -143,7 +143,7 @@ func TestHyperspace(t *testing.T) {
 					{
 						Repository: "ibc-go-simd",
 						Version:    "local", // Set your locally built version
-						UidGid:     "1025:1025",
+						UIDGID:     "1025:1025",
 					},
 				},
 				Bin:                 "simd",

--- a/examples/ibc/wasm/wasm_icq_test.go
+++ b/examples/ibc/wasm/wasm_icq_test.go
@@ -51,7 +51,7 @@ func TestInterchainQueriesWASM(t *testing.T) {
 	wasmImage := ibc.DockerImage{
 		Repository: "ghcr.io/strangelove-ventures/heighliner/wasmd",
 		Version:    "v0.0.1",
-		UidGid:     dockerutil.GetHeighlinerUserString(),
+		UIDGID:     dockerutil.GetHeighlinerUserString(),
 	}
 
 	genesisAllowICQ := map[string]interface{}{

--- a/examples/penumbra/penumbra_ibc_test.go
+++ b/examples/penumbra/penumbra_ibc_test.go
@@ -63,7 +63,7 @@ func TestPenumbraToPenumbraIBC(t *testing.T) {
 	i := ibc.DockerImage{
 		Repository: "ghcr.io/cosmos/relayer",
 		Version:    "justin-pen-0.77",
-		UidGid:     "1025:1025",
+		UIDGID:     "1025:1025",
 	}
 	r := interchaintest.NewBuiltinRelayerFactory(
 		ibc.CosmosRly,
@@ -280,7 +280,7 @@ func TestPenumbraToCosmosIBC(t *testing.T) {
 	image := ibc.DockerImage{
 		Repository: "ghcr.io/cosmos/ibc-go-simd",
 		Version:    "v8.3.2",
-		UidGid:     "100:1000",
+		UIDGID:     "100:1000",
 	}
 
 	chains, err := interchaintest.NewBuiltinChainFactory(zaptest.NewLogger(t), []*interchaintest.ChainSpec{
@@ -323,7 +323,7 @@ func TestPenumbraToCosmosIBC(t *testing.T) {
 	i := ibc.DockerImage{
 		Repository: "ghcr.io/cosmos/relayer",
 		Version:    "justin-proto-update",
-		UidGid:     "1025:1025",
+		UIDGID:     "1025:1025",
 	}
 	r := interchaintest.NewBuiltinRelayerFactory(
 		ibc.CosmosRly,

--- a/examples/polkadot/polkadot_chain_test.go
+++ b/examples/polkadot/polkadot_chain_test.go
@@ -42,12 +42,12 @@ func TestPolkadotComposableChainStart(t *testing.T) {
 					{
 						Repository: "seunlanlege/centauri-polkadot",
 						Version:    "v0.9.27",
-						UidGid:     "1000:1000",
+						UIDGID:     "1000:1000",
 					},
 					{
 						Repository: "seunlanlege/centauri-parachain",
 						Version:    "v0.9.27",
-						UidGid:     "1025:1025",
+						UIDGID:     "1025:1025",
 					},
 				},
 				Bin:            "polkadot",

--- a/examples/polkadot/push_wasm_client_code_test.go
+++ b/examples/polkadot/push_wasm_client_code_test.go
@@ -74,7 +74,7 @@ func TestPushWasmClientCode(t *testing.T) {
 					{
 						Repository: "ghcr.io/strangelove-ventures/heighliner/ibc-go-simd",
 						Version:    "feat-wasm-clients",
-						UidGid:     "1025:1025",
+						UIDGID:     "1025:1025",
 					},
 				},
 				Bin:            "simd",

--- a/examples/polkadot/substrate_cosmos_ibc_test.go
+++ b/examples/polkadot/substrate_cosmos_ibc_test.go
@@ -48,12 +48,12 @@ func TestSubstrateToCosmosIBC(t *testing.T) {
 					{
 						Repository: "seunlanlege/centauri-polkadot",
 						Version:    "v0.9.27",
-						UidGid:     "1025:1025",
+						UIDGID:     "1025:1025",
 					},
 					{
 						Repository: "seunlanlege/centauri-parachain",
 						Version:    "v0.9.27",
-						UidGid:     "1025:1025",
+						UIDGID:     "1025:1025",
 					},
 				},
 				Bin:            "polkadot",
@@ -75,7 +75,7 @@ func TestSubstrateToCosmosIBC(t *testing.T) {
 					{
 						Repository: "ibc-go-simd",
 						Version:    "feat-wasm-client",
-						UidGid:     "1025:1025",
+						UIDGID:     "1025:1025",
 					},
 				},
 				Bin:            "simd",
@@ -118,13 +118,13 @@ func TestSubstrateToCosmosIBC(t *testing.T) {
 	ic := interchaintest.NewInterchain().
 		AddChain(composable).
 		AddChain(simd) //.
-		//AddRelayer(r, relayerName).
-		/*AddLink(interchaintest.InterchainLink{
-			Chain1:  composable,
-			Chain2:  simd,
-			Relayer: r,
-			Path:    pathName,
-		})*/
+	//AddRelayer(r, relayerName).
+	/*AddLink(interchaintest.InterchainLink{
+		Chain1:  composable,
+		Chain2:  simd,
+		Relayer: r,
+		Path:    pathName,
+	})*/
 
 	require.NoError(t, ic.Build(ctx, eRep, interchaintest.InterchainBuildOptions{
 		TestName:  t.Name(),

--- a/examples/thorchain/chainspec_thorchain_test.go
+++ b/examples/thorchain/chainspec_thorchain_test.go
@@ -31,7 +31,7 @@ func ThorchainDefaultChainSpec(testName string, numVals int, numFn int, ethRoute
 	chainImage := ibc.NewDockerImage("thorchain", "local", "1025:1025")
 	genesisKVMods := []thorchain.GenesisKV{
 		thorchain.NewGenesisKV("app_state.bank.params.default_send_enabled", true), // disable bank module transfers
-		thorchain.NewGenesisKV("app_state.thorchain.reserve", "22000000000000000"),  // mint to reserve for mocknet (220M)
+		thorchain.NewGenesisKV("app_state.thorchain.reserve", "22000000000000000"), // mint to reserve for mocknet (220M)
 		thorchain.NewGenesisKV("app_state.thorchain.chain_contracts", []ChainContract{
 			{
 				Chain:  "ETH",
@@ -95,7 +95,7 @@ func ThorchainDefaultChainSpec(testName string, numVals int, numFn int, ethRoute
 				Image:       chainImage,
 				HomeDir:     "/var/data/bifrost",
 				Ports:       []string{"5040", "6040", "9000"},
-				//StartCmd: []string{"bifrost", "-p"},
+				// StartCmd: []string{"bifrost", "-p"},
 				StartCmd:         []string{"bifrost", "-p", "-l", "debug"},
 				Env:              bifrostEnv,
 				PreStart:         false,

--- a/examples/thorchain/features/arb.go
+++ b/examples/thorchain/features/arb.go
@@ -21,7 +21,6 @@ func Arb(
 	thorchain *tc.Thorchain,
 	exoChains ...ibc.Chain,
 ) (users []ibc.Wallet, err error) {
-	fmt.Println("#### Arb")
 	chains := append(exoChains, thorchain)
 	users, err = GetAndFundTestUsers(t, ctx, "arb", chains...)
 	if err != nil {
@@ -33,7 +32,7 @@ func Arb(
 		return users, err
 	}
 
-	mimirs, err := thorchain.ApiGetMimirs()
+	mimirs, err := thorchain.APIGetMimirs(ctx)
 	if err != nil {
 		return users, err
 	}
@@ -49,8 +48,6 @@ func Arb(
 
 	var eg errgroup.Group
 	for i, exoChain := range exoChains {
-		i := i
-		exoChain := exoChain
 		eg.Go(func() error {
 			exoChainType, err := common.NewChain(exoChain.Config().Name)
 			if err != nil {
@@ -65,7 +62,7 @@ func Arb(
 			}
 
 			memo := fmt.Sprintf("trade+:%s", thorUser.FormattedAddress())
-			exoInboundAddr, _, err := thorchain.ApiGetInboundAddress(exoChainType.String())
+			exoInboundAddr, _, err := thorchain.APIGetInboundAddress(ctx, exoChainType.String())
 			if err != nil {
 				return err
 			}
@@ -91,7 +88,7 @@ func Arb(
 		maxBasisPts := uint64(10_000)
 
 		for {
-			pools, err := thorchain.ApiGetPools()
+			pools, err := thorchain.APIGetPools(ctx)
 			if err != nil {
 				fmt.Println("Error getting arb api pools", err)
 				time.Sleep(time.Second * 2)

--- a/examples/thorchain/features/dual_lper.go
+++ b/examples/thorchain/features/dual_lper.go
@@ -44,7 +44,7 @@ func DualLp(
 		return thorUser, exoUser, fmt.Errorf("duallp, exo balance (%s), %w", exoChain.Config().Name, err)
 	}
 	memo = fmt.Sprintf("+:%s:%s", exoAsset, thorUser.FormattedAddress())
-	exoInboundAddr, _, err := thorchain.ApiGetInboundAddress(exoChainType.String())
+	exoInboundAddr, _, err := thorchain.APIGetInboundAddress(ctx, exoChainType.String())
 	if err != nil {
 		return thorUser, exoUser, fmt.Errorf("duallp, inbound addr (%s), %w", exoChain.Config().Name, err)
 	}

--- a/examples/thorchain/features/helpers.go
+++ b/examples/thorchain/features/helpers.go
@@ -66,7 +66,7 @@ func PollForPool(ctx context.Context, thorchain *tc.Thorchain, deltaBlocks int64
 		return fmt.Errorf("failed to get height: %w", err)
 	}
 	doPoll := func(ctx context.Context, height int64) (any, error) {
-		pool, err := thorchain.APIGetPool(nil, asset)
+		pool, err := thorchain.APIGetPool(ctx, asset)
 		if err != nil {
 			time.Sleep(time.Second) // rate limit
 			return nil, err
@@ -143,7 +143,7 @@ func PollSwapCompleted(ctx context.Context, thorchain *tc.Thorchain, deltaBlocks
 		return tc.Saver{}, fmt.Errorf("failed to get height: %w", err)
 	}
 	doPoll := func(ctx context.Context, height int64) (any, error) {
-		stages, err := thorchain.APIGetTxStages(nil, txHash)
+		stages, err := thorchain.APIGetTxStages(ctx, txHash)
 		if err != nil {
 			time.Sleep(time.Second) // rate limit
 			return nil, err
@@ -167,7 +167,7 @@ func PollOutboundSigned(ctx context.Context, thorchain *tc.Thorchain, deltaBlock
 		return tc.Saver{}, fmt.Errorf("failed to get height: %w", err)
 	}
 	doPoll := func(ctx context.Context, height int64) (any, error) {
-		stages, err := thorchain.APIGetTxStages(nil, txHash)
+		stages, err := thorchain.APIGetTxStages(ctx, txHash)
 		if err != nil {
 			time.Sleep(time.Second) // rate limit
 			return nil, err
@@ -215,7 +215,7 @@ func PollForPoolSuspended(ctx context.Context, thorchain *tc.Thorchain, deltaBlo
 		return fmt.Errorf("failed to get height: %w", err)
 	}
 	doPoll := func(ctx context.Context, height int64) (any, error) {
-		pool, err := thorchain.APIGetPool(nil, exoAsset)
+		pool, err := thorchain.APIGetPool(ctx, exoAsset)
 		if err != nil {
 			time.Sleep(time.Second) // rate limit
 			return nil, err

--- a/examples/thorchain/features/helpers.go
+++ b/examples/thorchain/features/helpers.go
@@ -66,7 +66,7 @@ func PollForPool(ctx context.Context, thorchain *tc.Thorchain, deltaBlocks int64
 		return fmt.Errorf("failed to get height: %w", err)
 	}
 	doPoll := func(ctx context.Context, height int64) (any, error) {
-		pool, err := thorchain.ApiGetPool(asset)
+		pool, err := thorchain.APIGetPool(nil, asset)
 		if err != nil {
 			time.Sleep(time.Second) // rate limit
 			return nil, err
@@ -91,7 +91,7 @@ func PollForSaver(ctx context.Context, thorchain *tc.Thorchain, deltaBlocks int6
 		return tc.Saver{}, fmt.Errorf("failed to get height: %w", err)
 	}
 	doPoll := func(ctx context.Context, height int64) (tc.Saver, error) {
-		savers, err := thorchain.ApiGetSavers(asset)
+		savers, err := thorchain.APIGetSavers(ctx, asset)
 		if err != nil {
 			time.Sleep(time.Second) // rate limit
 			return tc.Saver{}, err
@@ -117,7 +117,7 @@ func PollForEjectedSaver(ctx context.Context, thorchain *tc.Thorchain, deltaBloc
 		return tc.Saver{}, fmt.Errorf("failed to get height: %w", err)
 	}
 	doPoll := func(ctx context.Context, height int64) (tc.Saver, error) {
-		savers, err := thorchain.ApiGetSavers(asset)
+		savers, err := thorchain.APIGetSavers(ctx, asset)
 		if err != nil {
 			time.Sleep(time.Second) // rate limit
 			return tc.Saver{}, err
@@ -143,7 +143,7 @@ func PollSwapCompleted(ctx context.Context, thorchain *tc.Thorchain, deltaBlocks
 		return tc.Saver{}, fmt.Errorf("failed to get height: %w", err)
 	}
 	doPoll := func(ctx context.Context, height int64) (any, error) {
-		stages, err := thorchain.ApiGetTxStages(txHash)
+		stages, err := thorchain.APIGetTxStages(nil, txHash)
 		if err != nil {
 			time.Sleep(time.Second) // rate limit
 			return nil, err
@@ -167,7 +167,7 @@ func PollOutboundSigned(ctx context.Context, thorchain *tc.Thorchain, deltaBlock
 		return tc.Saver{}, fmt.Errorf("failed to get height: %w", err)
 	}
 	doPoll := func(ctx context.Context, height int64) (any, error) {
-		stages, err := thorchain.ApiGetTxStages(txHash)
+		stages, err := thorchain.APIGetTxStages(nil, txHash)
 		if err != nil {
 			time.Sleep(time.Second) // rate limit
 			return nil, err
@@ -215,7 +215,7 @@ func PollForPoolSuspended(ctx context.Context, thorchain *tc.Thorchain, deltaBlo
 		return fmt.Errorf("failed to get height: %w", err)
 	}
 	doPoll := func(ctx context.Context, height int64) (any, error) {
-		pool, err := thorchain.ApiGetPool(exoAsset)
+		pool, err := thorchain.APIGetPool(nil, exoAsset)
 		if err != nil {
 			time.Sleep(time.Second) // rate limit
 			return nil, err

--- a/examples/thorchain/features/ragnarok.go
+++ b/examples/thorchain/features/ragnarok.go
@@ -29,7 +29,7 @@ func Ragnarok(
 	}
 	exoAsset := exoChainType.GetGasAsset()
 
-	_, err = thorchain.APIGetPool(nil, exoAsset)
+	_, err = thorchain.APIGetPool(ctx, exoAsset)
 	if err != nil {
 		return fmt.Errorf("pool (%s) not found to ragnarok, %w", exoChain.Config().Name, err)
 	}

--- a/examples/thorchain/features/ragnarok.go
+++ b/examples/thorchain/features/ragnarok.go
@@ -29,7 +29,7 @@ func Ragnarok(
 	}
 	exoAsset := exoChainType.GetGasAsset()
 
-	_, err = thorchain.ApiGetPool(exoAsset)
+	_, err = thorchain.APIGetPool(nil, exoAsset)
 	if err != nil {
 		return fmt.Errorf("pool (%s) not found to ragnarok, %w", exoChain.Config().Name, err)
 	}

--- a/examples/thorchain/features/saver_eject.go
+++ b/examples/thorchain/features/saver_eject.go
@@ -36,7 +36,7 @@ func SaverEject(
 
 	// Reset mimirs
 	mimirLock.Lock()
-	mimirs, err := thorchain.ApiGetMimirs()
+	mimirs, err := thorchain.APIGetMimirs(nil)
 	if err != nil {
 		mimirLock.Unlock()
 		return exoUser, err
@@ -65,7 +65,7 @@ func SaverEject(
 	}
 	exoAsset := exoChainType.GetGasAsset()
 
-	pool, err := thorchain.ApiGetPool(exoAsset)
+	pool, err := thorchain.APIGetPool(nil, exoAsset)
 	if err != nil {
 		mimirLock.Unlock()
 		return exoUser, err
@@ -73,7 +73,7 @@ func SaverEject(
 	saveAmount := sdkmath.NewUintFromString(pool.BalanceAsset).
 		MulUint64(2000).QuoUint64(10_000)
 
-	saverQuote, err := thorchain.ApiGetSaverDepositQuote(exoAsset, saveAmount)
+	saverQuote, err := thorchain.APIGetSaverDepositQuote(nil, exoAsset, saveAmount)
 	if err != nil {
 		mimirLock.Unlock()
 		return exoUser, err
@@ -95,7 +95,7 @@ func SaverEject(
 		memo = fmt.Sprintf("+:%s", exoAsset.GetSyntheticAsset())
 	}
 
-	exoInboundAddr, _, err := thorchain.ApiGetInboundAddress(exoChainType.String())
+	exoInboundAddr, _, err := thorchain.APIGetInboundAddress(ctx, exoChainType.String())
 	if err != nil {
 		mimirLock.Unlock()
 		return exoUser, err
@@ -150,7 +150,7 @@ func SaverEject(
 		}
 	}
 
-	mimirs, err = thorchain.ApiGetMimirs()
+	mimirs, err = thorchain.APIGetMimirs(nil)
 	if err != nil {
 		mimirLock.Unlock()
 		return exoUser, err

--- a/examples/thorchain/features/saver_eject.go
+++ b/examples/thorchain/features/saver_eject.go
@@ -36,7 +36,7 @@ func SaverEject(
 
 	// Reset mimirs
 	mimirLock.Lock()
-	mimirs, err := thorchain.APIGetMimirs(nil)
+	mimirs, err := thorchain.APIGetMimirs(ctx)
 	if err != nil {
 		mimirLock.Unlock()
 		return exoUser, err
@@ -65,7 +65,7 @@ func SaverEject(
 	}
 	exoAsset := exoChainType.GetGasAsset()
 
-	pool, err := thorchain.APIGetPool(nil, exoAsset)
+	pool, err := thorchain.APIGetPool(ctx, exoAsset)
 	if err != nil {
 		mimirLock.Unlock()
 		return exoUser, err
@@ -73,7 +73,7 @@ func SaverEject(
 	saveAmount := sdkmath.NewUintFromString(pool.BalanceAsset).
 		MulUint64(2000).QuoUint64(10_000)
 
-	saverQuote, err := thorchain.APIGetSaverDepositQuote(nil, exoAsset, saveAmount)
+	saverQuote, err := thorchain.APIGetSaverDepositQuote(ctx, exoAsset, saveAmount)
 	if err != nil {
 		mimirLock.Unlock()
 		return exoUser, err
@@ -150,7 +150,7 @@ func SaverEject(
 		}
 	}
 
-	mimirs, err = thorchain.APIGetMimirs(nil)
+	mimirs, err = thorchain.APIGetMimirs(ctx)
 	if err != nil {
 		mimirLock.Unlock()
 		return exoUser, err

--- a/examples/thorchain/features/savers.go
+++ b/examples/thorchain/features/savers.go
@@ -32,14 +32,14 @@ func Saver(
 	}
 	exoAsset := exoChainType.GetGasAsset()
 
-	pool, err := thorchain.ApiGetPool(exoAsset)
+	pool, err := thorchain.APIGetPool(nil, exoAsset)
 	if err != nil {
 		return exoUser, err
 	}
 	saveAmount := sdkmath.NewUintFromString(pool.BalanceAsset).
 		MulUint64(500).QuoUint64(10_000)
 
-	saverQuote, err := thorchain.ApiGetSaverDepositQuote(exoAsset, saveAmount)
+	saverQuote, err := thorchain.APIGetSaverDepositQuote(nil, exoAsset, saveAmount)
 	if err != nil {
 		return exoUser, err
 	}
@@ -60,7 +60,7 @@ func Saver(
 		memo = fmt.Sprintf("+:%s", exoAsset.GetSyntheticAsset())
 	}
 
-	exoInboundAddr, _, err := thorchain.ApiGetInboundAddress(exoChainType.String())
+	exoInboundAddr, _, err := thorchain.APIGetInboundAddress(ctx, exoChainType.String())
 	if err != nil {
 		return exoUser, err
 	}

--- a/examples/thorchain/features/savers.go
+++ b/examples/thorchain/features/savers.go
@@ -32,14 +32,14 @@ func Saver(
 	}
 	exoAsset := exoChainType.GetGasAsset()
 
-	pool, err := thorchain.APIGetPool(nil, exoAsset)
+	pool, err := thorchain.APIGetPool(ctx, exoAsset)
 	if err != nil {
 		return exoUser, err
 	}
 	saveAmount := sdkmath.NewUintFromString(pool.BalanceAsset).
 		MulUint64(500).QuoUint64(10_000)
 
-	saverQuote, err := thorchain.APIGetSaverDepositQuote(nil, exoAsset, saveAmount)
+	saverQuote, err := thorchain.APIGetSaverDepositQuote(ctx, exoAsset, saveAmount)
 	if err != nil {
 		return exoUser, err
 	}

--- a/examples/thorchain/features/swap.go
+++ b/examples/thorchain/features/swap.go
@@ -71,13 +71,13 @@ func singleSwap(
 
 	srcChainAsset := srcChainType.GetGasAsset()
 	destChainAsset := destChainType.GetGasAsset()
-	pool, err := thorchain.ApiGetPool(srcChainAsset)
+	pool, err := thorchain.APIGetPool(ctx, srcChainAsset)
 	if err != nil {
 		return fmt.Errorf("getting srcChain pool, %w", err)
 	}
 
 	swapAmount := sdkmath.NewUintFromString(pool.BalanceAsset).QuoUint64(200)
-	swapQuote, err := thorchain.ApiGetSwapQuote(srcChainAsset, destChainAsset, swapAmount)
+	swapQuote, err := thorchain.APIGetSwapQuote(ctx, srcChainAsset, destChainAsset, swapAmount)
 	if err != nil {
 		return fmt.Errorf("get swap quote, %w", err)
 	}
@@ -104,7 +104,7 @@ func singleSwap(
 		return err
 	}
 
-	srcChainInboundAddr, _, err := thorchain.ApiGetInboundAddress(srcChainType.String())
+	srcChainInboundAddr, _, err := thorchain.APIGetInboundAddress(ctx, srcChainType.String())
 	if err != nil {
 		return fmt.Errorf("get srcChain inbound address: %w", err)
 	}
@@ -138,7 +138,7 @@ func singleSwap(
 		}
 	}
 
-	details, err := thorchain.ApiGetTxDetails(txHash)
+	details, err := thorchain.APIGetTxDetails(ctx, txHash)
 	if err != nil {
 		return err
 	}
@@ -160,7 +160,7 @@ func singleSwap(
 		outAmountPlusMaxGas = outAmountPlusMaxGas.Add(sdkmath.NewUintFromString(maxGas.Amount))
 	} else { // shouldn't enter here for atom -> rune
 		var maxGasAssetValue sdkmath.Uint
-		maxGasAssetValue, err = thorchain.ConvertAssetAmount(maxGas, destChainAsset.String())
+		maxGasAssetValue, err = thorchain.ConvertAssetAmount(ctx, maxGas, destChainAsset.String())
 		if err != nil {
 			return fmt.Errorf("failed to convert asset, %w", err)
 		}

--- a/examples/thorchain/helper_test.go
+++ b/examples/thorchain/helper_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"regexp"
 	"time"
-	
+
 	"github.com/strangelove-ventures/interchaintest/v8/ibc"
 )
 
@@ -31,7 +31,7 @@ func NiceWaitForBlocks(ctx context.Context, delta int64, chain ibc.Chain) error 
 	}
 
 	currentHeight := startingHeight
-	for ; currentHeight < startingHeight + delta; {
+	for currentHeight < startingHeight+delta {
 		time.Sleep(time.Millisecond * 200)
 		currentHeight, err = chain.Height(ctx)
 		if err != nil {

--- a/examples/thorchain/setup_test.go
+++ b/examples/thorchain/setup_test.go
@@ -34,7 +34,7 @@ import (
 func StartExoChains(t *testing.T, ctx context.Context, client *client.Client, network string) ExoChains {
 	chainSpecs := []*interchaintest.ChainSpec{
 		EthChainSpec("geth"), // only use this chain spec for eth or the one below
-		//EthChainSpec("anvil"),
+		// EthChainSpec("anvil"),
 		GaiaChainSpec(),
 		BtcChainSpec(),
 		BchChainSpec(),
@@ -164,7 +164,7 @@ func SetupContracts(ctx context.Context, ethExoChain *ExoChain, bscExoChain *Exo
 		if ethExoChain.chain.Config().Bin == "geth" {
 			ethContractAddr, err = SetupGethContracts(egCtx, ethExoChain)
 		} else {
-			ethContractAddr, err = SetupAnvilContracts(egCtx, ethExoChain) 
+			ethContractAddr, err = SetupAnvilContracts(egCtx, ethExoChain)
 		}
 		return err
 	})
@@ -173,7 +173,7 @@ func SetupContracts(ctx context.Context, ethExoChain *ExoChain, bscExoChain *Exo
 		bscContractAddr, err = SetupGethContracts(egCtx, bscExoChain)
 		return err
 	})
-		
+
 	return ethContractAddr, bscContractAddr, eg.Wait()
 }
 

--- a/ibc/packet_test.go
+++ b/ibc/packet_test.go
@@ -109,9 +109,6 @@ func TestPacket_Equal(t *testing.T) {
 	} {
 		require.Equal(t, tt.WantEqual, tt.Left.Equal(tt.Right), tt)
 		require.Equal(t, tt.WantEqual, tt.Right.Equal(tt.Left), tt)
-
-		require.True(t, tt.Left.Equal(tt.Left))
-		require.True(t, tt.Right.Equal(tt.Right))
 	}
 }
 

--- a/ibc/relayer.go
+++ b/ibc/relayer.go
@@ -171,11 +171,13 @@ func GetTransferChannel(ctx context.Context, r Relayer, rep RelayerExecReporter,
 
 	var srcChan *ChannelOutput
 	for _, channel := range srcChannels {
-		if len(channel.ConnectionHops) == 1 && channel.ConnectionHops[0] == srcConnectionID && channel.PortID == "transfer" {
+		ch := channel
+
+		if len(ch.ConnectionHops) == 1 && ch.ConnectionHops[0] == srcConnectionID && ch.PortID == "transfer" {
 			if srcChan != nil {
 				return nil, fmt.Errorf("found multiple transfer channels on %s for connection %s", srcChainID, srcConnectionID)
 			}
-			srcChan = &channel
+			srcChan = &ch
 		}
 	}
 
@@ -261,6 +263,8 @@ func (o Order) String() string {
 		return "unordered"
 	case Ordered:
 		return "ordered"
+	case Invalid:
+		return "invalid"
 	default:
 		return "invalid"
 	}

--- a/ibc/types.go
+++ b/ibc/types.go
@@ -21,6 +21,18 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/module/testutil"
 )
 
+// Chain type constant values, used to determine if a ChainConfig is of a certain type.
+const (
+	Polkadot   = "polkadot"
+	Parachain  = "parachain"
+	RelayChain = "relaychain"
+	Cosmos     = "cosmos"
+	Penumbra   = "penumbra"
+	Ethereum   = "ethereum"
+	Thorchain  = "thorchain"
+	UTXO       = "utxo"
+)
+
 // ChainConfig defines the chain parameters requires to run an interchaintest testnet for a chain.
 type ChainConfig struct {
 	// Chain type, e.g. cosmos.
@@ -302,11 +314,11 @@ type CometMockConfig struct {
 	BlockTimeMs int         `yaml:"block-time"`
 }
 
-func NewDockerImage(repository, version, uidGid string) DockerImage {
+func NewDockerImage(repository, version, uidGID string) DockerImage {
 	return DockerImage{
 		Repository: repository,
 		Version:    version,
-		UIDGID:     uidGid,
+		UIDGID:     uidGID,
 	}
 }
 
@@ -326,7 +338,7 @@ func (i DockerImage) Validate() error {
 		missing = append(missing, "Repository")
 	}
 	if i.UIDGID == "" {
-		missing = append(missing, "UidGid")
+		missing = append(missing, "UIDGID")
 	}
 
 	if len(missing) > 0 {

--- a/ibc/types.go
+++ b/ibc/types.go
@@ -294,7 +294,7 @@ type SidecarConfig struct {
 type DockerImage struct {
 	Repository string `json:"repository" yaml:"repository"`
 	Version    string `json:"version" yaml:"version"`
-	UidGid     string `json:"uid-gid" yaml:"uid-gid"`
+	UIDGID     string `json:"uid-gid" yaml:"uid-gid"`
 }
 
 type CometMockConfig struct {
@@ -306,7 +306,7 @@ func NewDockerImage(repository, version, uidGid string) DockerImage {
 	return DockerImage{
 		Repository: repository,
 		Version:    version,
-		UidGid:     uidGid,
+		UIDGID:     uidGid,
 	}
 }
 
@@ -325,7 +325,7 @@ func (i DockerImage) Validate() error {
 	if i.Repository == "" {
 		missing = append(missing, "Repository")
 	}
-	if i.UidGid == "" {
+	if i.UIDGID == "" {
 		missing = append(missing, "UidGid")
 	}
 

--- a/ibc/types.go
+++ b/ibc/types.go
@@ -338,7 +338,7 @@ func (i DockerImage) Validate() error {
 		missing = append(missing, "Repository")
 	}
 	if i.UIDGID == "" {
-		missing = append(missing, "UIDGID")
+		missing = append(missing, "UidGid")
 	}
 
 	if len(missing) > 0 {

--- a/interchain.go
+++ b/interchain.go
@@ -6,13 +6,14 @@ import (
 	"math"
 
 	"github.com/docker/docker/client"
-	"github.com/strangelove-ventures/interchaintest/v8/chain/cosmos"
-	"github.com/strangelove-ventures/interchaintest/v8/ibc"
-	"github.com/strangelove-ventures/interchaintest/v8/testreporter"
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
 
 	sdkmath "cosmossdk.io/math"
+
+	"github.com/strangelove-ventures/interchaintest/v8/chain/cosmos"
+	"github.com/strangelove-ventures/interchaintest/v8/ibc"
+	"github.com/strangelove-ventures/interchaintest/v8/testreporter"
 )
 
 // Interchain represents a full IBC network, encompassing a collection of
@@ -366,8 +367,6 @@ func (ic *Interchain) Build(ctx context.Context, rep *testreporter.RelayerExecRe
 
 	// For every relayer link, teach the relayer about the link and create the link.
 	for rp, link := range ic.links {
-		rp := rp
-		link := link
 		c0 := link.chains[0]
 		c1 := link.chains[1]
 
@@ -381,8 +380,6 @@ func (ic *Interchain) Build(ctx context.Context, rep *testreporter.RelayerExecRe
 
 	// For every provider consumer link, teach the relayer about the link and create the link.
 	for rp, link := range ic.providerConsumerLinks {
-		rp := rp
-		link := link
 		p := link.provider
 		c := link.consumer
 
@@ -399,8 +396,6 @@ func (ic *Interchain) Build(ctx context.Context, rep *testreporter.RelayerExecRe
 	// Now link the paths in parallel
 	// Creates clients, connections, and channels for each link/path.
 	for rp, link := range ic.providerConsumerLinks {
-		rp := rp
-		link := link
 		p := link.provider
 		c := link.consumer
 		eg.Go(func() error {
@@ -509,8 +504,6 @@ func (ic *Interchain) Build(ctx context.Context, rep *testreporter.RelayerExecRe
 	// Now link the paths in parallel
 	// Creates clients, connections, and channels for each link/path.
 	for rp, link := range ic.links {
-		rp := rp
-		link := link
 		c0 := link.chains[0]
 		c1 := link.chains[1]
 		eg.Go(func() error {

--- a/interchain_builder.go
+++ b/interchain_builder.go
@@ -5,15 +5,16 @@ import (
 	"testing"
 
 	"github.com/docker/docker/client"
-	"github.com/strangelove-ventures/interchaintest/v8/chain/cosmos"
-	"github.com/strangelove-ventures/interchaintest/v8/ibc"
-	"github.com/strangelove-ventures/interchaintest/v8/relayer"
-	"github.com/strangelove-ventures/interchaintest/v8/testreporter"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
 
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	"github.com/cosmos/cosmos-sdk/types/module/testutil"
+
+	"github.com/strangelove-ventures/interchaintest/v8/chain/cosmos"
+	"github.com/strangelove-ventures/interchaintest/v8/ibc"
+	"github.com/strangelove-ventures/interchaintest/v8/relayer"
+	"github.com/strangelove-ventures/interchaintest/v8/testreporter"
 )
 
 type codecRegistry func(registry codectypes.InterfaceRegistry)
@@ -29,6 +30,8 @@ func RegisterInterfaces(codecIR ...codecRegistry) *testutil.TestEncodingConfig {
 
 // CreateChainWithConfig builds a single chain from the given ibc config.
 func CreateChainWithConfig(t *testing.T, numVals, numFull int, name, version string, config ibc.ChainConfig) []ibc.Chain {
+	t.Helper()
+
 	if version == "" {
 		if len(config.Images) == 0 {
 			version = "latest"
@@ -57,6 +60,8 @@ func CreateChainWithConfig(t *testing.T, numVals, numFull int, name, version str
 
 // CreateChainsWithChainSpecs builds multiple chains from the given chain specs.
 func CreateChainsWithChainSpecs(t *testing.T, chainSpecs []*ChainSpec) []ibc.Chain {
+	t.Helper()
+
 	cf := NewBuiltinChainFactory(zaptest.NewLogger(t), chainSpecs)
 
 	chains, err := cf.Chains(t.Name())
@@ -74,6 +79,8 @@ func BuildInitialChainWithRelayer(
 	links []InterchainLink,
 	skipPathCreations bool,
 ) (context.Context, *Interchain, ibc.Relayer, *testreporter.Reporter, *testreporter.RelayerExecReporter, *client.Client, string) {
+	t.Helper()
+
 	ctx := context.Background()
 	rep := testreporter.NewNopReporter()
 	eRep := rep.RelayerExecReporter(t)
@@ -128,6 +135,7 @@ func BuildInitialChainWithRelayer(
 }
 
 func BuildInitialChain(t *testing.T, chains []ibc.Chain, enableBlockDB bool) (context.Context, *Interchain, *client.Client, string) {
+	t.Helper()
 	ctx, ic, _, _, _, client, network := BuildInitialChainWithRelayer(t, chains, enableBlockDB, 0, nil, nil, true)
 	return ctx, ic, client, network
 }

--- a/interchain_test.go
+++ b/interchain_test.go
@@ -151,8 +151,6 @@ func getRelayerWalletsTest(t *testing.T, relayerImpl ibc.RelayerImplementation) 
 	)
 
 	t.Run("Chain one wallet is returned", func(t *testing.T) {
-		t.Parallel()
-
 		g1Wallet, walletFound = r.GetWallet(chains[0].Config().ChainID)
 		require.True(t, walletFound)
 		require.NotEmpty(t, g1Wallet.Address())
@@ -160,8 +158,6 @@ func getRelayerWalletsTest(t *testing.T, relayerImpl ibc.RelayerImplementation) 
 	})
 
 	t.Run("Chain two wallet is returned", func(t *testing.T) {
-		t.Parallel()
-
 		g2Wallet, walletFound = r.GetWallet(chains[1].Config().ChainID)
 		require.True(t, walletFound)
 		require.NotEmpty(t, g2Wallet.Address())
@@ -169,15 +165,11 @@ func getRelayerWalletsTest(t *testing.T, relayerImpl ibc.RelayerImplementation) 
 	})
 
 	t.Run("Different wallets are returned", func(t *testing.T) {
-		t.Parallel()
-
 		require.NotEqual(t, g1Wallet.Address(), g2Wallet.Address())
 		require.NotEqual(t, g1Wallet.Mnemonic(), g2Wallet.Mnemonic())
 	})
 
 	t.Run("Wallet for different chain does not exist", func(t *testing.T) {
-		t.Parallel()
-
 		_, ok := r.GetWallet("cosmoshub-does-not-exist")
 		require.False(t, ok)
 	})
@@ -413,13 +405,10 @@ func broadcastTxCosmosChainTest(t *testing.T, relayerImpl ibc.RelayerImplementat
 	sendAmount := math.NewInt(10_000)
 
 	t.Run("relayer starts", func(t *testing.T) {
-		t.Parallel()
 		require.NoError(t, r.StartRelayer(ctx, eRep, pathName))
 	})
 
 	t.Run("broadcast success", func(t *testing.T) {
-		t.Parallel()
-
 		b := cosmos.NewBroadcaster(t, gaia0.(*cosmos.CosmosChain))
 		transferAmount := sdk.Coin{Denom: gaia0.Config().Denom, Amount: sendAmount}
 		memo := ""
@@ -440,8 +429,6 @@ func broadcastTxCosmosChainTest(t *testing.T, relayerImpl ibc.RelayerImplementat
 	})
 
 	t.Run("transfer success", func(t *testing.T) {
-		t.Parallel()
-
 		require.NoError(t, testutil.WaitForBlocks(ctx, 5, gaia0, gaia1))
 
 		srcDenomTrace := transfertypes.ParseDenomTrace(transfertypes.GetPrefixedDenom("transfer", "channel-0", gaia0.Config().Denom))

--- a/interchain_test.go
+++ b/interchain_test.go
@@ -88,11 +88,11 @@ func duplicateChainTest(t *testing.T, relayerImpl ibc.RelayerImplementation) {
 	_ = ic.Close()
 }
 
-func TestInterchain_GetRelayerWallets_CosmosRly(t *testing.T) {
+func TestInterchain_GetRelayerWallets_CosmosRly(t *testing.T) { //nolint:tparallel
 	getRelayerWalletsTest(t, ibc.CosmosRly)
 }
 
-func TestInterchain_GetRelayerWallets_HermesRelayer(t *testing.T) {
+func TestInterchain_GetRelayerWallets_HermesRelayer(t *testing.T) { //nolint:tparallel
 	getRelayerWalletsTest(t, ibc.Hermes)
 }
 
@@ -255,11 +255,11 @@ func TestInterchain_CreateUser(t *testing.T) {
 	})
 }
 
-func TestCosmosChain_BroadcastTx_CosmosRly(t *testing.T) {
+func TestCosmosChain_BroadcastTx_CosmosRly(t *testing.T) { //nolint:tparallel
 	broadcastTxCosmosChainTest(t, ibc.CosmosRly)
 }
 
-func TestCosmosChain_BroadcastTx_HermesRelayer(t *testing.T) {
+func TestCosmosChain_BroadcastTx_HermesRelayer(t *testing.T) { //nolint:tparallel
 	broadcastTxCosmosChainTest(t, ibc.Hermes)
 }
 

--- a/interchain_test.go
+++ b/interchain_test.go
@@ -6,12 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/strangelove-ventures/interchaintest/v8"
-	"github.com/strangelove-ventures/interchaintest/v8/chain/cosmos"
-	"github.com/strangelove-ventures/interchaintest/v8/ibc"
-	"github.com/strangelove-ventures/interchaintest/v8/relayer/rly"
-	"github.com/strangelove-ventures/interchaintest/v8/testreporter"
-	"github.com/strangelove-ventures/interchaintest/v8/testutil"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
@@ -27,6 +21,13 @@ import (
 	"github.com/cosmos/cosmos-sdk/crypto/hd"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/strangelove-ventures/interchaintest/v8"
+	"github.com/strangelove-ventures/interchaintest/v8/chain/cosmos"
+	"github.com/strangelove-ventures/interchaintest/v8/ibc"
+	"github.com/strangelove-ventures/interchaintest/v8/relayer/rly"
+	"github.com/strangelove-ventures/interchaintest/v8/testreporter"
+	"github.com/strangelove-ventures/interchaintest/v8/testutil"
 )
 
 func TestInterchain_DuplicateChain_CosmosRly(t *testing.T) {
@@ -38,6 +39,8 @@ func TestInterchain_DuplicateChain_HermesRelayer(t *testing.T) {
 }
 
 func duplicateChainTest(t *testing.T, relayerImpl ibc.RelayerImplementation) {
+	t.Helper()
+
 	if testing.Short() {
 		t.Skip("skipping in short mode")
 	}
@@ -94,6 +97,8 @@ func TestInterchain_GetRelayerWallets_HermesRelayer(t *testing.T) {
 }
 
 func getRelayerWalletsTest(t *testing.T, relayerImpl ibc.RelayerImplementation) {
+	t.Helper()
+
 	if testing.Short() {
 		t.Skip("skipping in short mode")
 	}
@@ -146,6 +151,8 @@ func getRelayerWalletsTest(t *testing.T, relayerImpl ibc.RelayerImplementation) 
 	)
 
 	t.Run("Chain one wallet is returned", func(t *testing.T) {
+		t.Parallel()
+
 		g1Wallet, walletFound = r.GetWallet(chains[0].Config().ChainID)
 		require.True(t, walletFound)
 		require.NotEmpty(t, g1Wallet.Address())
@@ -153,6 +160,8 @@ func getRelayerWalletsTest(t *testing.T, relayerImpl ibc.RelayerImplementation) 
 	})
 
 	t.Run("Chain two wallet is returned", func(t *testing.T) {
+		t.Parallel()
+
 		g2Wallet, walletFound = r.GetWallet(chains[1].Config().ChainID)
 		require.True(t, walletFound)
 		require.NotEmpty(t, g2Wallet.Address())
@@ -160,11 +169,15 @@ func getRelayerWalletsTest(t *testing.T, relayerImpl ibc.RelayerImplementation) 
 	})
 
 	t.Run("Different wallets are returned", func(t *testing.T) {
+		t.Parallel()
+
 		require.NotEqual(t, g1Wallet.Address(), g2Wallet.Address())
 		require.NotEqual(t, g1Wallet.Mnemonic(), g2Wallet.Mnemonic())
 	})
 
 	t.Run("Wallet for different chain does not exist", func(t *testing.T) {
+		t.Parallel()
+
 		_, ok := r.GetWallet("cosmoshub-does-not-exist")
 		require.False(t, ok)
 	})
@@ -284,7 +297,6 @@ func TestInterchain_ConcurrentRelayerOps(t *testing.T) {
 	numValidators := 1
 
 	for _, rly := range relayers {
-		rly := rly
 		t.Run(rly.name, func(t *testing.T) {
 			client, network := interchaintest.DockerSetup(t)
 			f, err := interchaintest.CreateLogFile(fmt.Sprintf("%d.json", time.Now().Unix()))
@@ -349,6 +361,8 @@ func getIBCPath(chainA, chainB ibc.Chain) string {
 }
 
 func broadcastTxCosmosChainTest(t *testing.T, relayerImpl ibc.RelayerImplementation) {
+	t.Helper()
+
 	if testing.Short() {
 		t.Skip("skipping in short mode")
 	}
@@ -399,10 +413,13 @@ func broadcastTxCosmosChainTest(t *testing.T, relayerImpl ibc.RelayerImplementat
 	sendAmount := math.NewInt(10_000)
 
 	t.Run("relayer starts", func(t *testing.T) {
+		t.Parallel()
 		require.NoError(t, r.StartRelayer(ctx, eRep, pathName))
 	})
 
 	t.Run("broadcast success", func(t *testing.T) {
+		t.Parallel()
+
 		b := cosmos.NewBroadcaster(t, gaia0.(*cosmos.CosmosChain))
 		transferAmount := sdk.Coin{Denom: gaia0.Config().Denom, Amount: sendAmount}
 		memo := ""
@@ -423,6 +440,8 @@ func broadcastTxCosmosChainTest(t *testing.T, relayerImpl ibc.RelayerImplementat
 	})
 
 	t.Run("transfer success", func(t *testing.T) {
+		t.Parallel()
+
 		require.NoError(t, testutil.WaitForBlocks(ctx, 5, gaia0, gaia1))
 
 		srcDenomTrace := transfertypes.ParseDenomTrace(transfertypes.GetPrefixedDenom("transfer", "channel-0", gaia0.Config().Denom))
@@ -546,6 +565,8 @@ func TestInterchain_AddNil(t *testing.T) {
 }
 
 func assertTransactionIsValid(t *testing.T, resp sdk.TxResponse) {
+	t.Helper()
+
 	require.NotNil(t, resp)
 	require.NotEqual(t, 0, resp.GasUsed)
 	require.NotEqual(t, 0, resp.GasWanted)

--- a/local-interchain/cmd/local-ic/new_chain.go
+++ b/local-interchain/cmd/local-ic/new_chain.go
@@ -56,7 +56,7 @@ var newChainCmd = &cobra.Command{
 			c.SetDockerImage(ibc.DockerImage{
 				Repository: getOrDefault("Docker Repo", "ghcr.io/strangelove-ventures/heighliner/gaia"),
 				Version:    getOrDefault("Docker Tag / Branch Version", "v16.0.0"),
-				UidGid:     "1025:1025",
+				UIDGID:     "1025:1025",
 			})
 			if i == 0 {
 				c.SetHostPortOverride(types.BaseHostPortOverride())

--- a/local-interchain/cmd/local-ic/start_chain.go
+++ b/local-interchain/cmd/local-ic/start_chain.go
@@ -88,7 +88,7 @@ local-ic start https://pastebin.com/raw/Ummk4DTM
 				DockerImage: ibc.DockerImage{
 					Repository: relayerImg,
 					Version:    relayerVer,
-					UidGid:     relayerUidGid,
+					UIDGID:     relayerUidGid,
 				},
 				StartupFlags: relayerFlags,
 			},

--- a/local-interchain/interchain/config.go
+++ b/local-interchain/interchain/config.go
@@ -212,7 +212,7 @@ func CreateChainConfigs(cfg types.Chain) (ibc.ChainConfig, *interchaintest.Chain
 			{
 				Repository: cfg.DockerImage.Repository,
 				Version:    cfg.DockerImage.Version,
-				UidGid:     cfg.DockerImage.UidGid,
+				UIDGID:     cfg.DockerImage.UIDGID,
 			},
 		}
 	}

--- a/local-interchain/interchain/start.go
+++ b/local-interchain/interchain/start.go
@@ -127,7 +127,7 @@ func StartChain(installDir, chainCfgFile string, ac *types.AppStartConfig) {
 			interchaintestrelayer.CustomDockerImage(
 				rlyCfg.DockerImage.Repository,
 				rlyCfg.DockerImage.Version,
-				rlyCfg.DockerImage.UidGid,
+				rlyCfg.DockerImage.UIDGID,
 			),
 			interchaintestrelayer.StartupFlags(rlyCfg.StartupFlags...),
 		)

--- a/local-interchain/interchain/types/types.go
+++ b/local-interchain/interchain/types/types.go
@@ -86,8 +86,8 @@ func (chain *Chain) SetChainDefaults() {
 		chain.CoinType = 118
 	}
 
-	if chain.DockerImage.UidGid == "" {
-		chain.DockerImage.UidGid = "1025:1025"
+	if chain.DockerImage.UIDGID == "" {
+		chain.DockerImage.UIDGID = "1025:1025"
 	}
 
 	if chain.NumberVals == 0 {

--- a/mocktesting/t_test.go
+++ b/mocktesting/t_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestT_Name(t *testing.T) {
 	mt := mocktesting.NewT("foo")
-	require.Equal(t, mt.Name(), "foo")
+	require.Equal(t, "foo", mt.Name())
 
 	require.Panics(t, func() {
 		_ = mocktesting.NewT("")

--- a/mocktesting/t_test.go
+++ b/mocktesting/t_test.go
@@ -4,8 +4,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/strangelove-ventures/interchaintest/v8/mocktesting"
 	"github.com/stretchr/testify/require"
+
+	"github.com/strangelove-ventures/interchaintest/v8/mocktesting"
 )
 
 func TestT_Name(t *testing.T) {

--- a/relayer/docker.go
+++ b/relayer/docker.go
@@ -104,7 +104,7 @@ func NewDockerRelayer(ctx context.Context, log *zap.Logger, testName string, cli
 		VolumeName: r.volumeName,
 		ImageRef:   containerImage.Ref(),
 		TestName:   testName,
-		UidGid:     containerImage.UidGid,
+		UidGid:     containerImage.UIDGID,
 	}); err != nil {
 		return nil, fmt.Errorf("set volume owner: %w", err)
 	}
@@ -471,7 +471,7 @@ func (r *DockerRelayer) ContainerImage() ibc.DockerImage {
 	return ibc.DockerImage{
 		Repository: r.c.DefaultContainerImage(),
 		Version:    r.c.DefaultContainerVersion(),
-		UidGid:     r.c.DockerUser(),
+		UIDGID:     r.c.DockerUser(),
 	}
 }
 

--- a/relayer/docker.go
+++ b/relayer/docker.go
@@ -13,10 +13,11 @@ import (
 	volumetypes "github.com/docker/docker/api/types/volume"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/stdcopy"
+	"go.uber.org/zap"
+
 	"github.com/strangelove-ventures/interchaintest/v8/dockerutil"
 	"github.com/strangelove-ventures/interchaintest/v8/ibc"
 	"github.com/strangelove-ventures/interchaintest/v8/testutil"
-	"go.uber.org/zap"
 )
 
 const (
@@ -104,7 +105,7 @@ func NewDockerRelayer(ctx context.Context, log *zap.Logger, testName string, cli
 		VolumeName: r.volumeName,
 		ImageRef:   containerImage.Ref(),
 		TestName:   testName,
-		UidGid:     containerImage.UIDGID,
+		UIDGID:     containerImage.UIDGID,
 	}); err != nil {
 		return nil, fmt.Errorf("set volume owner: %w", err)
 	}

--- a/relayer/docker.go
+++ b/relayer/docker.go
@@ -105,7 +105,7 @@ func NewDockerRelayer(ctx context.Context, log *zap.Logger, testName string, cli
 		VolumeName: r.volumeName,
 		ImageRef:   containerImage.Ref(),
 		TestName:   testName,
-		UIDGID:     containerImage.UIDGID,
+		UidGid:     containerImage.UIDGID,
 	}); err != nil {
 		return nil, fmt.Errorf("set volume owner: %w", err)
 	}

--- a/relayer/hermes/hermes_commander.go
+++ b/relayer/hermes/hermes_commander.go
@@ -5,12 +5,13 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/strangelove-ventures/interchaintest/v8/ibc"
-	"github.com/strangelove-ventures/interchaintest/v8/relayer"
 	"go.uber.org/zap"
 
 	ibcexported "github.com/cosmos/ibc-go/v8/modules/core/03-connection/types"
 	"github.com/cosmos/ibc-go/v8/modules/core/23-commitment/types"
+
+	"github.com/strangelove-ventures/interchaintest/v8/ibc"
+	"github.com/strangelove-ventures/interchaintest/v8/relayer"
 )
 
 var _ relayer.RelayerCommander = &commander{}
@@ -33,11 +34,11 @@ func (c commander) DefaultContainerVersion() string {
 }
 
 func (c commander) DockerUser() string {
-	return hermesDefaultUidGid
+	return hermesDefaultUIDGID
 }
 
 func (c commander) ParseGetChannelsOutput(stdout, stderr string) ([]ibc.ChannelOutput, error) {
-	jsonBz := extractJsonResult([]byte(stdout))
+	jsonBz := extractJSONResult([]byte(stdout))
 	var result ChannelOutputResult
 	if err := json.Unmarshal(jsonBz, &result); err != nil {
 		return nil, err
@@ -63,7 +64,7 @@ func (c commander) ParseGetChannelsOutput(stdout, stderr string) ([]ibc.ChannelO
 }
 
 func (c commander) ParseGetConnectionsOutput(stdout, stderr string) (ibc.ConnectionOutputs, error) {
-	jsonBz := extractJsonResult([]byte(stdout))
+	jsonBz := extractJSONResult([]byte(stdout))
 	var queryResult ConnectionQueryResult
 	if err := json.Unmarshal(jsonBz, &queryResult); err != nil {
 		return ibc.ConnectionOutputs{}, err
@@ -97,7 +98,7 @@ func (c commander) ParseGetConnectionsOutput(stdout, stderr string) (ibc.Connect
 }
 
 func (c commander) ParseGetClientsOutput(stdout, stderr string) (ibc.ClientOutputs, error) {
-	jsonBz := extractJsonResult([]byte(stdout))
+	jsonBz := extractJSONResult([]byte(stdout))
 	var queryResult ClientQueryResult
 	if err := json.Unmarshal(jsonBz, &queryResult); err != nil {
 		return ibc.ClientOutputs{}, err

--- a/relayer/hermes/hermes_types.go
+++ b/relayer/hermes/hermes_types.go
@@ -57,10 +57,10 @@ type ChannelEnd struct {
 	Ordering       string           `json:"ordering"`
 	State          string           `json:"state"`
 	Version        string           `json:"version"`
-	Remote         ChannelAndPortId `json:"remote"`
+	Remote         ChannelAndPortID `json:"remote"`
 }
 
-type ChannelAndPortId struct {
+type ChannelAndPortID struct {
 	ChannelID string `json:"channel_id"`
 	PortID    string `json:"port_id"`
 }

--- a/relayer/hyperspace/hyperspace_commander.go
+++ b/relayer/hyperspace/hyperspace_commander.go
@@ -9,12 +9,13 @@ import (
 
 	"github.com/misko9/go-substrate-rpc-client/v4/signature"
 	"github.com/pelletier/go-toml/v2"
-	"github.com/strangelove-ventures/interchaintest/v8/chain/polkadot"
-	"github.com/strangelove-ventures/interchaintest/v8/ibc"
 	"go.uber.org/zap"
 
 	ibcexported "github.com/cosmos/ibc-go/v8/modules/core/03-connection/types"
 	types23 "github.com/cosmos/ibc-go/v8/modules/core/23-commitment/types"
+
+	"github.com/strangelove-ventures/interchaintest/v8/chain/polkadot"
+	"github.com/strangelove-ventures/interchaintest/v8/ibc"
 )
 
 // hyperspaceCommander satisfies relayer.RelayerCommander.

--- a/relayer/hyperspace/hyperspace_commander.go
+++ b/relayer/hyperspace/hyperspace_commander.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"path"
+	"strings"
 
 	"github.com/misko9/go-substrate-rpc-client/v4/signature"
 	"github.com/pelletier/go-toml/v2"
@@ -43,7 +44,11 @@ func (hyperspaceCommander) DockerUser() string {
 }
 
 func (c *hyperspaceCommander) AddChainConfiguration(containerFilePath, homeDir string) []string {
-	fmt.Println("[hyperspace] AddChainConfiguration ", containerFilePath, homeDir)
+	c.log.Info("Hyperspace AddChainConfiguration",
+		zap.String("container_file_path", containerFilePath),
+		zap.String("home_dir", homeDir),
+	)
+
 	// c.chainConfigPaths = append(c.chainConfigPaths, containerFilePath)
 	return []string{
 		"hyperspace",
@@ -57,7 +62,11 @@ func (hyperspaceCommander) AddKey(chainID, keyName, coinType, signingAlgorithm, 
 }
 
 func (c *hyperspaceCommander) CreateChannel(pathName string, opts ibc.CreateChannelOptions, homeDir string) []string {
-	fmt.Println("[hyperspace] CreateChannel", pathName, homeDir)
+	c.log.Info("Hyperspace CreateChannel",
+		zap.String("path_name", pathName),
+		zap.String("home_dir", homeDir),
+	)
+
 	_, ok := c.paths[pathName]
 	if !ok {
 		panic(fmt.Sprintf("path %s not found", pathName))
@@ -81,7 +90,15 @@ func (c *hyperspaceCommander) CreateChannel(pathName string, opts ibc.CreateChan
 }
 
 func (c *hyperspaceCommander) CreateClients(pathName string, opts ibc.CreateClientOptions, homeDir string) []string {
-	fmt.Println("[hyperspace] CreateClients", pathName, opts, homeDir)
+	c.log.Info("Hyperspace CreateClients",
+		zap.String("path_name", pathName),
+		zap.String("home_dir", homeDir),
+		zap.String("trusting_period", opts.TrustingPeriod),
+		zap.Int64("trusting_period_percentage", opts.TrustingPeriodPercentage),
+		zap.String("max_clock_drift", opts.MaxClockDrift),
+		zap.Bool("override", opts.Override),
+	)
+
 	_, ok := c.paths[pathName]
 	if !ok {
 		panic(fmt.Sprintf("path %s not found", pathName))
@@ -108,7 +125,11 @@ func (hyperspaceCommander) CreateClient(srcChainID, dstChainID, pathName string,
 }
 
 func (c *hyperspaceCommander) CreateConnections(pathName, homeDir string) []string {
-	fmt.Println("[hyperspace] CreateConnections", pathName, homeDir)
+	c.log.Info("Hyperspace CreateConnections",
+		zap.String("path_name", pathName),
+		zap.String("home_dir", homeDir),
+	)
+
 	_, ok := c.paths[pathName]
 	if !ok {
 		panic(fmt.Sprintf("path %s not found", pathName))
@@ -160,8 +181,12 @@ func (hyperspaceCommander) UpdatePath(pathName, homeDir string, opts ibc.PathUpd
 
 // Prints chain config which is populated by hyperspace
 // Ideally, there should be a command from hyperspace to get this output.
-func (hyperspaceCommander) GetChannels(chainID, homeDir string) []string {
-	fmt.Println("[hyperspace] Get Channels")
+func (c hyperspaceCommander) GetChannels(chainID, homeDir string) []string {
+	c.log.Info("Hyperspace GetChannels",
+		zap.String("chain_id", chainID),
+		zap.String("home_dir", homeDir),
+	)
+
 	configFilePath := path.Join(homeDir, chainID+".config")
 	return []string{
 		"cat",
@@ -171,8 +196,12 @@ func (hyperspaceCommander) GetChannels(chainID, homeDir string) []string {
 
 // Prints chain config which is populated by hyperspace
 // Ideally, there should be a command from hyperspace to get this output.
-func (hyperspaceCommander) GetConnections(chainID, homeDir string) []string {
-	fmt.Println("[hyperspace] Get Connections")
+func (c hyperspaceCommander) GetConnections(chainID, homeDir string) []string {
+	c.log.Info("Hyperspace GetConnections",
+		zap.String("chain_id", chainID),
+		zap.String("home_dir", homeDir),
+	)
+
 	configFilePath := path.Join(homeDir, chainID+".config")
 	return []string{
 		"cat",
@@ -182,8 +211,12 @@ func (hyperspaceCommander) GetConnections(chainID, homeDir string) []string {
 
 // Prints chain config which is populated by hyperspace
 // Ideally, there should be a command from hyperspace to get this output.
-func (hyperspaceCommander) GetClients(chainID, homeDir string) []string {
-	fmt.Println("[hyperspace] Get Clients")
+func (c hyperspaceCommander) GetClients(chainID, homeDir string) []string {
+	c.log.Info("Hyperspace GetClients",
+		zap.String("chain_id", chainID),
+		zap.String("home_dir", homeDir),
+	)
+
 	configFilePath := path.Join(homeDir, chainID+".config")
 	return []string{
 		"cat",
@@ -204,7 +237,10 @@ func (hyperspaceCommander) RestoreKey(chainID, bech32Prefix, coinType, signingAl
 
 // hyperspace can only start 1 path.
 func (c *hyperspaceCommander) StartRelayer(homeDir string, pathNames ...string) []string {
-	fmt.Println("[hyperspace] StartRelayer", homeDir, pathNames)
+	fields := []zap.Field{zap.String("home_dir", homeDir), zap.String("path_names", strings.Join(pathNames, ","))}
+
+	c.log.Info("HyperSpace StartRelayer", fields...)
+
 	if len(pathNames) != 1 {
 		panic("Hyperspace's StartRelayer list of paths can only have 1 path")
 	}
@@ -230,8 +266,13 @@ func (hyperspaceCommander) UpdateClients(pathName, homeDir string) []string {
 	panic("[UpdateClients] Do not use me")
 }
 
-func (hyperspaceCommander) ConfigContent(ctx context.Context, cfg ibc.ChainConfig, keyName, rpcAddr, grpcAddr string) ([]byte, error) {
-	fmt.Println("[hyperspace] ConfigContent", cfg, keyName, rpcAddr, grpcAddr)
+func (c hyperspaceCommander) ConfigContent(ctx context.Context, cfg ibc.ChainConfig, keyName, rpcAddr, grpcAddr string) ([]byte, error) {
+	c.log.Info("Hyperspace ConfigContent",
+		zap.String("rpc_addr", rpcAddr),
+		zap.String("grpc_addr", grpcAddr),
+		zap.String("key_name", keyName),
+	)
+
 	HyperspaceRelayerChainConfig := ChainConfigToHyperspaceRelayerChainConfig(cfg, keyName, rpcAddr, grpcAddr)
 	bytes, err := toml.Marshal(HyperspaceRelayerChainConfig)
 	if err != nil {
@@ -354,8 +395,9 @@ func (hyperspaceCommander) ParseGetClientsOutput(stdout, stderr string) (ibc.Cli
 	}, nil
 }
 
-func (hyperspaceCommander) Init(homeDir string) []string {
-	fmt.Println("[hyperspace] Init", homeDir)
+func (c hyperspaceCommander) Init(homeDir string) []string {
+	c.log.Info("Hyperspace Init", zap.String("home_dir", homeDir))
+
 	// Return hyperspace help to ensure hyperspace binary is accessible
 	return []string{
 		"hyperspace",

--- a/relayer/hyperspace/hyperspace_config.go
+++ b/relayer/hyperspace/hyperspace_config.go
@@ -5,14 +5,15 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/strangelove-ventures/interchaintest/v8/chain/polkadot"
-	"github.com/strangelove-ventures/interchaintest/v8/ibc"
-	bip32 "github.com/tyler-smith/go-bip32"
-	bip39 "github.com/tyler-smith/go-bip39"
+	"github.com/tyler-smith/go-bip32"
+	"github.com/tyler-smith/go-bip39"
 
 	"github.com/cosmos/cosmos-sdk/crypto/hd"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	"github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/strangelove-ventures/interchaintest/v8/chain/polkadot"
+	"github.com/strangelove-ventures/interchaintest/v8/ibc"
 )
 
 type HyperspaceRelayerCoreConfig struct {
@@ -46,7 +47,7 @@ type HyperspaceRelayerCosmosChainConfig struct {
 	Name             string   `toml:"name"`
 	RPCUrl           string   `toml:"rpc_url"`
 	GRPCUrl          string   `toml:"grpc_url"`
-	WebsocketUrl     string   `toml:"websocket_url"`
+	WebsocketURL     string   `toml:"websocket_url"`
 	ChainID          string   `toml:"chain_id"`
 	AccountPrefix    string   `toml:"account_prefix"`
 	FeeDenom         string   `toml:"fee_denom"`
@@ -101,31 +102,32 @@ func GenKeyEntry(bech32Prefix, coinType, mnemonic string) KeyEntry {
 
 func ChainConfigToHyperspaceRelayerChainConfig(chainConfig ibc.ChainConfig, keyName, rpcAddr, grpcAddr string) interface{} {
 	chainType := chainConfig.Type
-	if chainType == "polkadot" || chainType == "parachain" || chainType == "relaychain" {
-		chainType = "parachain"
+	if chainType == ibc.Polkadot || chainType == ibc.Parachain || chainType == ibc.RelayChain {
+		chainType = ibc.Parachain
 	}
 
-	if chainType == "parachain" {
+	switch {
+	case chainType == ibc.Parachain:
 		addrs := strings.Split(rpcAddr, ",")
-		paraRpcAddr := rpcAddr
-		relayRpcAddr := grpcAddr
+		paraRPCAddr := rpcAddr
+		relayRPCAddr := grpcAddr
 		if len(addrs) > 1 {
-			paraRpcAddr, relayRpcAddr = addrs[0], addrs[1]
+			paraRPCAddr, relayRPCAddr = addrs[0], addrs[1]
 		}
 		return HyperspaceRelayerSubstrateChainConfig{
 			Type:             chainType,
 			Name:             chainConfig.Name,
 			ParaID:           2000,
-			ParachainRPCURL:  strings.Replace(strings.Replace(paraRpcAddr, "http", "ws", 1), "9933", "27451", 1),
-			RelayChainRPCURL: strings.Replace(strings.Replace(relayRpcAddr, "http", "ws", 1), "9933", "27451", 1),
+			ParachainRPCURL:  strings.Replace(strings.Replace(paraRPCAddr, "http", "ws", 1), "9933", "27451", 1),
+			RelayChainRPCURL: strings.Replace(strings.Replace(relayRPCAddr, "http", "ws", 1), "9933", "27451", 1),
 			CommitmentPrefix: "0x6962632f",
 			PrivateKey:       "//Alice",
 			SS58Version:      polkadot.Ss58Format,
 			KeyType:          "sr25519",
 			FinalityProtocol: "Grandpa",
 		}
-	} else if chainType == "cosmos" {
-		wsUrl := strings.Replace(rpcAddr, "http", "ws", 1) + "/websocket"
+	case chainType == ibc.Cosmos:
+		wsURL := strings.Replace(rpcAddr, "http", "ws", 1) + "/websocket"
 		return HyperspaceRelayerCosmosChainConfig{
 			Type:          chainType,
 			Name:          chainConfig.Name,
@@ -138,9 +140,9 @@ func ChainConfigToHyperspaceRelayerChainConfig(chainConfig ibc.ChainConfig, keyN
 			RPCUrl:        rpcAddr,
 			StorePrefix:   "ibc",
 			MaxTxSize:     200000,
-			WebsocketUrl:  wsUrl,
+			WebsocketURL:  wsURL,
 		}
-	} else {
+	default:
 		panic(fmt.Sprintf("unsupported chain type %s", chainType))
 	}
 }

--- a/relayer/hyperspace/hyperspace_relayer.go
+++ b/relayer/hyperspace/hyperspace_relayer.go
@@ -137,11 +137,14 @@ func (r *HyperspaceRelayer) PrintCoreConfig(ctx context.Context, rep ibc.Relayer
 
 	ctx, cancel := context.WithTimeout(ctx, time.Minute)
 	defer cancel()
+
 	res := r.Exec(ctx, rep, cmd, nil)
 	if res.Err != nil {
 		return res.Err
 	}
-	fmt.Println(string(res.Stdout))
+
+	fmt.Println(string(res.Stdout)) //nolint:forbidigo
+
 	return nil
 }
 
@@ -153,11 +156,14 @@ func (r *HyperspaceRelayer) PrintConfigs(ctx context.Context, rep ibc.RelayerExe
 
 	ctx, cancel := context.WithTimeout(ctx, time.Minute)
 	defer cancel()
+
 	res := r.Exec(ctx, rep, cmd, nil)
 	if res.Err != nil {
 		return res.Err
 	}
-	fmt.Println(string(res.Stdout))
+
+	fmt.Println(string(res.Stdout)) //nolint:forbidigo
+
 	return nil
 }
 

--- a/relayer/hyperspace/hyperspace_relayer.go
+++ b/relayer/hyperspace/hyperspace_relayer.go
@@ -9,9 +9,10 @@ import (
 
 	"github.com/docker/docker/client"
 	"github.com/pelletier/go-toml/v2"
+	"go.uber.org/zap"
+
 	"github.com/strangelove-ventures/interchaintest/v8/ibc"
 	"github.com/strangelove-ventures/interchaintest/v8/relayer"
-	"go.uber.org/zap"
 )
 
 var _ ibc.Relayer = &HyperspaceRelayer{}
@@ -121,8 +122,8 @@ func (r *HyperspaceRelayer) SetClientContractHash(ctx context.Context, rep ibc.R
 	if err != nil {
 		return err
 	}
-	switch chainType {
-	case "cosmos":
+
+	if chainType == ibc.Cosmos {
 		config.(*HyperspaceRelayerCosmosChainConfig).WasmChecksum = hash
 	}
 

--- a/relayer/hyperspace/hyperspace_test.go
+++ b/relayer/hyperspace/hyperspace_test.go
@@ -3,8 +3,9 @@ package hyperspace_test
 import (
 	"testing"
 
-	"github.com/strangelove-ventures/interchaintest/v8/relayer/hyperspace"
 	"github.com/stretchr/testify/require"
+
+	"github.com/strangelove-ventures/interchaintest/v8/relayer/hyperspace"
 )
 
 func TestKeys(t *testing.T) {

--- a/relayer/options.go
+++ b/relayer/options.go
@@ -21,7 +21,7 @@ func CustomDockerImage(repository string, version string, uidGid string) Relayer
 	return DockerImage(&ibc.DockerImage{
 		Repository: repository,
 		Version:    version,
-		UidGid:     uidGid,
+		UIDGID:     uidGid,
 	})
 }
 

--- a/relayer/options.go
+++ b/relayer/options.go
@@ -17,11 +17,11 @@ func DockerImage(image *ibc.DockerImage) RelayerOpt {
 // CustomDockerImage overrides the default relayer docker image.
 // uidGid is the uid:gid format owner that should be used within the container.
 // If uidGid is empty, root user will be assumed.
-func CustomDockerImage(repository string, version string, uidGid string) RelayerOpt {
+func CustomDockerImage(repository string, version string, uidGID string) RelayerOpt {
 	return DockerImage(&ibc.DockerImage{
 		Repository: repository,
 		Version:    version,
-		UIDGID:     uidGid,
+		UIDGID:     uidGID,
 	})
 }
 

--- a/relayer/rly/cosmos_relayer.go
+++ b/relayer/rly/cosmos_relayer.go
@@ -8,15 +8,16 @@ import (
 	"strings"
 
 	"github.com/docker/docker/client"
-	"github.com/strangelove-ventures/interchaintest/v8/ibc"
-	"github.com/strangelove-ventures/interchaintest/v8/relayer"
 	"go.uber.org/zap"
 
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
+
+	"github.com/strangelove-ventures/interchaintest/v8/ibc"
+	"github.com/strangelove-ventures/interchaintest/v8/relayer"
 )
 
 const (
-	RlyDefaultUidGid = "100:1000"
+	RlyDefaultUIDGID = "100:1000"
 )
 
 // CosmosRelayer is the ibc.Relayer implementation for github.com/cosmos/relayer.
@@ -111,7 +112,7 @@ func (commander) Name() string {
 }
 
 func (commander) DockerUser() string {
-	return RlyDefaultUidGid // docker run -it --rm --entrypoint echo ghcr.io/cosmos/relayer "$(id -u):$(id -g)"
+	return RlyDefaultUIDGID // docker run -it --rm --entrypoint echo ghcr.io/cosmos/relayer "$(id -u):$(id -g)"
 }
 
 func (commander) AddChainConfiguration(containerFilePath, homeDir string) []string {

--- a/relayerfactory.go
+++ b/relayerfactory.go
@@ -4,12 +4,13 @@ import (
 	"fmt"
 
 	"github.com/docker/docker/client"
+	"go.uber.org/zap"
+
 	"github.com/strangelove-ventures/interchaintest/v8/ibc"
 	"github.com/strangelove-ventures/interchaintest/v8/relayer"
 	"github.com/strangelove-ventures/interchaintest/v8/relayer/hermes"
 	"github.com/strangelove-ventures/interchaintest/v8/relayer/hyperspace"
 	"github.com/strangelove-ventures/interchaintest/v8/relayer/rly"
-	"go.uber.org/zap"
 )
 
 type TestName interface {
@@ -97,6 +98,11 @@ func (f *builtinRelayerFactory) Name() string {
 			return "hermes@" + f.version
 		}
 		return "hermes@" + hermes.DefaultContainerVersion
+	case ibc.Hyperspace:
+		if f.version == "" {
+			return "hyperspace@" + f.version
+		}
+		return "hyperspace@" + hyperspace.HyperspaceDefaultContainerVersion
 	default:
 		panic(fmt.Errorf("RelayerImplementation %v unknown", f.impl))
 	}
@@ -111,6 +117,8 @@ func (f builtinRelayerFactory) Capabilities() map[relayer.Capability]bool {
 	case ibc.Hermes:
 		// TODO: specify capability for hermes.
 		return rly.Capabilities()
+	case ibc.Hyperspace:
+		panic("capabilities are not defined for Hyperspace relayer.")
 	default:
 		panic(fmt.Errorf("RelayerImplementation %v unknown", f.impl))
 	}

--- a/tempdir_test.go
+++ b/tempdir_test.go
@@ -6,9 +6,10 @@ import (
 	"strings"
 	"testing"
 
-	interchaintest "github.com/strangelove-ventures/interchaintest/v8"
-	"github.com/strangelove-ventures/interchaintest/v8/mocktesting"
 	"github.com/stretchr/testify/require"
+
+	"github.com/strangelove-ventures/interchaintest/v8"
+	"github.com/strangelove-ventures/interchaintest/v8/mocktesting"
 )
 
 func TestTempDir_Cleanup(t *testing.T) {
@@ -59,7 +60,6 @@ func TestTempDir_Cleanup(t *testing.T) {
 			"test passed": false,
 			"test failed": true,
 		} {
-			failed := failed
 			t.Run(name, func(t *testing.T) {
 				mt := mocktesting.NewT("t")
 

--- a/test_setup.go
+++ b/test_setup.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/docker/docker/client"
+
 	"github.com/strangelove-ventures/interchaintest/v8/dockerutil"
 	"github.com/strangelove-ventures/interchaintest/v8/ibc"
 	"github.com/strangelove-ventures/interchaintest/v8/testreporter"
@@ -52,6 +53,8 @@ func StartChainPair(
 	f RelayerFactory,
 	preRelayerStartFuncs []func([]ibc.ChannelOutput),
 ) (ibc.Relayer, error) {
+	t.Helper()
+
 	relayerImpl := f.Build(t, cli, networkID)
 
 	ic := NewInterchain().
@@ -97,6 +100,8 @@ func StopStartRelayerWithPreStartFuncs(
 	preRelayerStartFuncs []func([]ibc.ChannelOutput),
 	pathNames ...string,
 ) ([]ibc.ChannelOutput, error) {
+	t.Helper()
+
 	if err := relayerImpl.StopRelayer(ctx, eRep); err != nil {
 		t.Logf("error stopping relayer: %v", err)
 	}
@@ -113,7 +118,6 @@ func StopStartRelayerWithPreStartFuncs(
 		if preRelayerStart == nil {
 			continue
 		}
-		preRelayerStart := preRelayerStart
 		wg.Add(1)
 		go func() {
 			preRelayerStart(channels)

--- a/test_user.go
+++ b/test_user.go
@@ -5,13 +5,14 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/strangelove-ventures/interchaintest/v8/dockerutil"
-	"github.com/strangelove-ventures/interchaintest/v8/ibc"
-	"github.com/strangelove-ventures/interchaintest/v8/testutil"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 
 	"cosmossdk.io/math"
+
+	"github.com/strangelove-ventures/interchaintest/v8/dockerutil"
+	"github.com/strangelove-ventures/interchaintest/v8/ibc"
+	"github.com/strangelove-ventures/interchaintest/v8/testutil"
 )
 
 // GetAndFundTestUserWithMnemonic restores a user using the given mnemonic
@@ -58,11 +59,11 @@ func GetAndFundTestUsers(
 	amount math.Int,
 	chains ...ibc.Chain,
 ) []ibc.Wallet {
+	t.Helper()
+
 	users := make([]ibc.Wallet, len(chains))
 	var eg errgroup.Group
 	for i, chain := range chains {
-		i := i
-		chain := chain
 		eg.Go(func() error {
 			user, err := GetAndFundTestUserWithMnemonic(ctx, keyNamePrefix, "", amount, chain)
 			if err != nil {

--- a/testreporter/messages_test.go
+++ b/testreporter/messages_test.go
@@ -6,8 +6,9 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/strangelove-ventures/interchaintest/v8/testreporter"
 	"github.com/stretchr/testify/require"
+
+	"github.com/strangelove-ventures/interchaintest/v8/testreporter"
 )
 
 func TestWrappedMessage_RoundTrip(t *testing.T) {

--- a/testreporter/reporter_test.go
+++ b/testreporter/reporter_test.go
@@ -76,11 +76,11 @@ func TestReporter_TrackPassingSingleTest(t *testing.T) {
 	requireTimeInRange(t, beginSuiteMsg.StartedAt, beforeStartSuite, afterStartSuite)
 
 	beginTestMsg := msgs[1].(testreporter.BeginTestMessage)
-	require.Equal(t, beginTestMsg.Name, "my_test")
+	require.Equal(t, "my_test", beginTestMsg.Name)
 	requireTimeInRange(t, beginTestMsg.StartedAt, beforeStartTest, afterStartTest)
 
 	finishTestMsg := msgs[2].(testreporter.FinishTestMessage)
-	require.Equal(t, finishTestMsg.Name, "my_test")
+	require.Equal(t, "my_test", finishTestMsg.Name)
 	require.False(t, finishTestMsg.Failed)
 	require.False(t, finishTestMsg.Skipped)
 	requireTimeInRange(t, finishTestMsg.FinishedAt, beforeFinishTest, afterFinishTest)
@@ -116,13 +116,13 @@ func TestReporter_TrackFailingSingleTest(t *testing.T) {
 	require.Len(t, msgs, 5)
 
 	testErrorMsg := msgs[2].(testreporter.TestErrorMessage)
-	require.Equal(t, testErrorMsg.Name, "my_test")
+	require.Equal(t, "my_test", testErrorMsg.Name)
 	// require.Fail adds some detail to the error message that complicates a plain string equality check.
 	require.Contains(t, testErrorMsg.Message, "forced failure")
 	requireTimeInRange(t, testErrorMsg.When, beforeFailure, afterFailure)
 
 	finishTestMsg := msgs[3].(testreporter.FinishTestMessage)
-	require.Equal(t, finishTestMsg.Name, "my_test")
+	require.Equal(t, "my_test", finishTestMsg.Name)
 	require.True(t, finishTestMsg.Failed)
 	require.False(t, finishTestMsg.Skipped)
 }

--- a/testreporter/reporter_test.go
+++ b/testreporter/reporter_test.go
@@ -8,9 +8,10 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
+
 	"github.com/strangelove-ventures/interchaintest/v8/mocktesting"
 	"github.com/strangelove-ventures/interchaintest/v8/testreporter"
-	"github.com/stretchr/testify/require"
 )
 
 // nopCloser wraps an io.Writer to provide a Close method that always returns nil.
@@ -151,18 +152,18 @@ func TestReporter_TrackParallel(t *testing.T) {
 	require.Len(t, msgs, 6)
 
 	beginTestMsg := msgs[1].(testreporter.BeginTestMessage)
-	require.Equal(t, beginTestMsg.Name, "my_test")
+	require.Equal(t, "my_test", beginTestMsg.Name)
 
 	pauseTestMsg := msgs[2].(testreporter.PauseTestMessage)
-	require.Equal(t, pauseTestMsg.Name, "my_test")
+	require.Equal(t, "my_test", pauseTestMsg.Name)
 	requireTimeInRange(t, pauseTestMsg.When, beforeParallel, beforeParallel.Add(parallelDelay))
 
 	continueTestMsg := msgs[3].(testreporter.ContinueTestMessage)
-	require.Equal(t, continueTestMsg.Name, "my_test")
+	require.Equal(t, "my_test", continueTestMsg.Name)
 	requireTimeInRange(t, continueTestMsg.When, afterParallel.Add(-parallelDelay), afterParallel)
 
 	finishTestMsg := msgs[4].(testreporter.FinishTestMessage)
-	require.Equal(t, finishTestMsg.Name, "my_test")
+	require.Equal(t, "my_test", finishTestMsg.Name)
 }
 
 // Check that TrackSkip skips the underlying test.
@@ -189,16 +190,16 @@ func TestReporter_TrackSkip(t *testing.T) {
 	require.Len(t, msgs, 5)
 
 	testSkipMsg := msgs[2].(testreporter.TestSkipMessage)
-	require.Equal(t, testSkipMsg.Name, "my_test")
-	require.Equal(t, testSkipMsg.Message, "skipping for reasons")
+	require.Equal(t, "my_test", testSkipMsg.Name)
+	require.Equal(t, "skipping for reasons", testSkipMsg.Message)
 	requireTimeInRange(t, testSkipMsg.When, beforeSkip, afterSkip)
 
 	finishTestMsg := msgs[3].(testreporter.FinishTestMessage)
-	require.Equal(t, finishTestMsg.Name, "my_test")
+	require.Equal(t, "my_test", finishTestMsg.Name)
 	require.False(t, finishTestMsg.Failed)
 	require.True(t, finishTestMsg.Skipped)
 
-	require.Equal(t, mt.Skips, []string{"skipping for reasons"})
+	require.Equal(t, []string{"skipping for reasons"}, mt.Skips)
 	require.True(t, mt.Skipped())
 }
 
@@ -214,7 +215,7 @@ func TestReporter_Errorf(t *testing.T) {
 	mt.RunCleanups()
 	require.NoError(t, r.Close())
 
-	require.Equal(t, mt.Errors, []string{"failed? true"})
+	require.Equal(t, []string{"failed? true"}, mt.Errors)
 }
 
 func TestReporter_RelayerExec(t *testing.T) {

--- a/testutil/poll_for_state.go
+++ b/testutil/poll_for_state.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/davecgh/go-spew/spew"
+
 	"github.com/strangelove-ventures/interchaintest/v8/ibc"
 )
 

--- a/testutil/poll_for_state_test.go
+++ b/testutil/poll_for_state_test.go
@@ -6,8 +6,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/strangelove-ventures/interchaintest/v8/ibc"
 	"github.com/stretchr/testify/require"
+
+	"github.com/strangelove-ventures/interchaintest/v8/ibc"
 )
 
 type mockChain struct {

--- a/testutil/toml.go
+++ b/testutil/toml.go
@@ -8,8 +8,9 @@ import (
 
 	"github.com/BurntSushi/toml"
 	"github.com/docker/docker/client"
-	"github.com/strangelove-ventures/interchaintest/v8/dockerutil"
 	"go.uber.org/zap"
+
+	"github.com/strangelove-ventures/interchaintest/v8/dockerutil"
 )
 
 // Toml is used for holding the decoded state of a toml config file.

--- a/testutil/wait.go
+++ b/testutil/wait.go
@@ -54,8 +54,6 @@ func NodesInSync(ctx context.Context, chain ChainHeighter, nodes []ChainHeighter
 		return err
 	})
 	for i, n := range nodes {
-		i := i
-		n := n
 		eg.Go(func() (err error) {
 			nodeHeights[i], err = n.Height(egCtx)
 			return err
@@ -66,7 +64,7 @@ func NodesInSync(ctx context.Context, chain ChainHeighter, nodes []ChainHeighter
 	}
 	for _, h := range nodeHeights {
 		if h < chainHeight {
-			return fmt.Errorf("Node is not yet in sync: %d < %d", h, chainHeight)
+			return fmt.Errorf("node is not yet in sync: %d < %d", h, chainHeight)
 		}
 	}
 	// all nodes >= chainHeight

--- a/testutil/wait_test.go
+++ b/testutil/wait_test.go
@@ -40,6 +40,8 @@ func TestWaitForBlocks(t *testing.T) {
 	t.Parallel()
 
 	t.Run("happy path", func(t *testing.T) {
+		t.Parallel()
+
 		var (
 			startHeight1 int64 = 10
 			chain1             = mockChainHeighter{CurHeight: startHeight1}
@@ -57,12 +59,16 @@ func TestWaitForBlocks(t *testing.T) {
 	})
 
 	t.Run("no chains", func(t *testing.T) {
+		t.Parallel()
+
 		require.Panics(t, func() {
 			_ = WaitForBlocks(context.Background(), 100)
 		})
 	})
 
 	t.Run("error", func(t *testing.T) {
+		t.Parallel()
+
 		errMock := mockChainHeighter{Err: errors.New("boom")}
 		const delta = 1
 		err := WaitForBlocks(context.Background(), delta, &mockChainHeighter{}, &errMock)
@@ -72,6 +78,8 @@ func TestWaitForBlocks(t *testing.T) {
 	})
 
 	t.Run("0 height", func(t *testing.T) {
+		t.Parallel()
+
 		const delta = 1
 		// Set height to -1 because the mock chain auto-increments the height resulting in starting height of 0.
 		chain := &mockChainHeighter{CurHeight: -1}
@@ -121,6 +129,8 @@ func TestWaitForInSync(t *testing.T) {
 	t.Parallel()
 
 	t.Run("happy path", func(t *testing.T) {
+		t.Parallel()
+
 		var (
 			startHeightChain int64 = 10
 			chain                  = mockChainHeighterFixed{CurHeight: startHeightChain}
@@ -138,6 +148,8 @@ func TestWaitForInSync(t *testing.T) {
 	})
 
 	t.Run("no nodes", func(t *testing.T) {
+		t.Parallel()
+
 		var (
 			startHeightChain int64 = 10
 			chain                  = mockChainHeighterFixed{CurHeight: startHeightChain}
@@ -148,6 +160,8 @@ func TestWaitForInSync(t *testing.T) {
 	})
 
 	t.Run("timeout", func(t *testing.T) {
+		t.Parallel()
+
 		var (
 			startHeightChain int64 = 10
 			chain                  = mockChainHeighterFixed{CurHeight: startHeightChain}


### PR DESCRIPTION
This PR updates the CI jobs for linting and running tests to use current deps. It also fixes all the linter warnings from `golangci-lint`.