### PR TITLE
Typo fix 

### DIFF
--- a/chain/penumbra/view/v1/view.pb.go
+++ b/chain/penumbra/view/v1/view.pb.go
@@ -205,7 +205,7 @@ type AuctionsResponse struct {
 	// service_. Note that the local view service may lag behind the fullnode. For
 	// example, if the chain hits an auction's `end_height`, but the user hasn't
 	// yet exchanged their sequence-0 (opened) auction NFT for a sequence-1
-	// (closed) auction NFT, the local view service will have a sequnce number of
+	// (closed) auction NFT, the local view service will have a sequence number of
 	// 0.
 	//
 	// Dutch auctions move from:


### PR DESCRIPTION
### Summary
Fixes a typo in the `view.pb.go` file.

### Changes
- Corrected "sequnce" to "sequence" in the generated file.

### Notes
- This is a minor fix in a generated file.
- Ensure any related processes account for the update.
