### PR TITLE
chore(ci): replace deprecated rust toolchain action

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,10 +25,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install stable with clippy and rustfmt
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          toolchain: stable
           components: rustfmt, clippy
       - name: Install clippy
         run: rustup component add clippy


### PR DESCRIPTION
Replace deprecated actions-rs/toolchain with dtolnay/rust-toolchain.
This keeps the same Rust toolchain and components while using the actively maintained action recommended by the Rust community.
