### PR TITLE
Fix typos 

### DIFF
--- a/chain/cosmos/broadcaster.go
+++ b/chain/cosmos/broadcaster.go
@@ -47,7 +47,7 @@ type Broadcaster struct {
 	clientContextOptions []ClientContextOpt
 }
 
-// NewBroadcaster returns a instance of Broadcaster which can be used with broadcast.Tx to
+// NewBroadcaster returns an instance of Broadcaster which can be used with broadcast.Tx to
 // broadcast messages sdk messages.
 func NewBroadcaster(t *testing.T, chain *CosmosChain) *Broadcaster {
 	t.Helper()

--- a/chain/cosmos/module_cosmwasm.go
+++ b/chain/cosmos/module_cosmwasm.go
@@ -131,7 +131,7 @@ func (tn *ChainNode) ExecuteContract(ctx context.Context, keyName string, contra
 	return txResp, nil
 }
 
-// QueryContract performs a smart query, taking in a query struct and returning a error with the response struct populated.
+// QueryContract performs a smart query, taking in a query struct and returning an error with the response struct populated.
 func (tn *ChainNode) QueryContract(ctx context.Context, contractAddress string, queryMsg any, response any) error {
 	var query []byte
 	var err error


### PR DESCRIPTION
This PR fixes minor typos in comments within two files to improve code clarity and consistency. 
These changes are non-functional and purely for documentation purposes.

#### Files and Changes:
- **`chain/cosmos/broadcaster.go`**
  - Fixed "a instance of Broadcaster" to "an instance of Broadcaster."
- **`chain/cosmos/module_cosmwasm.go`**
  - Corrected "returning a error" to "returning an error."
