### PR TITLE
feat(thorchain): add support for adding/duplicating validators

### DIFF
--- a/chain/ethereum/foundry/forge.go
+++ b/chain/ethereum/foundry/forge.go
@@ -24,7 +24,9 @@ type ForgeScriptOpts struct {
 
 // Add private-key or keystore to cmd.
 func (c *AnvilChain) AddKey(cmd []string, keyName string) []string {
+	c.MapAccess.Lock()
 	account, ok := c.keystoreMap[keyName]
+	c.MapAccess.Unlock()
 	if !ok {
 		panic(fmt.Sprintf("Keyname (%s) not found", keyName))
 	}
@@ -77,7 +79,9 @@ func WriteConfigFile(configFile string, localContractRootDir string, solidityCon
 // Run "forge script"
 // see: https://book.getfoundry.sh/reference/forge/forge-script
 func (c *AnvilChain) ForgeScript(ctx context.Context, keyName string, opts ForgeScriptOpts) (stdout, stderr []byte, err error) {
+	c.MapAccess.Lock()
 	account, ok := c.keystoreMap[keyName]
+	c.MapAccess.Unlock()
 	if !ok {
 		return nil, nil, fmt.Errorf("keyname (%s) not found", keyName)
 	}

--- a/chain/thorchain/api_query.go
+++ b/chain/thorchain/api_query.go
@@ -19,6 +19,28 @@ import (
 	"github.com/strangelove-ventures/interchaintest/v8/chain/thorchain/common"
 )
 
+// Generic query for routes not yet supported here
+func (c *Thorchain) ApiQuery(ctx context.Context, path string, args ...string) (any, error) {
+	url := fmt.Sprintf("%s/%s", c.GetAPIAddress(), path)
+	var res any
+	err := get(ctx, url, &res)
+	return res, err
+}
+
+func (c *Thorchain) ApiGetNode(ctx context.Context, addr string) (OpenapiNode, error) {
+	url := fmt.Sprintf("%s/thorchain/node/%s", c.GetAPIAddress(), addr)
+	var node OpenapiNode
+	err := get(ctx, url, &node)
+	return node, err
+}
+
+func (c *Thorchain) ApiGetNodes(ctx context.Context) ([]OpenapiNode, error) {
+	url := fmt.Sprintf("%s/thorchain/nodes", c.GetAPIAddress())
+	var nodes []OpenapiNode
+	err := get(ctx, url, &nodes)
+	return nodes, err
+}
+
 func (c *Thorchain) APIGetBalances(ctx context.Context, addr string) (common.Coins, error) {
 	url := fmt.Sprintf("%s/cosmos/bank/v1beta1/balances/%s", c.GetAPIAddress(), addr)
 	var balances struct {

--- a/chain/thorchain/api_query.go
+++ b/chain/thorchain/api_query.go
@@ -20,21 +20,21 @@ import (
 )
 
 // Generic query for routes not yet supported here.
-func (c *Thorchain) ApiQuery(ctx context.Context, path string, args ...string) (any, error) {
+func (c *Thorchain) APIQuery(ctx context.Context, path string, args ...string) (any, error) {
 	url := fmt.Sprintf("%s/%s", c.GetAPIAddress(), path)
 	var res any
 	err := get(ctx, url, &res)
 	return res, err
 }
 
-func (c *Thorchain) ApiGetNode(ctx context.Context, addr string) (OpenapiNode, error) {
+func (c *Thorchain) APIGetNode(ctx context.Context, addr string) (OpenapiNode, error) {
 	url := fmt.Sprintf("%s/thorchain/node/%s", c.GetAPIAddress(), addr)
 	var node OpenapiNode
 	err := get(ctx, url, &node)
 	return node, err
 }
 
-func (c *Thorchain) ApiGetNodes(ctx context.Context) ([]OpenapiNode, error) {
+func (c *Thorchain) APIGetNodes(ctx context.Context) ([]OpenapiNode, error) {
 	url := fmt.Sprintf("%s/thorchain/nodes", c.GetAPIAddress())
 	var nodes []OpenapiNode
 	err := get(ctx, url, &nodes)

--- a/chain/thorchain/api_query.go
+++ b/chain/thorchain/api_query.go
@@ -19,7 +19,7 @@ import (
 	"github.com/strangelove-ventures/interchaintest/v8/chain/thorchain/common"
 )
 
-// Generic query for routes not yet supported here
+// Generic query for routes not yet supported here.
 func (c *Thorchain) ApiQuery(ctx context.Context, path string, args ...string) (any, error) {
 	url := fmt.Sprintf("%s/%s", c.GetAPIAddress(), path)
 	var res any

--- a/chain/thorchain/module_thorchain.go
+++ b/chain/thorchain/module_thorchain.go
@@ -51,7 +51,7 @@ func (tn *ChainNode) Bond(ctx context.Context, amount math.Int) error {
 	return err
 }
 
-// Sets validator node keys, must be called by validator
+// Sets validator node keys, must be called by validator.
 func (tn *ChainNode) SetNodeKeys(ctx context.Context) error {
 	_, err := tn.ExecTx(ctx,
 		valKey, "thorchain", "set-node-keys",
@@ -60,7 +60,7 @@ func (tn *ChainNode) SetNodeKeys(ctx context.Context) error {
 	return err
 }
 
-// Sets validator ip address, must be called by validator
+// Sets validator ip address, must be called by validator.
 func (tn *ChainNode) SetIpAddress(ctx context.Context) error {
 	_, err := tn.ExecTx(ctx,
 		valKey, "thorchain", "set-ip-address", tn.NodeAccount.IPAddress,
@@ -68,7 +68,7 @@ func (tn *ChainNode) SetIpAddress(ctx context.Context) error {
 	return err
 }
 
-// Sets validator's binary version
+// Sets validator's binary version.
 func (tn *ChainNode) SetVersion(ctx context.Context) error {
 	_, err := tn.ExecTx(ctx,
 		valKey, "thorchain", "set-version",

--- a/chain/thorchain/module_thorchain.go
+++ b/chain/thorchain/module_thorchain.go
@@ -61,7 +61,7 @@ func (tn *ChainNode) SetNodeKeys(ctx context.Context) error {
 }
 
 // Sets validator ip address, must be called by validator.
-func (tn *ChainNode) SetIpAddress(ctx context.Context) error {
+func (tn *ChainNode) SetIPAddress(ctx context.Context) error {
 	_, err := tn.ExecTx(ctx,
 		valKey, "thorchain", "set-ip-address", tn.NodeAccount.IPAddress,
 	)

--- a/chain/thorchain/module_thorchain.go
+++ b/chain/thorchain/module_thorchain.go
@@ -41,3 +41,37 @@ func (c *Thorchain) SetMimir(ctx context.Context, keyName string, key string, va
 	)
 	return err
 }
+
+func (tn *ChainNode) Bond(ctx context.Context, amount math.Int) error {
+	_, err := tn.ExecTx(ctx,
+		valKey, "thorchain", "deposit",
+		amount.String(), tn.Chain.Config().Denom,
+		fmt.Sprintf("bond:%s", tn.NodeAccount.NodeAddress),
+	)
+	return err
+}
+
+// Sets validator node keys, must be called by validator
+func (tn *ChainNode) SetNodeKeys(ctx context.Context) error {
+	_, err := tn.ExecTx(ctx,
+		valKey, "thorchain", "set-node-keys",
+		tn.NodeAccount.PubKeySet.Secp256k1, tn.NodeAccount.PubKeySet.Ed25519, tn.NodeAccount.ValidatorConsPubKey,
+	)
+	return err
+}
+
+// Sets validator ip address, must be called by validator
+func (tn *ChainNode) SetIpAddress(ctx context.Context) error {
+	_, err := tn.ExecTx(ctx,
+		valKey, "thorchain", "set-ip-address", tn.NodeAccount.IPAddress,
+	)
+	return err
+}
+
+// Sets validator's binary version
+func (tn *ChainNode) SetVersion(ctx context.Context) error {
+	_, err := tn.ExecTx(ctx,
+		valKey, "thorchain", "set-version",
+	)
+	return err
+}

--- a/chain/thorchain/thorchain.go
+++ b/chain/thorchain/thorchain.go
@@ -137,6 +137,178 @@ func (c *Thorchain) Nodes() ChainNodes {
 	return append(c.Validators, c.FullNodes...)
 }
 
+// AddValidators adds new validators to the network, peering with the existing nodes.
+func (c *Thorchain) AddValidators(ctx context.Context, configFileOverrides map[string]any, inc int) error {
+	// Get peer string for existing nodes
+	peers := c.Nodes().PeerString(ctx)
+
+	// Get genesis.json
+	genbz, err := c.Validators[0].GenesisFileContent(ctx)
+	if err != nil {
+		return err
+	}
+
+	prevCount := c.NumValidators
+	c.NumValidators += inc
+	if err := c.initializeChainNodes(ctx, c.testName, c.getFullNode().DockerClient, c.getFullNode().NetworkID); err != nil {
+		return err
+	}
+
+	// Create full node, validator keys, and start up
+	var eg errgroup.Group
+	for i := prevCount; i < c.NumValidators; i++ {
+		eg.Go(func() error {
+			val := c.Validators[i]
+			if err := val.InitFullNodeFiles(ctx); err != nil {
+				return err
+			}
+			if err := val.SetPeers(ctx, peers); err != nil {
+				return err
+			}
+			if err := val.OverwriteGenesisFile(ctx, genbz); err != nil {
+				return err
+			}
+			for configFile, modifiedConfig := range configFileOverrides {
+				modifiedToml, ok := modifiedConfig.(testutil.Toml)
+				if !ok {
+					return fmt.Errorf("provided toml override for file %s is of type (%T). Expected (DecodedToml)", configFile, modifiedConfig)
+				}
+				if err := testutil.ModifyTomlConfigFile(
+					ctx,
+					val.logger(),
+					val.DockerClient,
+					val.TestName,
+					val.VolumeName,
+					configFile,
+					modifiedToml,
+				); err != nil {
+					return err
+				}
+			}
+			if err := val.CreateKey(ctx, valKey); err != nil {
+				return fmt.Errorf("failed to create key: %w", err)
+			}
+			if err := val.GetNodeAccount(ctx); err != nil {
+				return fmt.Errorf("failed to get node account info: %w", err)
+			}
+			if err := val.CreateNodeContainer(ctx); err != nil {
+				return err
+			}
+			return val.StartContainer(ctx)
+		})
+	}
+
+	if err := eg.Wait(); err != nil {
+		return err
+	}
+
+	// Fund validator address and register for next churn
+	decimalPow := int64(math.Pow10(int(*c.cfg.CoinDecimals)))
+	for i := prevCount; i < c.NumValidators; i++ {
+		// Fund validator from faucet
+		if err := c.SendFunds(ctx, "faucet", ibc.WalletAmount{
+			Address: c.Validators[i].NodeAccount.NodeAddress,
+			Amount: sdkmath.NewInt(100).MulRaw(decimalPow), // 100e8 rune
+			Denom: c.cfg.Denom,
+		}); err != nil {
+			return fmt.Errorf("failed to fund val %d, %w", i, err)
+		}
+
+		eg.Go(func() error {
+			val := c.Validators[i]
+			// thornode tx thorchain deposit 1e8 RUNE "bond:$NODE_ADDRESS"
+			// Bond 2 rune since the next 3 txs will deduct .02 rune/tx and we need > 1 rune bonded
+			if err := val.Bond(ctx, sdkmath.NewInt(2).MulRaw(decimalPow)); err != nil {
+				return fmt.Errorf("failed to set val %d node keys, %w", i, err)
+			}
+			// thornode tx thorchain set-node-keys "$NODE_PUB_KEY" "$NODE_PUB_KEY_ED25519" "$VALIDATOR"
+			if err := val.SetNodeKeys(ctx); err != nil {
+				return fmt.Errorf("failed to set val %d node keys, %w", i, err)
+			}
+			// thornode tx thorchain set-ip-address "192.168.0.10"
+			if err := val.SetIpAddress(ctx); err != nil {
+				return fmt.Errorf("failed to set val %d ip address, %w", i, err)
+			}
+			// thornode tx thorchain set-version
+			if err := val.SetVersion(ctx); err != nil {
+				return fmt.Errorf("failed to set val %d version, %w", i, err)
+			}
+			return nil
+		})
+	}
+
+	if err := eg.Wait(); err != nil {
+		return err
+	}
+
+	// start sidecar/bifrost
+	return c.StartAllValSidecars(ctx)
+}
+
+// AddDuplicateValidator spins up a duplicate validator node to test double signing
+func (c *Thorchain) AddDuplicateValidator(ctx context.Context, configFileOverrides map[string]any, originalVal *ChainNode) (*ChainNode, error) {
+	// Get peer string for existing nodes
+	peers := c.Nodes().PeerString(ctx)
+
+	// Get genesis.json
+	genbz, err := c.Validators[0].GenesisFileContent(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	c.NumValidators += 1
+	if err := c.initializeChainNodes(ctx, c.testName, c.getFullNode().DockerClient, c.getFullNode().NetworkID); err != nil {
+		return nil, err
+	}
+
+	// Create full node, validator keys, and start up
+	val := c.Validators[c.NumValidators-1]
+	if err := val.InitFullNodeFiles(ctx); err != nil {
+		return nil, err
+	}
+	if err := val.SetPeers(ctx, peers); err != nil {
+		return nil, err
+	}
+	if err := val.OverwriteGenesisFile(ctx, genbz); err != nil {
+		return nil, err
+	}
+	for configFile, modifiedConfig := range configFileOverrides {
+		modifiedToml, ok := modifiedConfig.(testutil.Toml)
+		if !ok {
+			return nil, fmt.Errorf("provided toml override for file %s is of type (%T). Expected (DecodedToml)", configFile, modifiedConfig)
+		}
+		if err := testutil.ModifyTomlConfigFile(
+			ctx,
+			val.logger(),
+			val.DockerClient,
+			val.TestName,
+			val.VolumeName,
+			configFile,
+			modifiedToml,
+		); err != nil {
+			return nil, err
+		}
+	}
+	privValFile, err := originalVal.PrivValFileContent(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get priv_validator_key.json, %w", err)
+	}
+	if err := val.OverwritePrivValFile(ctx, privValFile); err != nil {
+		return nil, fmt.Errorf("failed to overwrite priv_validator_key.json, %w", err)
+	}
+	if err := val.RecoverKey(ctx, valKey, originalVal.ValidatorMnemonic); err != nil {
+		return nil, fmt.Errorf("failed to create key: %w", err)
+	}
+	val.ValidatorMnemonic = originalVal.ValidatorMnemonic
+	if err := val.GetNodeAccount(ctx); err != nil {
+		return nil, fmt.Errorf("failed to get node account info: %w", err)
+	}
+	if err := val.CreateNodeContainer(ctx); err != nil {
+		return nil, err
+	}
+	return val, val.StartContainer(ctx)
+}
+
 // AddFullNodes adds new fullnodes to the network, peering with the existing nodes.
 func (c *Thorchain) AddFullNodes(ctx context.Context, configFileOverrides map[string]any, inc int) error {
 	// Get peer string for existing nodes

--- a/chain/thorchain/thorchain.go
+++ b/chain/thorchain/thorchain.go
@@ -208,8 +208,8 @@ func (c *Thorchain) AddValidators(ctx context.Context, configFileOverrides map[s
 		// Fund validator from faucet
 		if err := c.SendFunds(ctx, "faucet", ibc.WalletAmount{
 			Address: c.Validators[i].NodeAccount.NodeAddress,
-			Amount: sdkmath.NewInt(100).MulRaw(decimalPow), // 100e8 rune
-			Denom: c.cfg.Denom,
+			Amount:  sdkmath.NewInt(100).MulRaw(decimalPow), // 100e8 rune
+			Denom:   c.cfg.Denom,
 		}); err != nil {
 			return fmt.Errorf("failed to fund val %d, %w", i, err)
 		}
@@ -245,7 +245,7 @@ func (c *Thorchain) AddValidators(ctx context.Context, configFileOverrides map[s
 	return c.StartAllValSidecars(ctx)
 }
 
-// AddDuplicateValidator spins up a duplicate validator node to test double signing
+// AddDuplicateValidator spins up a duplicate validator node to test double signing.
 func (c *Thorchain) AddDuplicateValidator(ctx context.Context, configFileOverrides map[string]any, originalVal *ChainNode) (*ChainNode, error) {
 	// Get peer string for existing nodes
 	peers := c.Nodes().PeerString(ctx)

--- a/chain/thorchain/thorchain.go
+++ b/chain/thorchain/thorchain.go
@@ -226,7 +226,7 @@ func (c *Thorchain) AddValidators(ctx context.Context, configFileOverrides map[s
 				return fmt.Errorf("failed to set val %d node keys, %w", i, err)
 			}
 			// thornode tx thorchain set-ip-address "192.168.0.10"
-			if err := val.SetIpAddress(ctx); err != nil {
+			if err := val.SetIPAddress(ctx); err != nil {
 				return fmt.Errorf("failed to set val %d ip address, %w", i, err)
 			}
 			// thornode tx thorchain set-version

--- a/chain/thorchain/types.go
+++ b/chain/thorchain/types.go
@@ -30,7 +30,7 @@ type OpenapiNode struct {
 	// the consensus pub key for the node
 	ValidatorConsPubKey string `json:"validator_cons_pub_key"`
 	// the P2PID (:6040/p2pid endpoint) of the node
-	PeerId string `json:"peer_id"`
+	PeerID string `json:"peer_id"`
 	// the block height at which the node became active
 	ActiveBlockHeight int64 `json:"active_block_height"`
 	// the block height of the current provided information for the node
@@ -45,7 +45,7 @@ type OpenapiNode struct {
 	// indicates whether the node has been forced to leave by the network, typically via ban
 	ForcedToLeave bool   `json:"forced_to_leave"`
 	LeaveHeight   int64  `json:"leave_height"`
-	IpAddress     string `json:"ip_address"`
+	IPAddress     string `json:"ip_address"`
 	// the currently set version of the node
 	Version string `json:"version"`
 	// the accumulated slash points, reset at churn but excessive slash points may carry over

--- a/chain/thorchain/types.go
+++ b/chain/thorchain/types.go
@@ -23,6 +23,70 @@ type NodeAccount struct {
 	PubKeySet           NodeAccountPubKeySet `json:"pub_key_set"`
 }
 
+type OpenapiNode struct {
+	NodeAddress string `json:"node_address"`
+	Status string `json:"status"`
+	PubKeySet NodeAccountPubKeySet `json:"pub_key_set"`
+	// the consensus pub key for the node
+	ValidatorConsPubKey string `json:"validator_cons_pub_key"`
+	// the P2PID (:6040/p2pid endpoint) of the node
+	PeerId string `json:"peer_id"`
+	// the block height at which the node became active
+	ActiveBlockHeight int64 `json:"active_block_height"`
+	// the block height of the current provided information for the node
+	StatusSince int64 `json:"status_since"`
+	NodeOperatorAddress string `json:"node_operator_address"`
+	// current node bond
+	TotalBond string `json:"total_bond"`
+	BondProviders NodeBondProviders `json:"bond_providers"`
+	// the set of vault public keys of which the node is a member
+	SignerMembership []string `json:"signer_membership"`
+	RequestedToLeave bool `json:"requested_to_leave"`
+	// indicates whether the node has been forced to leave by the network, typically via ban
+	ForcedToLeave bool `json:"forced_to_leave"`
+	LeaveHeight int64 `json:"leave_height"`
+	IpAddress string `json:"ip_address"`
+	// the currently set version of the node
+	Version string `json:"version"`
+	// the accumulated slash points, reset at churn but excessive slash points may carry over
+	SlashPoints int64 `json:"slash_points"`
+	Jail NodeJail `json:"jail"`
+	CurrentAward string `json:"current_award"`
+	// the last observed heights for all chain by the node
+	ObserveChains []ChainHeight `json:"observe_chains"`
+	PreflightStatus NodePreflightStatus `json:"preflight_status"`
+}
+
+type NodePreflightStatus struct {
+	// the next status of the node
+	Status string `json:"status"`
+	// the reason for the transition to the next status
+	Reason string `json:"reason"`
+	Code int64 `json:"code"`
+}
+
+type NodeBondProviders struct {
+	// node operator fee in basis points
+	NodeOperatorFee string `json:"node_operator_fee"`
+	// all the bond providers for the node
+	Providers []NodeBondProvider `json:"providers"`
+}
+
+type NodeBondProvider struct {
+	BondAddress *string `json:"bond_address,omitempty"`
+	Bond *string `json:"bond,omitempty"`
+}
+
+type NodeJail struct {
+	ReleaseHeight *int64 `json:"release_height,omitempty"`
+	Reason *string `json:"reason,omitempty"`
+}
+
+type ChainHeight struct {
+	Chain string `json:"chain"`
+	Height int64 `json:"height"`
+}
+
 // ProtoMessage is implemented by generated protocol buffer messages.
 // Pulled from github.com/cosmos/gogoproto/proto.
 type ProtoMessage interface {

--- a/chain/thorchain/types.go
+++ b/chain/thorchain/types.go
@@ -24,9 +24,9 @@ type NodeAccount struct {
 }
 
 type OpenapiNode struct {
-	NodeAddress string `json:"node_address"`
-	Status string `json:"status"`
-	PubKeySet NodeAccountPubKeySet `json:"pub_key_set"`
+	NodeAddress string               `json:"node_address"`
+	Status      string               `json:"status"`
+	PubKeySet   NodeAccountPubKeySet `json:"pub_key_set"`
 	// the consensus pub key for the node
 	ValidatorConsPubKey string `json:"validator_cons_pub_key"`
 	// the P2PID (:6040/p2pid endpoint) of the node
@@ -34,26 +34,26 @@ type OpenapiNode struct {
 	// the block height at which the node became active
 	ActiveBlockHeight int64 `json:"active_block_height"`
 	// the block height of the current provided information for the node
-	StatusSince int64 `json:"status_since"`
+	StatusSince         int64  `json:"status_since"`
 	NodeOperatorAddress string `json:"node_operator_address"`
 	// current node bond
-	TotalBond string `json:"total_bond"`
+	TotalBond     string            `json:"total_bond"`
 	BondProviders NodeBondProviders `json:"bond_providers"`
 	// the set of vault public keys of which the node is a member
 	SignerMembership []string `json:"signer_membership"`
-	RequestedToLeave bool `json:"requested_to_leave"`
+	RequestedToLeave bool     `json:"requested_to_leave"`
 	// indicates whether the node has been forced to leave by the network, typically via ban
-	ForcedToLeave bool `json:"forced_to_leave"`
-	LeaveHeight int64 `json:"leave_height"`
-	IpAddress string `json:"ip_address"`
+	ForcedToLeave bool   `json:"forced_to_leave"`
+	LeaveHeight   int64  `json:"leave_height"`
+	IpAddress     string `json:"ip_address"`
 	// the currently set version of the node
 	Version string `json:"version"`
 	// the accumulated slash points, reset at churn but excessive slash points may carry over
-	SlashPoints int64 `json:"slash_points"`
-	Jail NodeJail `json:"jail"`
-	CurrentAward string `json:"current_award"`
+	SlashPoints  int64    `json:"slash_points"`
+	Jail         NodeJail `json:"jail"`
+	CurrentAward string   `json:"current_award"`
 	// the last observed heights for all chain by the node
-	ObserveChains []ChainHeight `json:"observe_chains"`
+	ObserveChains   []ChainHeight       `json:"observe_chains"`
 	PreflightStatus NodePreflightStatus `json:"preflight_status"`
 }
 
@@ -62,7 +62,7 @@ type NodePreflightStatus struct {
 	Status string `json:"status"`
 	// the reason for the transition to the next status
 	Reason string `json:"reason"`
-	Code int64 `json:"code"`
+	Code   int64  `json:"code"`
 }
 
 type NodeBondProviders struct {
@@ -74,17 +74,17 @@ type NodeBondProviders struct {
 
 type NodeBondProvider struct {
 	BondAddress *string `json:"bond_address,omitempty"`
-	Bond *string `json:"bond,omitempty"`
+	Bond        *string `json:"bond,omitempty"`
 }
 
 type NodeJail struct {
-	ReleaseHeight *int64 `json:"release_height,omitempty"`
-	Reason *string `json:"reason,omitempty"`
+	ReleaseHeight *int64  `json:"release_height,omitempty"`
+	Reason        *string `json:"reason,omitempty"`
 }
 
 type ChainHeight struct {
-	Chain string `json:"chain"`
-	Height int64 `json:"height"`
+	Chain  string `json:"chain"`
+	Height int64  `json:"height"`
 }
 
 // ProtoMessage is implemented by generated protocol buffer messages.

--- a/go.mod
+++ b/go.mod
@@ -95,6 +95,7 @@ require (
 	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d // indirect
 	github.com/bgentry/speakeasy v0.1.1-0.20220910012023-760eaf8b6816 // indirect
 	github.com/bits-and-blooms/bitset v1.10.0 // indirect
+	github.com/btcsuite/btcd v0.22.1 // indirect
 	github.com/btcsuite/btcd/btcec/v2 v2.3.4 // indirect
 	github.com/cenkalti/backoff/v4 v4.1.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -294,6 +294,8 @@ github.com/bgentry/speakeasy v0.1.1-0.20220910012023-760eaf8b6816 h1:41iFGWnSlI2
 github.com/bgentry/speakeasy v0.1.1-0.20220910012023-760eaf8b6816/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bits-and-blooms/bitset v1.10.0 h1:ePXTeiPEazB5+opbv5fr8umg2R/1NlzgDsyepwsSr88=
 github.com/bits-and-blooms/bitset v1.10.0/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
+github.com/btcsuite/btcd v0.22.1 h1:CnwP9LM/M9xuRrGSCGeMVs9iv09uMqwsVX7EeIpgV2c=
+github.com/btcsuite/btcd v0.22.1/go.mod h1:wqgTSL29+50LRkmOVknEdmt8ZojIzhuWvgu/iptuN7Y=
 github.com/btcsuite/btcd/btcec/v2 v2.3.3 h1:6+iXlDKE8RMtKsvK0gshlXIuPbyWM/h84Ensb7o3sC0=
 github.com/btcsuite/btcd/btcec/v2 v2.3.3/go.mod h1:zYzJ8etWJQIv1Ogk7OzpWjowwOdXY1W/17j2MW85J04=
 github.com/btcsuite/btcd/btcutil v1.1.3 h1:xfbtw8lwpp0G6NwSHb+UE67ryTFHJAiNuipusjXSohQ=
@@ -311,6 +313,7 @@ github.com/cenkalti/backoff/v4 v4.1.1/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInq
 github.com/cenkalti/backoff/v4 v4.1.3 h1:cFAlzYUlVYDysBEH2T5hyJZMh3+5+WCBvSnK6Q8UtC4=
 github.com/cenkalti/backoff/v4 v4.1.3/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
+github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
@@ -407,6 +410,8 @@ github.com/crate-crypto/go-ipa v0.0.0-20240223125850-b1e8a79f509c h1:uQYC5Z1mdLR
 github.com/crate-crypto/go-ipa v0.0.0-20240223125850-b1e8a79f509c/go.mod h1:geZJZH3SzKCqnz5VT0q/DyIG/tvu/dZk+VIfXicupJs=
 github.com/crate-crypto/go-kzg-4844 v1.0.0 h1:TsSgHwrkTKecKJ4kadtHi4b3xHW5dCFUDFnUp1TsawI=
 github.com/crate-crypto/go-kzg-4844 v1.0.0/go.mod h1:1kMhvPgI0Ky3yIa+9lFySEBUBXkYxeOi8ZF1sYioxhc=
+github.com/creachadair/taskgroup v0.3.2 h1:zlfutDS+5XG40AOxcHDSThxKzns8Tnr9jnr6VqkYlkM=
+github.com/creachadair/taskgroup v0.3.2/go.mod h1:wieWwecHVzsidg2CsUnFinW1faVN4+kq+TDlRJQ0Wbk=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/danieljoos/wincred v1.1.2 h1:QLdCxFs1/Yl4zduvBdcHB8goaYk9RARS2SgLLRuAyr0=
@@ -432,6 +437,9 @@ github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0 h1:8UrgZ3GkP4i/CLijOJx79Yu+etly
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0/go.mod h1:v57UDF4pDQJcEfFUCRop3lJL149eHGSe9Jvczhzjo/0=
 github.com/desertbit/timer v0.0.0-20180107155436-c41aec40b27f h1:U5y3Y5UE0w7amNe7Z5G/twsBW0KEalRQXZzf8ufSh9I=
 github.com/desertbit/timer v0.0.0-20180107155436-c41aec40b27f/go.mod h1:xH/i4TFMt8koVQZ6WFms69WAsDWr2XsYL3Hkl7jkoLE=
+github.com/dgraph-io/badger v1.6.2 h1:mNw0qs90GVgGGWylh0umH5iag1j6n/PeJtNvL6KY/x8=
+github.com/dgraph-io/badger/v2 v2.2007.4 h1:TRWBQg8UrlUhaFdco01nO2uXwzKS7zd+HVdwV/GHc4o=
+github.com/dgraph-io/badger/v2 v2.2007.4/go.mod h1:vSw/ax2qojzbN6eXHIx6KPKtCSHJN/Uz0X0VPruTIhk=
 github.com/dgraph-io/badger/v4 v4.2.0 h1:kJrlajbXXL9DFTNuhhu9yCx7JJa4qpYWxtE8BzuWsEs=
 github.com/dgraph-io/badger/v4 v4.2.0/go.mod h1:qfCqhPoWDFJRx1gp5QwwyGo8xk1lbHUxvK9nK0OGAak=
 github.com/dgraph-io/ristretto v0.1.1 h1:6CWw5tJNgpegArSHpNHJKldNeq03FQCwYvfMVWajOK8=
@@ -1163,10 +1171,14 @@ github.com/supranational/blst v0.3.11 h1:LyU6FolezeWAhvQk0k6O/d49jqgO52MSDDfYgbe
 github.com/supranational/blst v0.3.11/go.mod h1:jZJtfjgudtNl4en1tzwPIV3KjUnQUvG3/j+w+fVonLw=
 github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d h1:vfofYNRScrDdvS342BElfbETmL1Aiz3i2t0zfRj16Hs=
 github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d/go.mod h1:RRCYJbIwD5jmqPI9XoAFR0OcDxqUctll6zUj/+B4S48=
+github.com/tecbot/gorocksdb v0.0.0-20191217155057-f0fad39f321c h1:g+WoO5jjkqGAzHWCjJB1zZfXPIAaDpzXIEJ0eS6B5Ok=
+github.com/tecbot/gorocksdb v0.0.0-20191217155057-f0fad39f321c/go.mod h1:ahpPrc7HpcfEWDQRZEmnXMzHY03mLDYMCxeDzy46i+8=
 github.com/tendermint/go-amino v0.16.0 h1:GyhmgQKvqF82e2oZeuMSp9JTN0N09emoSZlb2lyGa2E=
 github.com/tendermint/go-amino v0.16.0/go.mod h1:TQU0M1i/ImAo+tYpZi73AU3V/dKeCoMC9Sphe2ZwGME=
 github.com/tendermint/tendermint v0.38.0-dev h1:yX4zsEgTF9PxlLmhx9XAPTGH2E9FSlqSpHcY7sW7Vb8=
 github.com/tendermint/tendermint v0.38.0-dev/go.mod h1:EHKmaqObmcGysoRr7krxXoxxhUDyYWbKvvRYJ9tCGWY=
+github.com/tendermint/tm-db v0.6.6 h1:EzhaOfR0bdKyATqcd5PNeyeq8r+V4bRPHBfyFdD9kGM=
+github.com/tendermint/tm-db v0.6.6/go.mod h1:wP8d49A85B7/erz/r4YbKssKw6ylsO/hKtFk7E1aWZI=
 github.com/tidwall/btree v1.7.0 h1:L1fkJH/AuEh5zBnnBbmTwQ5Lt+bRJ5A8EWecslvo9iI=
 github.com/tidwall/btree v1.7.0/go.mod h1:twD9XRA5jj9VUQGELzDO4HPQTNJsoWWfYEL+EUQ2cKY=
 github.com/tidwall/gjson v1.17.1 h1:wlYEnwqAHgzmhNUFfw7Xalt2JzQvsMx2Se4PcoFCT/U=

--- a/local-interchain/go.mod
+++ b/local-interchain/go.mod
@@ -19,6 +19,7 @@ require (
 	cosmossdk.io/math v1.3.0
 	github.com/cosmos/cosmos-sdk v0.50.9
 	github.com/cosmos/go-bip39 v1.0.0
+	github.com/docker/docker v24.0.9+incompatible
 	github.com/go-playground/validator v9.31.0+incompatible
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/handlers v1.5.2
@@ -67,6 +68,7 @@ require (
 	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d // indirect
 	github.com/bgentry/speakeasy v0.1.1-0.20220910012023-760eaf8b6816 // indirect
 	github.com/bits-and-blooms/bitset v1.10.0 // indirect
+	github.com/btcsuite/btcd v0.22.1 // indirect
 	github.com/btcsuite/btcd/btcec/v2 v2.3.4 // indirect
 	github.com/cenkalti/backoff/v4 v4.1.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
@@ -105,7 +107,6 @@ require (
 	github.com/dgraph-io/badger/v4 v4.2.0 // indirect
 	github.com/dgraph-io/ristretto v0.1.1 // indirect
 	github.com/docker/distribution v2.8.2+incompatible // indirect
-	github.com/docker/docker v24.0.9+incompatible // indirect
 	github.com/docker/go-connections v0.5.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
@@ -234,6 +235,7 @@ require (
 	github.com/supranational/blst v0.3.11 // indirect
 	github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d // indirect
 	github.com/tendermint/go-amino v0.16.0 // indirect
+	github.com/tendermint/tendermint v0.38.0-dev // indirect
 	github.com/tidwall/btree v1.7.0 // indirect
 	github.com/tidwall/gjson v1.17.1 // indirect
 	github.com/tidwall/match v1.1.1 // indirect

--- a/local-interchain/go.sum
+++ b/local-interchain/go.sum
@@ -288,6 +288,8 @@ github.com/bgentry/speakeasy v0.1.1-0.20220910012023-760eaf8b6816 h1:41iFGWnSlI2
 github.com/bgentry/speakeasy v0.1.1-0.20220910012023-760eaf8b6816/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bits-and-blooms/bitset v1.10.0 h1:ePXTeiPEazB5+opbv5fr8umg2R/1NlzgDsyepwsSr88=
 github.com/bits-and-blooms/bitset v1.10.0/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
+github.com/btcsuite/btcd v0.22.2 h1:vBZ+lGGd1XubpOWO67ITJpAEsICWhA0YzqkcpkgNBfo=
+github.com/btcsuite/btcd v0.22.2/go.mod h1:wqgTSL29+50LRkmOVknEdmt8ZojIzhuWvgu/iptuN7Y=
 github.com/btcsuite/btcd/btcec/v2 v2.3.3 h1:6+iXlDKE8RMtKsvK0gshlXIuPbyWM/h84Ensb7o3sC0=
 github.com/btcsuite/btcd/btcec/v2 v2.3.3/go.mod h1:zYzJ8etWJQIv1Ogk7OzpWjowwOdXY1W/17j2MW85J04=
 github.com/btcsuite/btcd/btcutil v1.1.3 h1:xfbtw8lwpp0G6NwSHb+UE67ryTFHJAiNuipusjXSohQ=
@@ -305,6 +307,7 @@ github.com/cenkalti/backoff/v4 v4.1.1/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInq
 github.com/cenkalti/backoff/v4 v4.1.3 h1:cFAlzYUlVYDysBEH2T5hyJZMh3+5+WCBvSnK6Q8UtC4=
 github.com/cenkalti/backoff/v4 v4.1.3/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
+github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
@@ -401,6 +404,8 @@ github.com/crate-crypto/go-ipa v0.0.0-20240223125850-b1e8a79f509c h1:uQYC5Z1mdLR
 github.com/crate-crypto/go-ipa v0.0.0-20240223125850-b1e8a79f509c/go.mod h1:geZJZH3SzKCqnz5VT0q/DyIG/tvu/dZk+VIfXicupJs=
 github.com/crate-crypto/go-kzg-4844 v1.0.0 h1:TsSgHwrkTKecKJ4kadtHi4b3xHW5dCFUDFnUp1TsawI=
 github.com/crate-crypto/go-kzg-4844 v1.0.0/go.mod h1:1kMhvPgI0Ky3yIa+9lFySEBUBXkYxeOi8ZF1sYioxhc=
+github.com/creachadair/taskgroup v0.3.2 h1:zlfutDS+5XG40AOxcHDSThxKzns8Tnr9jnr6VqkYlkM=
+github.com/creachadair/taskgroup v0.3.2/go.mod h1:wieWwecHVzsidg2CsUnFinW1faVN4+kq+TDlRJQ0Wbk=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/danieljoos/wincred v1.1.2 h1:QLdCxFs1/Yl4zduvBdcHB8goaYk9RARS2SgLLRuAyr0=
@@ -426,6 +431,9 @@ github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0 h1:8UrgZ3GkP4i/CLijOJx79Yu+etly
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0/go.mod h1:v57UDF4pDQJcEfFUCRop3lJL149eHGSe9Jvczhzjo/0=
 github.com/desertbit/timer v0.0.0-20180107155436-c41aec40b27f h1:U5y3Y5UE0w7amNe7Z5G/twsBW0KEalRQXZzf8ufSh9I=
 github.com/desertbit/timer v0.0.0-20180107155436-c41aec40b27f/go.mod h1:xH/i4TFMt8koVQZ6WFms69WAsDWr2XsYL3Hkl7jkoLE=
+github.com/dgraph-io/badger v1.6.2 h1:mNw0qs90GVgGGWylh0umH5iag1j6n/PeJtNvL6KY/x8=
+github.com/dgraph-io/badger/v2 v2.2007.4 h1:TRWBQg8UrlUhaFdco01nO2uXwzKS7zd+HVdwV/GHc4o=
+github.com/dgraph-io/badger/v2 v2.2007.4/go.mod h1:vSw/ax2qojzbN6eXHIx6KPKtCSHJN/Uz0X0VPruTIhk=
 github.com/dgraph-io/badger/v4 v4.2.0 h1:kJrlajbXXL9DFTNuhhu9yCx7JJa4qpYWxtE8BzuWsEs=
 github.com/dgraph-io/badger/v4 v4.2.0/go.mod h1:qfCqhPoWDFJRx1gp5QwwyGo8xk1lbHUxvK9nK0OGAak=
 github.com/dgraph-io/ristretto v0.1.1 h1:6CWw5tJNgpegArSHpNHJKldNeq03FQCwYvfMVWajOK8=
@@ -1148,8 +1156,14 @@ github.com/supranational/blst v0.3.11 h1:LyU6FolezeWAhvQk0k6O/d49jqgO52MSDDfYgbe
 github.com/supranational/blst v0.3.11/go.mod h1:jZJtfjgudtNl4en1tzwPIV3KjUnQUvG3/j+w+fVonLw=
 github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d h1:vfofYNRScrDdvS342BElfbETmL1Aiz3i2t0zfRj16Hs=
 github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d/go.mod h1:RRCYJbIwD5jmqPI9XoAFR0OcDxqUctll6zUj/+B4S48=
+github.com/tecbot/gorocksdb v0.0.0-20191217155057-f0fad39f321c h1:g+WoO5jjkqGAzHWCjJB1zZfXPIAaDpzXIEJ0eS6B5Ok=
+github.com/tecbot/gorocksdb v0.0.0-20191217155057-f0fad39f321c/go.mod h1:ahpPrc7HpcfEWDQRZEmnXMzHY03mLDYMCxeDzy46i+8=
 github.com/tendermint/go-amino v0.16.0 h1:GyhmgQKvqF82e2oZeuMSp9JTN0N09emoSZlb2lyGa2E=
 github.com/tendermint/go-amino v0.16.0/go.mod h1:TQU0M1i/ImAo+tYpZi73AU3V/dKeCoMC9Sphe2ZwGME=
+github.com/tendermint/tendermint v0.38.0-dev h1:yX4zsEgTF9PxlLmhx9XAPTGH2E9FSlqSpHcY7sW7Vb8=
+github.com/tendermint/tendermint v0.38.0-dev/go.mod h1:EHKmaqObmcGysoRr7krxXoxxhUDyYWbKvvRYJ9tCGWY=
+github.com/tendermint/tm-db v0.6.6 h1:EzhaOfR0bdKyATqcd5PNeyeq8r+V4bRPHBfyFdD9kGM=
+github.com/tendermint/tm-db v0.6.6/go.mod h1:wP8d49A85B7/erz/r4YbKssKw6ylsO/hKtFk7E1aWZI=
 github.com/tidwall/btree v1.7.0 h1:L1fkJH/AuEh5zBnnBbmTwQ5Lt+bRJ5A8EWecslvo9iI=
 github.com/tidwall/btree v1.7.0/go.mod h1:twD9XRA5jj9VUQGELzDO4HPQTNJsoWWfYEL+EUQ2cKY=
 github.com/tidwall/gjson v1.17.1 h1:wlYEnwqAHgzmhNUFfw7Xalt2JzQvsMx2Se4PcoFCT/U=


### PR DESCRIPTION
Currently, in order to use bifrost, thorchain must be started at genesis with a single validator. Churns occur every 60 blocks, so it will take at most ~2 minutes to update the validator set. This PR adds the ability to easily add validators to thorchain's network. It also adds support for duplicating a validator, in our case, to test double sign slashing.

This PR also fixes a possible race condition in ethereum-based chains.