### PR TITLE
fix: typos in documentation files

### DIFF
--- a/local-interchain/chains/README.md
+++ b/local-interchain/chains/README.md
@@ -2,7 +2,7 @@
 
 ## interchainsecurity & neutron
 
-Current the neutron heighliner image does not work due to some /tmp issue in the docker image. For this reason, you must compile the image yourself to use the latest v50 instance.
+Currently the neutron heighliner image does not work due to some /tmp issue in the docker image. For this reason, you must compile the image yourself to use the latest v50 instance.
 
 ```bash
 git clone https://github.com/neutron-org/neutron.git --depth 1 --branch v4.2.1


### PR DESCRIPTION
Corrected `Current` to `Currently`