### PR TITLE
fix(thorchain/utxo): fix race conditions

### DIFF
--- a/chain/thorchain/sidecar.go
+++ b/chain/thorchain/sidecar.go
@@ -70,6 +70,10 @@ func NewSidecar(
 		homeDir = "/home/sidecar"
 	}
 
+	// Give each sidecard their own env copy for runtime changes
+	envCopy := make([]string, len(env))
+	copy(envCopy, env)
+
 	s := &SidecarProcess{
 		log:              log,
 		Index:            index,
@@ -84,7 +88,7 @@ func NewSidecar(
 		homeDir:          homeDir,
 		ports:            processPorts,
 		startCmd:         startCmd,
-		env:              env,
+		env:              envCopy,
 	}
 	s.containerLifecycle = dockerutil.NewContainerLifecycle(log, dockerClient, s.Name())
 

--- a/chain/utxo/cli.go
+++ b/chain/utxo/cli.go
@@ -109,10 +109,12 @@ func (c *UtxoChain) CreateWallet(ctx context.Context, keyName string) error {
 			return err
 		}
 
+		c.MapAccess.Lock()
 		c.KeyNameToWalletMap[keyName] = &NodeWallet{
 			keyName:   keyName,
 			loadCount: 1,
 		}
+		c.MapAccess.Unlock()
 	}
 
 	return c.UnloadWallet(ctx, keyName)
@@ -151,12 +153,14 @@ func (c *UtxoChain) GetNewAddress(ctx context.Context, keyName string, mweb bool
 		addr = splitAddr[1]
 	}
 
+	c.MapAccess.Lock()
 	wallet.address = addr
 	c.AddrToKeyNameMap[addr] = keyName
 
 	if c.WalletVersion >= noDefaultKeyWalletVersion {
 		wallet.ready = true
 	}
+	c.MapAccess.Unlock()
 
 	if err := c.UnloadWallet(ctx, keyName); err != nil {
 		return "", err

--- a/chain/utxo/utxo_chain.go
+++ b/chain/utxo/utxo_chain.go
@@ -39,9 +39,9 @@ var natPorts = nat.PortMap{
 }
 
 type UtxoChain struct {
-	testName     string
-	cfg          ibc.ChainConfig
-	cancel       context.CancelFunc
+	testName string
+	cfg      ibc.ChainConfig
+	cancel   context.CancelFunc
 
 	log *zap.Logger
 
@@ -285,7 +285,7 @@ func (c *UtxoChain) Start(testName string, ctx context.Context, additionalGenesi
 	if err := c.SetAccount(ctx, addr, faucetKeyName); err != nil {
 		return err
 	}
-	
+
 	go func() {
 		// Don't use ctx from Start(), it gets cancelled soon after returning.
 		goRoutineCtx := context.Background()
@@ -299,7 +299,7 @@ func (c *UtxoChain) Start(testName string, ctx context.Context, additionalGenesi
 
 		c.MapAccess.Lock()
 		faucetWallet, found := c.KeyNameToWalletMap[faucetKeyName]
-		if !found  || !faucetWallet.ready {
+		if !found || !faucetWallet.ready {
 			c.logger().Error("faucet wallet not found or not ready")
 			c.MapAccess.Unlock()
 			return

--- a/chain/utxo/wallet.go
+++ b/chain/utxo/wallet.go
@@ -50,6 +50,8 @@ type NodeWallet struct {
 }
 
 func (c *UtxoChain) getWalletForNewAddress(keyName string) (*NodeWallet, error) {
+	c.MapAccess.Lock()
+	defer c.MapAccess.Unlock()
 	wallet, found := c.KeyNameToWalletMap[keyName]
 	if c.WalletVersion >= noDefaultKeyWalletVersion {
 		if !found {
@@ -75,6 +77,8 @@ func (c *UtxoChain) getWalletForNewAddress(keyName string) (*NodeWallet, error) 
 }
 
 func (c *UtxoChain) getWalletForSetAccount(keyName string, addr string) (*NodeWallet, error) {
+	c.MapAccess.Lock()
+	defer c.MapAccess.Unlock()
 	wallet, found := c.KeyNameToWalletMap[keyName]
 	if !found {
 		return nil, fmt.Errorf("Wallet keyname (%s) not found, get new address not called", keyName)
@@ -100,6 +104,8 @@ func (c *UtxoChain) getWalletForUse(keyName string) (*NodeWallet, error) {
 }
 
 func (c *UtxoChain) getWallet(keyName string) (*NodeWallet, error) {
+	c.MapAccess.Lock()
+	defer c.MapAccess.Unlock()
 	wallet, found := c.KeyNameToWalletMap[keyName]
 	if !found {
 		return nil, fmt.Errorf("Wallet keyname (%s) not found", keyName)

--- a/examples/thorchain/setup_test.go
+++ b/examples/thorchain/setup_test.go
@@ -94,6 +94,12 @@ func StartExoChains(t *testing.T, ctx context.Context, client *client.Client, ne
 	}))
 	t.Cleanup(func() {
 		_ = ic.Close()
+		for _, chain := range chains {
+			utxoChain, ok := chain.(*utxo.UtxoChain)
+			if ok {
+				utxoChain.Stop()
+			}
+		}
 	})
 
 	return exoChains

--- a/examples/utxo/start_test.go
+++ b/examples/utxo/start_test.go
@@ -56,6 +56,12 @@ func TestUtxo(t *testing.T) {
 	}))
 	t.Cleanup(func() {
 		_ = ic.Close()
+		for _, chain := range chains {
+			utxoChain, ok := chain.(*utxo.UtxoChain)
+			if ok {
+				utxoChain.Stop()
+			}
+		}
 	})
 
 	// Create and fund a user using GetAndFundTestUsers

--- a/local-interchain/chains/state/README.md
+++ b/local-interchain/chains/state/README.md
@@ -1,3 +1,3 @@
 
 ## avs-and-eigenlayer-deployed-anvil-state.json
-- <https://github.com/mangata-finance/eigen-layer-monorepo/blob/main/tests/integration/avs-and-eigenlayer-deployed-anvil-state.json>
+- <https://github.com/gasp-xyz/gasp-monorepo/blob/v0.3.0/tests/integration/avs-and-eigenlayer-deployed-anvil-state.json>


### PR DESCRIPTION
Fixes a few race conditions on thorchain and utxo chains.

Thorchain: sidecar processes now get their own copy of env list so they can make runtime changes in parallel.

Utxo: reading and writing KeynameToWalletMap and AddrToKeynameMap is now protected by a mutex. The block producing go routine is now ran after faucet creation and a utxo stop method is added for the test framework to cancel its context.

Thorchain's setup_test.go is updated to call the utxo chain's stop method. This will also be reflected in the thornode v50 branch.